### PR TITLE
fix: revert to a single Hits collection for tracker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ set(DD4hep_required_libraries ${DD4hep_required_components})
 list(TRANSFORM DD4hep_required_libraries PREPEND DD4hep::)
 
 # Dependencies
-find_package(DD4hep REQUIRED COMPONENTS ${DD4hep_required_components})
+find_package(DD4hep 1.21 REQUIRED COMPONENTS ${DD4hep_required_components})
 find_package(ActsDD4hep)
 if(ActsDD4hep_FOUND)
   add_compile_definitions(USE_ACTSDD4HEP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,11 @@ set(DD4hep_required_libraries ${DD4hep_required_components})
 list(TRANSFORM DD4hep_required_libraries PREPEND DD4hep::)
 
 # Dependencies
-find_package(DD4hep 1.21 REQUIRED COMPONENTS ${DD4hep_required_components})
+find_package(DD4hep REQUIRED COMPONENTS ${DD4hep_required_components})
+if(${DD4hep_VERSION} VERSION_LESS 1.21)
+  message(WARNING "DD4hep before 1.21 does not write collections correctly \n"
+                  "More info at https://github.com/AIDASoft/DD4hep/pull/922")
+endif()
 find_package(ActsDD4hep)
 if(ActsDD4hep_FOUND)
   add_compile_definitions(USE_ACTSDD4HEP)

--- a/compact/tracker/central_tracker_hybrid_v2.xml
+++ b/compact/tracker/central_tracker_hybrid_v2.xml
@@ -336,7 +336,7 @@ total X0 0.24% per disk layer （4 sectors per disk):
       id="TrackerEndcapP_0_ID"
       name="InnerTrackerEndcapP"
       type="epic_TrapEndcapTracker"
-      readout="TrackerEndcapHits1"
+      readout="TrackerEndcapHits"
       vis="TrackerVis"
       reflect="false">
       <module name="Module1" vis="TrackerModuleVis">
@@ -384,7 +384,7 @@ total X0 0.24% per disk layer （4 sectors per disk):
       id="TrackerEndcapN_0_ID"
       name="InnerTrackerEndcapN"
       type="epic_TrapEndcapTracker"
-      readout="TrackerEndcapHits2"
+      readout="TrackerEndcapHits"
       vis="TrackerVis"
       reflect="true">
       <support material="Aluminum" name="serv_cone_neg" vis="TrackerServiceVis">
@@ -495,7 +495,7 @@ total X0 0.24% per disk layer （4 sectors per disk):
       id="TrackerBarrel_1_ID"
       name="MedialTrackerBarrel"
       type="epic_TrackerBarrel"
-      readout="MPGDTrackerBarrelHits1"
+      readout="MPGDTrackerBarrelHits"
       insideTrackingVolume="true">
       <dimensions
         rmin="MedialTrackerBarrelEnvelope_rmin"
@@ -591,7 +591,7 @@ total X0 0.24% per disk layer （4 sectors per disk):
       id="TrackerEndcapP_1_ID"
       name="MedialTrackerEndcapP"
       type="epic_TrapEndcapTracker"
-      readout="TrackerEndcapHits3"
+      readout="TrackerEndcapHits"
       vis="TrackerVis"
       reflect="false">
       <support material="Aluminum" name="serv_cyl_pos" vis="TrackerServiceVis"
@@ -629,7 +629,7 @@ total X0 0.24% per disk layer （4 sectors per disk):
       id="TrackerEndcapN_1_ID"
       name="MedialTrackerEndcapN"
       type="epic_TrapEndcapTracker"
-      readout="TrackerEndcapHits4"
+      readout="TrackerEndcapHits"
       vis="TrackerVis"
       reflect="true">
       <support material="Aluminum" name="serv_cyl_neg" vis="TrackerServiceVis"
@@ -693,7 +693,7 @@ total X0 0.24% per disk layer （4 sectors per disk):
       id="TrackerBarrel_2_ID"
       name="OuterTrackerBarrel"
       type="epic_TrackerBarrel"
-      readout="MPGDTrackerBarrelHits2"
+      readout="MPGDTrackerBarrelHits"
       insideTrackingVolume="true">
       <dimensions
         rmin="OuterTrackerBarrelEnvelope_rmin"
@@ -825,7 +825,7 @@ total X0 0.24% per disk layer （4 sectors per disk):
       id="TrackerEndcapP_2_ID"
       name="OuterTrackerEndcapP"
       type="epic_TrapEndcapTracker"
