### PR TITLE
feat: install dd4hep_configure_scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,8 @@ endif()
 #-----------------------------------------------------------------------------------
 # Configure and install detector setup script
 #
+dd4hep_configure_scripts(${PROJECT_NAME} DEFAULT_SETUP)
+
 execute_process(
   COMMAND git rev-parse --abbrev-ref HEAD
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
This allows for more convenient use of the geometry without (it is hoped) custom setup scripts:
- `source bin/thisepic.sh`
- `bin/run_test_epic.sh tcsh`
(also avoiding the need for tcsh setup scripts by directing users to start a subshell in the second example)