### PR TITLE
fix: specify BEAMLINE for triggered jobs

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -265,6 +265,8 @@ jobs:
         token: ${{ secrets.EICWEB_DETECTOR_BENCHMARK_TRIGGER }}
         ref_name: master
         variables: |
+          BEAMLINE_REPOSITORYURL=${{ github.server_url }}/ip6.git
+          BEAMLINE_VERSION=master
           JUGGLER_DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
           JUGGLER_DETECTOR_VERSION=${{ github.ref_name }}
     - uses: peter-evans/commit-comment@v2


### PR DESCRIPTION
This fixes the issue where triggered benchmark jobs are using the (old) eicweb ip6 repository. See e.g. https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/826381.