-      readout="TrackerEndcapHits5"
+      readout="TrackerEndcapHits"
       vis="TrackerVis"
       reflect="false">
       <support material="Aluminum" name="serv_cyl_pos" vis="TrackerServiceVis"
@@ -903,7 +903,7 @@ total X0 0.24% per disk layer （4 sectors per disk):
       id="TrackerEndcapN_2_ID"
       name="OuterTrackerEndcapN"
       type="epic_TrapEndcapTracker"
-      readout="TrackerEndcapHits6"
+      readout="TrackerEndcapHits"
       vis="TrackerVis"
       reflect="true">
       <support material="Aluminum" name="serv_cyl_pos" vis="TrackerServiceVis"
@@ -1038,7 +1038,7 @@ total X0 0.24% per disk layer （4 sectors per disk):
       id="TrackerEndcapP_3_ID"
       name="GEMEndcapP"
       type="epic_TrapEndcapTracker"
-      readout="GEMTrackerEndcapHits1"
+      readout="GEMTrackerEndcapHits"
       vis="TrackerVis"
       reflect="false">
       <module name="RingModule" vis="TrackerGEMModuleVis">
@@ -1152,7 +1152,7 @@ total X0 0.24% per disk layer （4 sectors per disk):
       id="TrackerEndcapN_3_ID"
       name="GEMEndcapN"
       type="epic_TrapEndcapTracker"
-      readout="GEMTrackerEndcapHits2"
+      readout="GEMTrackerEndcapHits"
       vis="TrackerVis"
       reflect="true">
       <module name="RingModule" vis="TrackerGEMModuleVis">
@@ -1300,7 +1300,7 @@ total X0 0.24% per disk layer （4 sectors per disk):
       id="TrackerEndcapP_4_ID"
       name="ForwardGEM"
       type="epic_TrapEndcapTracker"
-      readout="GEMTrackerEndcapHits3"
+      readout="GEMTrackerEndcapHits"
       vis="TrackerVis"
       reflect="false">
       <module name="LargeModule" vis="TrackerGEMModuleVis">
@@ -1379,47 +1379,15 @@ total X0 0.24% per disk layer （4 sectors per disk):
       <segmentation type="CartesianGridXY" grid_size_x="0.010*mm" grid_size_y="0.010*mm" />
       <id>system:8,layer:4,module:12,sensor:2,x:32:-14,y:-18</id>
     </readout>
-    <readout name="TrackerEndcapHits1">
+    <readout name="TrackerEndcapHits">
       <segmentation type="CartesianGridXZ" grid_size_x="0.010*mm" grid_size_z="0.010*mm" />
       <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
     </readout>
-    <readout name="TrackerEndcapHits2">
-      <segmentation type="CartesianGridXZ" grid_size_x="0.010*mm" grid_size_z="0.010*mm" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
-    </readout>
-    <readout name="TrackerEndcapHits3">
-      <segmentation type="CartesianGridXZ" grid_size_x="0.010*mm" grid_size_z="0.010*mm" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
-    </readout>
-    <readout name="TrackerEndcapHits4">
-      <segmentation type="CartesianGridXZ" grid_size_x="0.010*mm" grid_size_z="0.010*mm" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
-    </readout>
-    <readout name="TrackerEndcapHits5">
-      <segmentation type="CartesianGridXZ" grid_size_x="0.010*mm" grid_size_z="0.010*mm" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
-    </readout>
-    <readout name="TrackerEndcapHits6">
-      <segmentation type="CartesianGridXZ" grid_size_x="0.010*mm" grid_size_z="0.010*mm" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
-    </readout>
-    <readout name="MPGDTrackerBarrelHits1">
+    <readout name="MPGDTrackerBarrelHits">
       <segmentation type="CartesianGridXY" grid_size_x="0.150*mm*sqrt(12)" grid_size_y="0.150*mm*sqrt(12)" />
       <id>system:8,layer:4,module:12,sensor:2,x:32:-14,y:-18</id>
     </readout>
-    <readout name="MPGDTrackerBarrelHits2">
-      <segmentation type="CartesianGridXY" grid_size_x="0.150*mm*sqrt(12)" grid_size_y="0.150*mm*sqrt(12)" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-14,y:-18</id>
-    </readout>
-    <readout name="GEMTrackerEndcapHits1">
-      <segmentation type="CartesianGridXZ" grid_size_x="0.050*mm*sqrt(12)" grid_size_z="0.250*mm*sqrt(12)" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
-    </readout>
-    <readout name="GEMTrackerEndcapHits2">
-      <segmentation type="CartesianGridXZ" grid_size_x="0.050*mm*sqrt(12)" grid_size_z="0.250*mm*sqrt(12)" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
-    </readout>
-    <readout name="GEMTrackerEndcapHits3">
+    <readout name="GEMTrackerEndcapHits">
       <segmentation type="CartesianGridXZ" grid_size_x="0.050*mm*sqrt(12)" grid_size_z="0.250*mm*sqrt(12)" />
       <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
     </readout>

