### PR TITLE
dRICH: test small sensor overlap

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  overlap_tolerance: 0.01
+
 jobs:
   xmllint-before-build:
     runs-on: ubuntu-latest
@@ -189,7 +192,7 @@ jobs:
         setup: install/setup.sh
         run: |
           mkdir -p doc
-          checkOverlaps -c ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml | tee doc/overlap_check_tgeo.out
+          checkOverlaps -c ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml -t ${{env.overlap_tolerance}} | tee doc/overlap_check_tgeo.out
           noverlaps="$(grep -c ovlp doc/overlap_check_tgeo.out || true)"
           if [[ "${noverlaps}" -gt "0" ]] ; then echo "${noverlaps} overlaps found!" && false ; fi
 
@@ -209,7 +212,7 @@ jobs:
         setup: install/setup.sh
         run: |
           mkdir -p doc
-          python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml | tee doc/overlap_check_geant4.out
+          python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml -t ${{env.overlap_tolerance}} | tee doc/overlap_check_geant4.out
           noverlaps="$(grep -c GeomVol1002 doc/overlap_check_geant4.out || true)"
           if [[ "${noverlaps}" -gt "0" ]] ; then echo "${noverlaps} overlaps found!" && false ; fi
 
@@ -229,7 +232,7 @@ jobs:
         setup: install/setup.sh
         run: |
           mkdir -p doc
-          python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml | tee doc/overlap_check_geant4.out
+          python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml -t ${{env.overlap_tolerance}} | tee doc/overlap_check_geant4.out
           noverlaps="$(grep -c GeomVol1002 doc/overlap_check_geant4.out || true)"
           if [[ "${noverlaps}" -gt "0" ]] ; then echo "${noverlaps} overlaps found!" && false ; fi
 
@@ -249,7 +252,7 @@ jobs:
         setup: install/setup.sh
         run: |
           mkdir -p doc
-          python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/${DETECTOR_CONFIG}_inner_detector.xml | tee doc/overlap_check_geant4.out
+          python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/${DETECTOR_CONFIG}_inner_detector.xml -t ${{env.overlap_tolerance}} | tee doc/overlap_check_geant4.out
           noverlaps="$(grep -c GeomVol1002 doc/overlap_check_geant4.out || true)"
           if [[ "${noverlaps}" -gt "0" ]] ; then echo "${noverlaps} overlaps found!" && false ; fi
 

--- a/compact/drich.xml
+++ b/compact/drich.xml
@@ -3,20 +3,20 @@
 
 <define>
 <!-- vessel (=snout+tank) geometry -->
-<constant name="DRICH_Length"             value="ForwardRICHRegion_length"/>  <!-- overall vessel length -->
-<constant name="DRICH_zmin"               value="ForwardRICHRegion_zmin"/>
+<constant name="DRICH_Length"             value="140.0*cm"/>  <!-- overall vessel length -->
+<constant name="DRICH_zmin"               value="190.0*cm"/>
 <constant name="DRICH_zmax"               value="DRICH_zmin + DRICH_Length"/>
-<constant name="DRICH_rmin0"              value="DRICH_zmin * ForwardRICHRegion_tan1"/>  <!-- bore radius at dRICh entrance -->
-<constant name="DRICH_rmin1"              value="DRICH_zmax * ForwardRICHRegion_tan2"/>  <!-- bore radius at dRICh exit -->
+<constant name="DRICH_rmin0"              value="8.273*cm"/>  <!-- bore radius at dRICh entrance -->
+<constant name="DRICH_rmin1"              value="16.062*cm"/>  <!-- bore radius at dRICh exit -->
 <constant name="DRICH_wall_thickness"     value="0.5*cm"/>  <!-- thickness of radial walls -->
 <constant name="DRICH_window_thickness"   value="0.1*cm"/>  <!-- thickness of entrance and exit walls -->
 <!-- snout geometry: cone with front radius rmax0 and back radius of rmax1 -->
-<constant name="DRICH_rmax0"              value="95.0*cm"/>
-<constant name="DRICH_SnoutLength"        value="20.0*cm"/>
-<constant name="DRICH_SnoutSlope"         value="DRICH_rmax0 / DRICH_zmin"/> <!-- TODO: increase slope to allow more space for aerogel cones ? -->
-<constant name="DRICH_rmax1"              value="DRICH_rmax0 + DRICH_SnoutLength * DRICH_SnoutSlope"/>
+<constant name="DRICH_rmax0"              value="126.667*cm"/>
+<constant name="DRICH_SnoutLength"        value="4.0*cm"/>
+<constant name="DRICH_SnoutSlope"         value="0.667"/> <!-- TODO: increase slope to allow more space for aerogel cones ? -->
+<constant name="DRICH_rmax1"              value="129.333*cm"/>
 <!-- tank geometry: cylinder, holding the majority of detector components -->
