### PR TITLE
feat: install using GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ endif()
 # Export compile commands as json for run-clang-tidy
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Install into GNU standards
+include(GNUInstallDirs)
+
 # Set required DD4hep components based on user input
 set(USE_DDG4 "TRUE" CACHE BOOL "Require DD4hep DDG4 component")
 set(DD4hep_required_components DDCore DDRec)
@@ -99,7 +102,7 @@ add_custom_command(TARGET ${PROJECT_NAME}.xml
     COMMENT "Creating default ${PROJECT_NAME}.xml geometry"
     )
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.xml
-    DESTINATION share/${PROJECT_NAME}/
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/
     )
 
 file(GLOB CONFIG_YMLS ${CMAKE_CURRENT_SOURCE_DIR}/configurations/*.yml)
@@ -116,21 +119,21 @@ foreach(config_yml ${CONFIG_YMLS})
         COMMENT "Creating configuration ${config} for ${PROJECT_NAME}"
         )
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}_${config}.xml
-        DESTINATION share/${PROJECT_NAME}/
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/
         )
 endforeach()
 
 #-----------------------------------------------------------------------------------
 # Install the detector description files.
 install(DIRECTORY compact/
-    DESTINATION share/${PROJECT_NAME}/compact
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/compact
     FILES_MATCHING PATTERN "*.xml"
     )
 
 #-----------------------------------------------------------------------------------
 # Install the detector calibration files.
 install(DIRECTORY calibrations/
-    DESTINATION share/${PROJECT_NAME}/calibrations
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/calibrations
     )
 
 # Handle ECCE compatibility mode


### PR DESCRIPTION
This will ensure that files are installed into their correct locations, even on systems that use lib64 as LIBDIR. This commit does not actually change the installed location of any files (but setup.sh should go into BINDIR).