--- a/compact/tracker/mpgd_barrel.xml
+++ b/compact/tracker/mpgd_barrel.xml
@@ -80,7 +80,7 @@
       id="TrackerBarrel_2_ID"
       name="InnerMPGDBarrel"
       type="epic_TrackerBarrel"
-      readout="InnerMPGDBarrelHits"
+      readout="MPGDBarrelHits"
       insideTrackingVolume="true">
       <dimensions
         rmin="InnerMPGDBarrelLayer_rmin"
@@ -116,7 +116,7 @@
       id="TrackerBarrel_4_ID"
       name="OuterMPGDBarrel"
       type="epic_TrackerBarrel"
-      readout="OuterMPGDBarrelHits"
+      readout="MPGDBarrelHits"
       insideTrackingVolume="true">
       <dimensions
         rmin="OuterMPGDBarrelLayer_rmin"
@@ -153,11 +153,7 @@
 
 
   <readouts>
-    <readout name="InnerMPGDBarrelHits">
-      <segmentation type="CartesianGridXY" grid_size_x="0.150*mm*sqrt(12)" grid_size_y="0.150*mm*sqrt(12)" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-14,y:-18</id>
-    </readout>
-    <readout name="OuterMPGDBarrelHits">
+    <readout name="MPGDBarrelHits">
       <segmentation type="CartesianGridXY" grid_size_x="0.150*mm*sqrt(12)" grid_size_y="0.150*mm*sqrt(12)" />
       <id>system:8,layer:4,module:12,sensor:2,x:32:-14,y:-18</id>
     </readout>

--- a/compact/tracker/silicon_barrel.xml
+++ b/compact/tracker/silicon_barrel.xml
@@ -52,7 +52,7 @@
       id="TrackerBarrel_0_ID"
       name="SagittaSiBarrel"
       type="epic_TrackerBarrel"
-      readout="SagittaSiBarrelHits"
+      readout="SiBarrelHits"
       insideTrackingVolume="true">
       <dimensions
         rmin="SiBarrelLayer1_rmin"
@@ -109,7 +109,7 @@
       id="TrackerBarrel_1_ID"
       name="OuterSiBarrel"
       type="epic_TrackerBarrel"
-      readout="OuterSiBarrelHits"
+      readout="SiBarrelHits"
       insideTrackingVolume="true">
       <dimensions
         rmin="SiBarrelLayer2_rmin"
@@ -162,11 +162,7 @@
   </detectors>
 
   <readouts>
-    <readout name="SagittaSiBarrelHits">
-      <segmentation type="CartesianGridXY" grid_size_x="0.010*mm" grid_size_y="0.010*mm" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-12,y:-20</id>
-    </readout>
-    <readout name="OuterSiBarrelHits">
+    <readout name="SiBarrelHits">
       <segmentation type="CartesianGridXY" grid_size_x="0.010*mm" grid_size_y="0.010*mm" />
       <id>system:8,layer:4,module:12,sensor:2,x:32:-12,y:-20</id>
     </readout>

--- a/compact/tracker/silicon_disks.xml
+++ b/compact/tracker/silicon_disks.xml
@@ -3,16 +3,16 @@
   <comment>
     Main parameters. June 2022 setup with symmetric disk locations.
     Here to comply with the ACTS translation onion structure we have:
-      - the first disk in the inner tracking assembly, 
+      - the first disk in the inner tracking assembly,
       - the second silicon disk in the middle silicon tracking assembly
       - the and the following 3 disks in the outer silicon tracking assembly
-    in their own tracking assembly. 
+    in their own tracking assembly.
   </comment>
 
   <define>
 
     <comment> Main tracker disk setup </comment>
-    
+
     <comment> Support/service thicknesses from ATHENA disks for now </comment>
     <constant name="SiTrackerEndcapAl_thickness"    value="0.15*mm"/>
     <constant name="SiTrackerEndcapCF_thickness"    value="0.12*mm"/>
@@ -59,7 +59,7 @@
       id="TrackerEndcapP_0_ID"
       name="InnerTrackerEndcapP"
       type="epic_TrapEndcapTracker"