-<constant name="DRICH_rmax2"              value="ForwardPIDRegion_rmax"/>  <!-- cylinder radius -->
+<constant name="DRICH_rmax2"              value="220.0*cm"/>  <!-- cylinder radius -->
 <!-- additional parameters -->
 <constant name="DRICH_aerogel_thickness"  value="4.0*cm"/>  <!-- aerogel thickness -->
 <constant name="DRICH_sensor_size"        value="25.8*mm"/> <!-- sensor side length -->
@@ -146,13 +146,13 @@
   material="Acrylic_DRICH"
   surface="MirrorSurface_DRICH"
   vis="DRICH_mirror_vis"
-  backplane="DRICH_window_thickness + 0.71*cm"
+  backplane="DRICH_window_thickness + 1.0*cm"
   rmin="DRICH_rmin1 + DRICH_wall_thickness - 1.0*cm"
-  rmax="DRICH_rmax2 - DRICH_wall_thickness - 3.0*cm"
+  rmax="DRICH_rmax2 - DRICH_wall_thickness - 1.0*cm"
   phiw="59.5*degree"
   thickness="0.2*cm"
-  focus_tune_x="69.78*cm"
-  focus_tune_z="51.45*cm"
+  focus_tune_x="30.0*cm"
+  focus_tune_z="-40.0*cm"
   />
 
 <!-- /detectors/detector/sensors -->
@@ -205,15 +205,15 @@
     - `zmin`: z-plane cut
 </documentation>
 <sphere
-  centerz="-168.07*cm + DRICH_SnoutLength + (DRICH_Length-DRICH_SnoutLength)/2.0"
-  centerx="124.98*cm"
-  radius="140*cm"
+  centerz="-55.0 * cm"
+  centerx="DRICH_rmax2 - 35.0*cm"
+  radius="85.0 * cm"
   />
 <sphericalpatch
-  phiw="14*degree"
-  rmin="DRICH_rmax1 + 2.0*cm"
+  phiw="18*degree"
+  rmin="DRICH_rmax1 + 5.0*cm"
   rmax="DRICH_rmax2 - 5.0*cm"
-  zmin="DRICH_SnoutLength + 3.0*cm"
+  zmin="DRICH_SnoutLength + 5.0*cm"
   />
 
 
@@ -243,8 +243,8 @@
   <readout name="DRICHHits">
     <segmentation
       type="CartesianGridXY"
-      grid_size_x="DRICH_sensor_pixel_pitch*DRICH_num_px/(DRICH_num_px-1)"
-      grid_size_y="DRICH_sensor_pixel_pitch*DRICH_num_px/(DRICH_num_px-1)"
+      grid_size_x="DRICH_sensor_pixel_pitch"
+      grid_size_y="DRICH_sensor_pixel_pitch"
       offset_x="-DRICH_sensor_pixel_pitch*DRICH_num_px/2.0"
       offset_y="-DRICH_sensor_pixel_pitch*DRICH_num_px/2.0"
       />

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -44,13 +44,20 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
 
   // attributes, from compact file =============================================
   // - vessel
-  double vesselZmin      = dims.attr<double>(_Unicode(zmin));
-  double vesselLength    = dims.attr<double>(_Unicode(length));
-  double vesselRmin0     = dims.attr<double>(_Unicode(rmin0));
-  double vesselRmin1     = dims.attr<double>(_Unicode(rmin1));
-  double vesselRmax0     = dims.attr<double>(_Unicode(rmax0));
-  double vesselRmax1     = dims.attr<double>(_Unicode(rmax1));
-  double vesselRmax2     = dims.attr<double>(_Unicode(rmax2));
+  // double vesselZmin      = dims.attr<double>(_Unicode(zmin));
+  // double vesselLength    = dims.attr<double>(_Unicode(length));
+  // double vesselRmin0     = dims.attr<double>(_Unicode(rmin0));
+  // double vesselRmin1     = dims.attr<double>(_Unicode(rmin1));
+  // double vesselRmax0     = dims.attr<double>(_Unicode(rmax0));
+  // double vesselRmax1     = dims.attr<double>(_Unicode(rmax1));
+  // double vesselRmax2     = dims.attr<double>(_Unicode(rmax2));
+  double vesselZmin      = 195*cm; // DEBUG: override large ATHENA dimensions (which will overlap other subsystems)
+  double vesselLength    = 30*cm;
+  double vesselRmin0     = 20*cm;
+  double vesselRmin1     = 20*cm;
+  double vesselRmax0     = 60*cm;
+  double vesselRmax1     = 70*cm;
+  double vesselRmax2     = 170*cm;
   double snoutLength     = dims.attr<double>(_Unicode(snout_length));
   int    nSectors        = dims.attr<int>(_Unicode(nsectors));
   double wallThickness   = dims.attr<double>(_Unicode(wall_thickness));
