### PR TITLE
fix(dRICH): add sensor coverage for high theta along sector boundaries

### DIFF
--- a/compact/drich.xml
+++ b/compact/drich.xml
@@ -210,7 +210,7 @@
   radius="100.0*cm"
   />
 <sphericalpatch
-  phiw="14*degree"
+  phiw="18*degree"
   rmin="DRICH_rmax1 + 2.0*cm"
   rmax="DRICH_rmax2 - 5.0*cm"
   zmin="DRICH_SnoutLength + 5.0*cm"


### PR DESCRIPTION
Updated pixel hit maps (cf. #24 for previous hit maps):

![after0](https://user-images.githubusercontent.com/7843751/186513135-159eaabc-5746-429e-8bea-b234827bec47.png)
![after1](https://user-images.githubusercontent.com/7843751/186513151-f25422c5-3b78-450d-bcf1-d508eea5bb94.png)