-      readout="InnerTrackerEndcapPHits"
+      readout="TrackerEndcapHits"
       vis="TrackerVis"
       reflect="false">
       <module name="Module1" vis="TrackerModuleVis">
@@ -87,7 +87,7 @@
       id="TrackerEndcapN_0_ID"
       name="InnerTrackerEndcapN"
       type="epic_TrapEndcapTracker"
-      readout="InnerTrackerEndcapNHits"
+      readout="TrackerEndcapHits"
       vis="TrackerVis"
       reflect="true">
       <module name="Module1" vis="TrackerModuleVis">
@@ -199,7 +199,7 @@
       id="TrackerEndcapP_1_ID"
       name="MiddleTrackerEndcapP"
       type="epic_TrapEndcapTracker"
-      readout="MiddleTrackerEndcapPHits"
+      readout="TrackerEndcapHits"
       vis="TrackerVis"
       reflect="false">
       <module name="Module1" vis="TrackerModuleVis">
@@ -227,7 +227,7 @@
       id="TrackerEndcapN_1_ID"
       name="MiddleTrackerEndcapN"
       type="epic_TrapEndcapTracker"
-      readout="MiddleTrackerEndcapNHits"
+      readout="TrackerEndcapHits"
       vis="TrackerVis"
       reflect="true">
       <module name="Module1" vis="TrackerModuleVis">
@@ -255,7 +255,7 @@
       id="TrackerEndcapP_2_ID"
       name="OuterTrackerEndcapP"
       type="epic_TrapEndcapTracker"
-      readout="OuterTrackerEndcapPHits"
+      readout="TrackerEndcapHits"
       vis="TrackerVis"
       reflect="false">
       <module name="Module2" vis="TrackerModuleVis">
@@ -323,7 +323,7 @@
       id="TrackerEndcapN_2_ID"
       name="OuterTrackerEndcapN"
       type="epic_TrapEndcapTracker"
-      readout="OuterTrackerEndcapNHits"
+      readout="TrackerEndcapHits"
       vis="TrackerVis"
       reflect="true">
       <module name="Module2" vis="TrackerModuleVis">
@@ -390,27 +390,7 @@
   </detectors>
 
   <readouts>
-    <readout name="InnerTrackerEndcapPHits">
-      <segmentation type="CartesianGridXZ" grid_size_x="0.010*mm" grid_size_z="0.010*mm" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
-    </readout>
-    <readout name="InnerTrackerEndcapNHits">
-      <segmentation type="CartesianGridXZ" grid_size_x="0.010*mm" grid_size_z="0.010*mm" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
-    </readout>
-    <readout name="MiddleTrackerEndcapPHits">
-      <segmentation type="CartesianGridXZ" grid_size_x="0.010*mm" grid_size_z="0.010*mm" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
-    </readout>
-    <readout name="MiddleTrackerEndcapNHits">
-      <segmentation type="CartesianGridXZ" grid_size_x="0.010*mm" grid_size_z="0.010*mm" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
-    </readout>
-    <readout name="OuterTrackerEndcapPHits">
-      <segmentation type="CartesianGridXZ" grid_size_x="0.010*mm" grid_size_z="0.010*mm" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
-    </readout>
-    <readout name="OuterTrackerEndcapNHits">
+    <readout name="TrackerEndcapHits">
       <segmentation type="CartesianGridXZ" grid_size_x="0.010*mm" grid_size_z="0.010*mm" />
       <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
     </readout>


### PR DESCRIPTION
We currently write to a separate Hits collection for each barrel and endcap tracker detector definition. This is required by some of the dependencies because the collections are not read correctly if we don't do this.

This branch moves everything back into a single collection to debug the underlying issues and figure out where they exactly are coming from.

### Briefly, what does this PR introduce?
About half a year ago (or longer), when switching fully from dd4pod to edm4hep, we had to put all hits in a dedicated collection instead of reusing the collections across subdetectors. This reverts the behavior as DD4hep versions 1.21 and later have fixed this issues.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
  - Benchmarks need updating:
    - [x] https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/merge_requests/130
    - [x] https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks/-/merge_requests/269
    - [x] https://eicweb.phy.anl.gov/EIC/benchmarks/physics_benchmarks/-/merge_requests/179
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators:
  - [x] Post on mattermost about this
  - [x] Let @eic/epic-devs know about this, in particular @mposik1983 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes. This now requires DD4hep 1.21 or newer for correct behavior (more recent than LCG 101).

### Does this PR change default behavior?
Yes. By default the hits collections for vertex trackers, silicon barrel and disk trackers, and MPGD trackers will not be numbered anymore.