### PR TITLE
fix (dRICH): correct z-position after recent tracker updates

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -435,12 +435,12 @@ Examples:
 
     <comment> Global PID regions with suballocations for TOF and RICH detectors </comment>
     <constant name="ForwardPIDRegion_zmin"        value="CentralTrackingRegionP_zmax" />
-    <constant name="ForwardPIDRegion_length"      value="155.0*cm" />
+    <constant name="ForwardPIDRegion_length"      value="142.0*cm" />
     <constant name="ForwardPIDRegion_rmax"        value="180.0*cm" />
 
     <comment> Forward TOF region currenlty empty for future upgrades </comment>
     <constant name="ForwardTOFRegion_zmin"        value="ForwardPIDRegion_zmin" />
-    <constant name="ForwardTOFRegion_length"      value="35.0*cm" />
+    <constant name="ForwardTOFRegion_length"      value="22.0*cm" />
     <constant name="ForwardTOFRegion_rmax"        value="CentralTrackingRegion_rmax" />
     <constant name="ForwardTOFRegion_tan"         value="CentralTrackingRegionP_tan" />
 


### PR DESCRIPTION
`CentralTrackingRegionP_zmax` was incresed by 13 cm in https://github.com/eic/epic/pull/20. To re-adjust the dRICH z-position, this PR: 

- Reduces `ForwardTOFRegion_length` by 13 cm, for dRICH zmin to be at 195 cm
- Reduces `ForwardPIDRegion_length` by 13 cm, for dRICH zmax to be at 315 cm

