### PR TITLE
test: post commit status with eicweb pipeline

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -267,6 +267,7 @@ jobs:
         variables: |
           JUGGLER_DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
           JUGGLER_DETECTOR_VERSION=${{ github.ref_name }}
+          GITHUB_REPOSITORY=${{ github.repository }}
           GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
     - run: |
         gh api \
@@ -275,7 +276,7 @@ jobs:
           /repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha || github.sha }} \
           -f state='pending' \
           -f target_url=${{ steps.trigger.outputs.web_url }} \
-          -f description='The detector benchmarks are running...' \
+          -f description='The detector benchmarks have been triggered...' \
           -f context='eicweb/detector_benchmarks'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -267,10 +267,18 @@ jobs:
         variables: |
           JUGGLER_DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
           JUGGLER_DETECTOR_VERSION=${{ github.ref_name }}
-    - uses: peter-evans/commit-comment@v2
-      with:
-        body: |
-          Detector benchmarks started at ${{ steps.trigger.outputs.web_url }}
+          GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
+    - run: |
+        gh api \
+           --method POST \
+          -H "Accept: application/vnd.github+json" \
+          /repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha || github.sha }} \
+          -f state='pending' \
+          -f target_url=${{ steps.trigger.outputs.web_url }} \
+          -f description='The detector benchmarks are running...' \
+          -f context='eicweb/detector_benchmarks'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   generate-prim-file:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This replaces the posting of a commit comment with updating a commit status. This status is attached to the pull_request, with a link to the eicweb pipeline.

GitHub actions tokens expire, so we cannot pass them to the triggered pipelines. We will have to figure out a way to pass the success of those pipelines back using a token in those pipelines.

For now we will need to check the pending status by hand and override.

Credit for the idea: @veprbl 