@@ -63,8 +70,8 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   auto   radiatorElem       = detElem.child(_Unicode(radiator));
   double radiatorRmin       = radiatorElem.attr<double>(_Unicode(rmin));
   double radiatorRmax       = radiatorElem.attr<double>(_Unicode(rmax));
-  double radiatorPitch      = radiatorElem.attr<double>(_Unicode(pitch));
-  double radiatorFrontplane = radiatorElem.attr<double>(_Unicode(frontplane));
+  // double radiatorPitch      = radiatorElem.attr<double>(_Unicode(pitch));
+  // double radiatorFrontplane = radiatorElem.attr<double>(_Unicode(frontplane));
   // - aerogel
   auto   aerogelElem      = radiatorElem.child(_Unicode(aerogel));
   auto   aerogelMat       = desc.material(aerogelElem.attr<std::string>(_Unicode(material)));
@@ -79,7 +86,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   auto   mirrorElem      = detElem.child(_Unicode(mirror));
   auto   mirrorMat       = desc.material(mirrorElem.attr<std::string>(_Unicode(material)));
   auto   mirrorVis       = desc.visAttributes(mirrorElem.attr<std::string>(_Unicode(vis)));
-  auto   mirrorSurf      = surfMgr.opticalSurface(mirrorElem.attr<std::string>(_Unicode(surface)));
+  // auto   mirrorSurf      = surfMgr.opticalSurface(mirrorElem.attr<std::string>(_Unicode(surface)));
   double mirrorBackplane = mirrorElem.attr<double>(_Unicode(backplane));
   double mirrorThickness = mirrorElem.attr<double>(_Unicode(thickness));
   double mirrorRmin      = mirrorElem.attr<double>(_Unicode(rmin));
@@ -308,26 +315,26 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   // aerogel placement and surface properties
   // TODO [low-priority]: define skin properties for aerogel and filter
   // FIXME: radiatorPitch might not be working correctly (not yet used)
-  auto radiatorPos      = Position(0., 0., radiatorFrontplane) + originFront;
-  auto aerogelPlacement = Translation3D(radiatorPos.x(), radiatorPos.y(), radiatorPos.z()) * // re-center to originFront
-                          RotationY(radiatorPitch); // change polar angle to specified pitch
-  auto       aerogelPV = gasvolVol.placeVolume(aerogelVol, aerogelPlacement);
-  DetElement aerogelDE(det, "aerogel_de", 0);
-  aerogelDE.setPlacement(aerogelPV);
+  // auto radiatorPos      = Position(0., 0., radiatorFrontplane) + originFront;
+  // auto aerogelPlacement = Translation3D(radiatorPos.x(), radiatorPos.y(), radiatorPos.z()) * // re-center to originFront
+  //                         RotationY(radiatorPitch); // change polar angle to specified pitch
+  // auto       aerogelPV = gasvolVol.placeVolume(aerogelVol, aerogelPlacement);
+  // DetElement aerogelDE(det, "aerogel_de", 0);
+  // aerogelDE.setPlacement(aerogelPV);
   // SkinSurface aerogelSkin(desc, aerogelDE, "mirror_optical_surface", aerogelSurf, aerogelVol);
   // aerogelSkin.isValid();
 
   // filter placement and surface properties
   PlacedVolume filterPV;
   if (!debugOptics) {
-    auto filterPlacement =
-        Translation3D(0., 0., airGap) *                                    // add an air gap
-        Translation3D(radiatorPos.x(), radiatorPos.y(), radiatorPos.z()) * // re-center to originFront
-        RotationY(radiatorPitch) *                                         // change polar angle
-        Translation3D(0., 0., (aerogelThickness + filterThickness) / 2.);  // move to aerogel backplane
-    filterPV = gasvolVol.placeVolume(filterVol, filterPlacement);
-    DetElement filterDE(det, "filter_de", 0);
-    filterDE.setPlacement(filterPV);
+    // auto filterPlacement =
+    //     Translation3D(0., 0., airGap) *                                    // add an air gap
+    //     Translation3D(radiatorPos.x(), radiatorPos.y(), radiatorPos.z()) * // re-center to originFront
+    //     RotationY(radiatorPitch) *                                         // change polar angle
+    //     Translation3D(0., 0., (aerogelThickness + filterThickness) / 2.);  // move to aerogel backplane
+    // filterPV = gasvolVol.placeVolume(filterVol, filterPlacement);
+    // DetElement filterDE(det, "filter_de", 0);
+    // filterDE.setPlacement(filterPV);
     // SkinSurface filterSkin(desc, filterDE, "mirror_optical_surface", filterSurf, filterVol);
     // filterSkin.isValid();
   };
