### PR TITLE
fix(dRICH): improve optics

### DIFF
--- a/compact/drich.xml
+++ b/compact/drich.xml
@@ -151,8 +151,8 @@
   rmax="DRICH_rmax2 - DRICH_wall_thickness - 3.0*cm"
   phiw="59.5*degree"
   thickness="0.2*cm"
-  focus_tune_x="-10.0*cm"
-  focus_tune_z="15.0*cm"
+  focus_tune_x="-5.0*cm"
+  focus_tune_z="0.0*cm"
   />
 
 <!-- /detectors/detector/sensors -->

--- a/compact/drich.xml
+++ b/compact/drich.xml
@@ -151,8 +151,8 @@
   rmax="DRICH_rmax2 - DRICH_wall_thickness - 3.0*cm"
   phiw="59.5*degree"
   thickness="0.2*cm"
-  focus_tune_x="0.0*cm"
-  focus_tune_z="30.0*cm"
+  focus_tune_x="-10.0*cm"
+  focus_tune_z="15.0*cm"
   />
 
 <!-- /detectors/detector/sensors -->
@@ -205,9 +205,9 @@
     - `zmin`: z-plane cut
 </documentation>
 <sphere
-  centerz="-90.0*cm"
+  centerz="-50.0*cm"
   centerx="180.0*cm"
-  radius="140.0*cm"
+  radius="100.0*cm"
   />
 <sphericalpatch
   phiw="14*degree"

--- a/compact/drich.xml
+++ b/compact/drich.xml
@@ -146,13 +146,13 @@
   material="Acrylic_DRICH"
   surface="MirrorSurface_DRICH"
   vis="DRICH_mirror_vis"
-  backplane="DRICH_window_thickness + 0.71*cm"
+  backplane="DRICH_window_thickness + 2.0*cm"
   rmin="DRICH_rmin1 + DRICH_wall_thickness - 1.0*cm"
   rmax="DRICH_rmax2 - DRICH_wall_thickness - 3.0*cm"
   phiw="59.5*degree"
   thickness="0.2*cm"
-  focus_tune_x="69.78*cm"
-  focus_tune_z="51.45*cm"
+  focus_tune_x="0.0*cm"
+  focus_tune_z="30.0*cm"
   />
 
 <!-- /detectors/detector/sensors -->
@@ -205,15 +205,15 @@
     - `zmin`: z-plane cut
 </documentation>
 <sphere
-  centerz="-168.07*cm + DRICH_SnoutLength + (DRICH_Length-DRICH_SnoutLength)/2.0"
-  centerx="124.98*cm"
-  radius="140*cm"
+  centerz="-90.0*cm"
+  centerx="180.0*cm"
+  radius="140.0*cm"
   />
 <sphericalpatch
   phiw="14*degree"
   rmin="DRICH_rmax1 + 2.0*cm"
   rmax="DRICH_rmax2 - 5.0*cm"
-  zmin="DRICH_SnoutLength + 3.0*cm"
+  zmin="DRICH_SnoutLength + 5.0*cm"
   />
 
 


### PR DESCRIPTION
- [x] maximize polar acceptance (with no B field)
- [x] try to ensure photons are at normal incidence to sensors
- [x] get close to the parallel-to-point focal region

# Updated Parameters
```
    # focus_tune_x          = -5
    # focus_tune_z          = 0
    # sensor_sphere_radius  = 100
    # sensor_sphere_centerz = -50
    # 
    # SECTOR 0 MIRROR:
    #   mirror x = 113.888311 cm
    #   mirror y = 0.000000 cm
    #   mirror z = 94.364601 cm
    #   mirror R = 218.535399 cm
```

# Changes

## Foci
Wide, collimated photon beams reflecting off the mirror, to show the parallel-to-point foci
#### Before changes:
![before-foci](https://user-images.githubusercontent.com/7843751/185673974-c20ed87f-8442-417a-b3dc-c207cc93b4b3.png)
#### After changes:
![after-foci](https://user-images.githubusercontent.com/7843751/185674026-4dd1ae5f-0609-468b-8e1d-2b67f03872cc.png)

## Rings
8 GeV pions, thrown at 4 different polar angles within the dRICH acceptance. Note the highest-theta has no aerogel ring, because there is no aerogel coverage at high theta.
#### Before changes:
![before](https://user-images.githubusercontent.com/7843751/185672992-0253261d-4db8-463b-9d89-445cb78389a0.png)
#### After changes (B-field off):
![after](https://user-images.githubusercontent.com/7843751/185673562-3aac7308-5dfb-47c0-8abc-4a77ead6cae6.png)
#### After changes (B-field on):
![field_on](https://user-images.githubusercontent.com/7843751/185674106-fb711b58-5074-4522-ad01-5a6b797e7f1f.png)

## Sensor Pixel Hit Map (after changes)
Thrown 8 GeV pions, equally distributed in theta and phi, to one dRICH sector. The lowest theta pions are thrown at phi=0 only; the higher thetas have 5 phi bins: one along phi=0, one along each sector boundary (adjacent sector hit maps are below), and one in between phi=0 and the sector boundary.

We have losses at high theta along the sector boundary (note the missing gas rings)

![c1_n2](https://user-images.githubusercontent.com/7843751/185687139-bf4fac7c-b285-440e-9eb7-55167bda71d8.png)
![c1_n3](https://user-images.githubusercontent.com/7843751/185687163-69de3adf-74d2-44a1-bbc1-bc8296cfe021.png)
![c1_n7](https://user-images.githubusercontent.com/7843751/185687180-dfe033f3-bea6-4e2f-9d7d-12bcbfd3da47.png)


