### PR TITLE
dRICH: Parse modified drich xml files

### DIFF
--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -118,7 +118,11 @@
   {% endif -%}
 
   {% if features is not defined or features['pid'] is none or 'drich' in features['pid'] %}
-  <include ref="compact/drich.xml"/>
+    {% if features is not defined or features['pid'] is none or features['pid']['drich'] is none %}
+    <include ref="compact/drich.xml"/>
+    {% else %}
+    <include ref="{{ features['pid']['drich'] }}"/>
+    {% endif -%}
   {% endif -%}
 
   {% if features is not defined or features['pid'] is none or 'mrich' in features['pid'] %}

--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -118,11 +118,11 @@
   {% endif -%}
 
   {% if features is not defined or features['pid'] is none or 'drich' in features['pid'] %}
-    {% if features is not defined or features['pid'] is none or features['pid']['drich'] is none %}
-    <include ref="compact/drich.xml"/>
-    {% else %}
-    <include ref="{{ features['pid']['drich'] }}"/>
-    {% endif -%}
+  {%- if features is not defined or features['pid'] is none or features['pid']['drich'] is none %}
+  <include ref="compact/drich.xml"/>
+  {% else %}
+  <include ref="{{ features['pid']['drich'] }}"/>
+  {% endif -%}
   {% endif -%}
 
   {% if features is not defined or features['pid'] is none or 'mrich' in features['pid'] %}


### PR DESCRIPTION
#### Proposed change:
If the config yaml file (for `jinja`) is
```
features:
  pid:
    drich:
```
it will use the default `compact/drich.xml`, else if it is
```
features:
  pid:
    drich: my_custom_drich.xml
```
it will instead use `my_custom_drich.xml`

#### Context:
This will allow us to test several versions of the dRICH geometry, in parallel, for example in optics optimization routines. The general idea on our end is:
1. create a new `drich.xml` compact file, with some variables changed
2. create a config file, which specifies the new compact file
3. render the template (`jinja`)
4. simulate