@@ -487,6 +494,8 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
               Translation3D(sensorSphRadius, 0., 0.) * // push radially to spherical surface
               RotationY(M_PI / 2) *                    // rotate sensor to be compatible with generator coords
               RotationZ(-M_PI / 2);                    // correction for readout segmentation mapping
+
+if((imod==1256 || imod==1257) && isec==0) { // DEBUG: restrict to overlapping sensors
           auto sensorPV = gasvolVol.placeVolume(sensorVol, sensorPlacement);
 
           // generate LUT for module number -> sensor position, for readout mapping tests
@@ -504,6 +513,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
             SkinSurface sensorSkin(desc, sensorDE, Form("sensor_optical_surface%d", isec), sensorSurf, sensorVol);
             sensorSkin.isValid();
           };
+}; ////////////////////////// END sensor restriction
 
 #ifdef IRT_AUXFILE
           // IRT sensors
@@ -650,14 +660,14 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
     // mirror volume, attributes, and placement
     Volume mirrorVol(detName + "_mirror_" + secName, mirrorSolid2, mirrorMat);
     mirrorVol.setVisAttributes(mirrorVis);
-    auto mirrorSectorPlacement = RotationZ(sectorRotation) * Translation3D(0, 0, 0); // rotate about beam axis to sector
-    auto mirrorPV              = gasvolVol.placeVolume(mirrorVol, mirrorSectorPlacement);
+    // auto mirrorSectorPlacement = RotationZ(sectorRotation) * Translation3D(0, 0, 0); // rotate about beam axis to sector
+    // auto mirrorPV              = gasvolVol.placeVolume(mirrorVol, mirrorSectorPlacement);
 
     // properties
-    DetElement mirrorDE(det, Form("mirror_de%d", isec), isec);
-    mirrorDE.setPlacement(mirrorPV);
-    SkinSurface mirrorSkin(desc, mirrorDE, Form("mirror_optical_surface%d", isec), mirrorSurf, mirrorVol);
-    mirrorSkin.isValid();
+    // DetElement mirrorDE(det, Form("mirror_de%d", isec), isec);
+    // mirrorDE.setPlacement(mirrorPV);
+    // SkinSurface mirrorSkin(desc, mirrorDE, Form("mirror_optical_surface%d", isec), mirrorSurf, mirrorVol);
+    // mirrorSkin.isValid();
 
 #ifdef IRT_AUXFILE
     // get mirror center coordinates, w.r.t. IP


### PR DESCRIPTION
Do not merge.

This is a hacked version of the dRICH that only includes two sensors,
which have an obvious overlap in `jsroot`. In `athena` CI overlap
checks, this was missed, whereas the ECCE's `fun4all` overlap check did
catch this (they imported our geometry via GDML).

See https://eicweb.phy.anl.gov/EIC/detectors/athena/-/issues/151 for
more details.

The goal of this test is to see if the latest CI workflow still misses
this overlap.

Screenshot from `jsroot`:
![2022-07-29-133519_288x605_scrot](https://user-images.githubusercontent.com/7843751/181814429-eff654cc-371c-43a2-a3c5-7ed63138bd9c.png)

Zoom into overlap:
![2022-07-29-133556_795x475_scrot](https://user-images.githubusercontent.com/7843751/181814442-b47fc1bb-b4a8-4c1f-b3a1-81cf629df3b8.png)

