### PR TITLE
.gitignore: only ignore xml files in the repository root, not in compact/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 !*.png
 
-*.xml
+/*.xml
 *.prim
 */*.eps
 */*/*.eps


### PR DESCRIPTION
This is a minor convenience fix.