The following `diff` of the artifact `constants.out` shows consequences for other detectors:
```diff
182c182
< DRICH_SnoutSlope               =        0.457 = DRICH_rmax0 / DRICH_zmin
---
> DRICH_SnoutSlope               =        0.487 = DRICH_rmax0 / DRICH_zmin
190c190
< DRICH_rmax1                    =      104.135 = DRICH_rmax0 + DRICH_SnoutLength * DRICH_SnoutSlope
---
> DRICH_rmax1                    =      104.744 = DRICH_rmax0 + DRICH_SnoutLength * DRICH_SnoutSlope
192,193c192,193
< DRICH_rmin0                    =        9.056 = DRICH_zmin * ForwardRICHRegion_tan1
< DRICH_rmin1                    =       15.965 = DRICH_zmax * ForwardRICHRegion_tan2
---
> DRICH_rmin0                    =        8.490 = DRICH_zmin * ForwardRICHRegion_tan1
> DRICH_rmin1                    =       15.332 = DRICH_zmax * ForwardRICHRegion_tan2
200,201c200,201
< DRICH_zmax                     =      328.000 = DRICH_zmin + DRICH_Length
< DRICH_zmin                     =      208.000 = ForwardRICHRegion_zmin
---
> DRICH_zmax                     =      315.000 = DRICH_zmin + DRICH_Length
> DRICH_zmin                     =      195.000 = ForwardRICHRegion_zmin
208c208
< EcalBarrelForward_zmax         =      208.000 = ForwardRICHRegion_zmin
---
> EcalBarrelForward_zmax         =      195.000 = ForwardRICHRegion_zmin
214,215c214,215
< EcalBarrel_length              =      538.000 = EcalBarrelForward_zmax + EcalBarrelBackward_zmax
< EcalBarrel_offset              =      -61.000 = (EcalBarrelForward_zmax - EcalBarrelBackward_zmax)/2.0
---
> EcalBarrel_length              =      525.000 = EcalBarrelForward_zmax + EcalBarrelBackward_zmax
> EcalBarrel_offset              =      -67.500 = (EcalBarrelForward_zmax - EcalBarrelBackward_zmax)/2.0
234c234
< EcalEndcapP_NModules           =    32536.000 = 32536
---
> EcalEndcapP_NModules           =    30001.000 = 30001
236c236
< EcalEndcapP_rmax               =      259.000 = floor(Eta1_1_tan * EcalEndcapP_zmin)
---
> EcalEndcapP_rmax               =      249.000 = floor(Eta1_1_tan * EcalEndcapP_zmin)
238,239c238,239
< EcalEndcapP_zmax               =      376.000 = EcalEndcapP_zmin + EcalEndcapP_length
< EcalEndcapP_zmin               =      346.000 = ForwardServiceGap_zmax
---
> EcalEndcapP_zmax               =      363.000 = EcalEndcapP_zmin + EcalEndcapP_length
> EcalEndcapP_zmin               =      333.000 = ForwardServiceGap_zmax
273c273
< ForwardInnerEndcapRegion_length =      165.000 = ForwardPIDRegion_length + ForwardTrackingRegion_length
---
> ForwardInnerEndcapRegion_length =      152.000 = ForwardPIDRegion_length + ForwardTrackingRegion_length
286c286
< ForwardPIDRegion_length        =      155.000 = 155.0*cm
---
> ForwardPIDRegion_length        =      142.000 = 142.0*cm
292c292
< ForwardRICHRegion_zmin         =      208.000 = ForwardTOFRegion_zmin + ForwardTOFRegion_length
---
> ForwardRICHRegion_zmin         =      195.000 = ForwardTOFRegion_zmin + ForwardTOFRegion_length
322,324c322,324
< ForwardServiceGap_zmax         =      346.000 = ForwardServiceGap_zmin + ForwardServiceGap_length
< ForwardServiceGap_zmin         =      338.000 = ForwardPIDRegion_zmin + ForwardInnerEndcapRegion_length
< ForwardTOFRegion_length        =       35.000 = 35.0*cm
---
> ForwardServiceGap_zmax         =      333.000 = ForwardServiceGap_zmin + ForwardServiceGap_length
> ForwardServiceGap_zmin         =      325.000 = ForwardPIDRegion_zmin + ForwardInnerEndcapRegion_length
> ForwardTOFRegion_length        =       22.000 = 22.0*cm
332c332
< ForwardTrackingRegion_zmin     =      328.000 = ForwardPIDRegion_zmin + ForwardPIDRegion_length
---
> ForwardTrackingRegion_zmin     =      315.000 = ForwardPIDRegion_zmin + ForwardPIDRegion_length
339c339
< HcalBarrelForward_zmax         =      338.000 = ForwardServiceGap_zmin
---
> HcalBarrelForward_zmax         =      325.000 = ForwardServiceGap_zmin
345,346c345,346
< HcalBarrel_length              =      658.000 = HcalBarrelForward_zmax + HcalBarrelBackward_zmax
< HcalBarrel_offset              =        9.000 = (HcalBarrelForward_zmax - HcalBarrelBackward_zmax)/2
---
> HcalBarrel_length              =      645.000 = HcalBarrelForward_zmax + HcalBarrelBackward_zmax
> HcalBarrel_offset              =        2.500 = (HcalBarrelForward_zmax - HcalBarrelBackward_zmax)/2
366c366
< HcalEndcapP_rmin               =       29.997 = (HcalEndcapP_zmin + HcalEndcapP_length) * tan(2.0 * abs(CrossingAngle)) + BeampipeOD / 2.0 + 2.0 * cm
---
> HcalEndcapP_rmin               =       29.346 = (HcalEndcapP_zmin + HcalEndcapP_length) * tan(2.0 * abs(CrossingAngle)) + BeampipeOD / 2.0 + 2.0 * cm
368,369c368,369
< HcalEndcapP_zmax               =      496.000 = HcalEndcapP_zmin + HcalEndcapP_length
< HcalEndcapP_zmin               =      376.000 = EcalEndcapP_zmin + EcalEndcapP_length
---
> HcalEndcapP_zmax               =      483.000 = HcalEndcapP_zmin + HcalEndcapP_length
> HcalEndcapP_zmin               =      363.000 = EcalEndcapP_zmin + EcalEndcapP_length
```

### Before:

![view1_top new](https://user-images.githubusercontent.com/7843751/184724079-db099834-8d42-414b-b649-774e0bc0b1fc.png)

### After:

![view1_top](https://user-images.githubusercontent.com/7843751/184724102-9cd3928f-4be3-4f3c-a01c-473312927d70.png)

