### PR TITLE
ci: generate slides for Wednesday meetings

### DIFF
--- a/.github/workflows/generate-weekly-meeting-slides.yml
+++ b/.github/workflows/generate-weekly-meeting-slides.yml
@@ -7,6 +7,6 @@ jobs:
   generate-weekly-meeting-slides:
     runs-on: ubuntu-latest
     steps:
-    - uses: eic/generate-meeting-slides@v1
+    - uses: eic/generate-meeting-slides@v2
       with:
         since: "1 week ago"

--- a/.github/workflows/generate-weekly-meeting-slides.yml
+++ b/.github/workflows/generate-weekly-meeting-slides.yml
@@ -1,0 +1,12 @@
+on:
+  schedule:
+    - cron:  '30 11 * * 3' # 11:30 UTC = 07:30 EDT on Wednesday
+  workflow_dispatch:
+
+jobs:
+  generate-weekly-meeting-slides:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: eic/generate-meeting-slides@v1
+      with:
+        since: "1 week ago"


### PR DESCRIPTION
This may help us keep track of new and stale issues, merged and WIP PRs at our weekly meetings... Or it may not.