### PR TITLE
fix: `silicon_barrel` readout bits `x:32:-12,y:-20`

### DIFF
--- a/compact/tracker/silicon_barrel.xml
+++ b/compact/tracker/silicon_barrel.xml
@@ -68,18 +68,18 @@
                length="SiBarrelMod1_length"
                thickness="SiBarrelMod1Frame_thickness" />
         <module_component name="ITS3"
-                          material="Silicon" 
+                          material="Silicon"
                           sensitive="true"
-                          width="SiBarrelStave1_width" 
+                          width="SiBarrelStave1_width"
                           length="SiBarrelMod1_length"
-                          thickness="SiBarrelSensor_thickness" 
+                          thickness="SiBarrelSensor_thickness"
                           vis="TrackerLayerVis" />
-        <module_component name="Service" 
-                          material="Aluminum" 
+        <module_component name="Service"
+                          material="Aluminum"
                           sensitive="false"
-                          width="SiBarrelStave1_width" 
-                          length="SiBarrelMod1_length" 
-                          thickness="SiBarrelMod1Service_thickness" 
+                          width="SiBarrelStave1_width"
+                          length="SiBarrelMod1_length"
+                          thickness="SiBarrelMod1Service_thickness"
                           vis="TrackerLayerVis"/>
       </module>
       <comment> Layers composed of many arrayed modules  </comment>
@@ -125,18 +125,18 @@
                length="SiBarrelMod2_length"
                thickness="SiBarrelMod2Frame_thickness" />
         <module_component name="ITS3"
-                          material="Silicon" 
+                          material="Silicon"
                           sensitive="true"
-                          width="SiBarrelStave2_width" 
+                          width="SiBarrelStave2_width"
                           length="SiBarrelMod2_length"
-                          thickness="SiBarrelSensor_thickness" 
+                          thickness="SiBarrelSensor_thickness"
                           vis="TrackerLayerVis" />
-        <module_component name="Service" 
-                          material="Aluminum" 
+        <module_component name="Service"
+                          material="Aluminum"
                           sensitive="false"
-                          width="SiBarrelStave2_width" 
-                          length="SiBarrelMod2_length" 
-                          thickness="SiBarrelMod2Service_thickness" 
+                          width="SiBarrelStave2_width"
+                          length="SiBarrelMod2_length"
+                          thickness="SiBarrelMod2Service_thickness"
                           vis="TrackerLayerVis"/>
       </module>
       <comment> Layers composed of many arrayed modules  </comment>
@@ -165,11 +165,11 @@
   <readouts>
     <readout name="SagittaSiBarrelHits">
       <segmentation type="CartesianGridXY" grid_size_x="0.010*mm" grid_size_y="0.010*mm" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,y:-16</id>
+      <id>system:8,layer:4,module:12,sensor:2,x:32:-12,y:-20</id>
     </readout>
     <readout name="OuterSiBarrelHits">
       <segmentation type="CartesianGridXY" grid_size_x="0.010*mm" grid_size_y="0.010*mm" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,y:-16</id>
+      <id>system:8,layer:4,module:12,sensor:2,x:32:-12,y:-20</id>
     </readout>
   </readouts>
 


### PR DESCRIPTION
The `silicon_barrel` staves are 4 cm wide in x, so 4000 segments are needed, or at least 12 bits. They are 108.46 cm long in y, so 108460 segments are  needed, or at least 17 bits. This changes the 32 bit allocation for x:y from 16:16 to 12:20.