### PR TITLE
fix (dRICH): swap mirror and sensor construction order

### DIFF
--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -376,9 +376,9 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
 
   // initialize sensor centroids (used for mirror parameterization below); this is
   // the average (x,y,z) of the placed sensors, w.r.t. originFront
-  double sensorCentroidX = 0;
-  double sensorCentroidZ = 0;
-  int    sensorCount     = 0;
+  // double sensorCentroidX = 0;
+  // double sensorCentroidZ = 0;
+  // int    sensorCount     = 0;
 
   for (int isec = 0; isec < nSectors; isec++) {
 
@@ -469,11 +469,11 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
         if (patchCut) {
 
           // append sensor position to centroid calculation
-          if (isec == 0) {
-            sensorCentroidX += xCheck;
-            sensorCentroidZ += zCheck;
-            sensorCount++;
-          };
+          // if (isec == 0) {
+          //   sensorCentroidX += xCheck;
+          //   sensorCentroidZ += zCheck;
+          //   sensorCount++;
+          // };
 
           // placement (note: transformations are in reverse order)
           // - transformations operate on global coordinates; the corresponding
@@ -551,10 +551,10 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
     };     // end thetaGen loop
 
     // calculate centroid sensor position
-    if (isec == 0) {
-      sensorCentroidX /= sensorCount;
-      sensorCentroidZ /= sensorCount;
-    };
+    // if (isec == 0) {
+    //   sensorCentroidX /= sensorCount;
+    //   sensorCentroidZ /= sensorCount;
+    // };
 
     // END SENSOR MODULE LOOP ------------------------
 

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -376,6 +376,9 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
 
   // initialize sensor centroids (used for mirror parameterization below); this is
   // the average (x,y,z) of the placed sensors, w.r.t. originFront
+  // - deprecated, but is still here in case we want it later; the IRT auxfile
+  //   requires sensors to be built after the mirrors, but if we want to use
+  //   `sensorCentroid*`, the sensor positions must be known before mirror focusing
   // double sensorCentroidX = 0;
   // double sensorCentroidZ = 0;
   // int    sensorCount     = 0;
@@ -707,15 +710,6 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
         rad->SetReferenceRefractiveIndex(rIndex);
     }
     // write
-    for(auto sector_bounds : irtDetector->_m_OpticalBoundaries) {
-      for(auto bound : sector_bounds.second) {
-        auto surface = bound->GetSurface();
-        printout(ALWAYS, "IRTLOG", "stored boundary: %s", surface->GetName());
-        printf("IRTLOG                   normal: "); surface->GetNormal(TVector3()).Print();
-        printf("IRTLOG                   center: "); surface->GetCenter().Print();
-      }
-      printout(ALWAYS, "IRTLOG", "---");
-    }
     irtGeometry->Write();
     irtAuxFile->Close();
   }

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -175,7 +175,6 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   if (createIrtFile) {
     irtBoundary = new FlatSurface((1 / mm) * TVector3(0, 0, vesselZmin), normX, normY);
     for (int isec = 0; isec < nSectors; isec++) {
-      printout(ALWAYS, "IRTLOG", "============ BOUND: entrance");
       auto rad = irtGeometry->SetContainerVolume(
           irtDetector,             // Cherenkov detector
           "GasVolume",             // name
@@ -345,7 +344,6 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
     aerogelFlatSurface    = new FlatSurface((1 / mm) * TVector3(0, 0, irtAerogelZpos), normX, normY);
     filterFlatSurface     = new FlatSurface((1 / mm) * TVector3(0, 0, irtFilterZpos), normX, normY);
     for (int isec = 0; isec < nSectors; isec++) {
-      printout(ALWAYS, "IRTLOG", "============ BOUND: aerogel");
       auto aerogelFlatRadiator = irtGeometry->AddFlatRadiator(
           irtDetector,             // Cherenkov detector
           "Aerogel",               // name
@@ -355,7 +353,6 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
           aerogelFlatSurface,      // surface
           aerogelThickness / mm    // surface thickness
       );
-      printout(ALWAYS, "IRTLOG", "============ BOUND: filter");
       auto filterFlatRadiator = irtGeometry->AddFlatRadiator(
           irtDetector,             // Cherenkov detector
           "Filter",                // name
@@ -678,7 +675,6 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
                                                   mirrorSphericalSurface,            // surface
                                                   false                              // bool refractive
       );
-      printout(ALWAYS, "IRTLOG", "============ BOUND: mirror");
       irtDetector->AddOpticalBoundary(isec, mirrorOpticalBoundary);
       printout(ALWAYS, "IRTLOG", "");
       printout(ALWAYS, "IRTLOG", "  SECTOR %d MIRROR:", isec);
@@ -710,10 +706,14 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
         rad->SetReferenceRefractiveIndex(rIndex);
     }
     // write
-    for(auto sss : irtDetector->_m_OpticalBoundaries) {
-      for(auto bound : sss.second) {
-        printout(ALWAYS, "IRTLOG", "stored boundary: %s", bound->GetSurface()->GetName());
+    for(auto sector_bounds : irtDetector->_m_OpticalBoundaries) {
+      for(auto bound : sector_bounds.second) {
+        auto surface = bound->GetSurface();
+        printout(ALWAYS, "IRTLOG", "stored boundary: %s", surface->GetName());
+        printf("IRTLOG                   normal: "); surface->GetNormal(TVector3()).Print();
+        printf("IRTLOG                   center: "); surface->GetCenter().Print();
       }
+      printout(ALWAYS, "IRTLOG", "---");
     }
     irtGeometry->Write();
     irtAuxFile->Close();


### PR DESCRIPTION
Swap the construction of mirrors and sensors in `epic/src/dRICH_geo.cpp`. The sensors must be added last, since a call to `CherenkovDetector::CreatePhotonDetectorInstance` will internally add the sensor surface itself to the list of optical boundaries a typical photon will encounter. So the list of boundaries must be in this order:
- vessel entrance
- aerogel entrance
- aerogel exit
- filter entrance
- filter exit
- mirror
- sensor

The way we had it before, mirror and sensor boundaries were switched, and `IRT::Transport` was therefore never seeing the mirror boundary

The variables `sensorCentroidX,Y` and `sensorCount` can no longer be used (without some mild refactoring), and currently aren't being used anyway. They have been commented out, but remain in the code in case we want them for usage in an alternate mirror focusing technique. 