### PR TITLE
ci: workflow_dispatch with inputs

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -15,7 +15,7 @@ on:
         default: 'https://github.com/eic/ip6'
         type: string
       beamline_version:
-        description: 'Branch for beamline repository'
+        description: 'Branch in beamline repository'
         required: false
         default: 'master'
         type: string

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -8,6 +8,17 @@ on:
       - '*'
   pull_request:
   workflow_dispatch:
+    inputs:
+      beamline_repositoryurl:
+        description: 'Repository URL for beamline'
+        required: false
+        default: 'https://github.com/eic/ip6'
+        type: string
+      beamline_version:
+        description: 'Branch for beamline repository'
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -35,8 +46,9 @@ jobs:
         run: |
           PREFIX=${PWD}/install
           # install ip6 repo
-          git clone https://github.com/eic/ip6.git eic_ip6
+          git clone ${{ inputs.beamline_repositoryurl || 'https://github.com/eic/ip6.git' }} eic_ip6
           pushd eic_ip6
+          git checkout ${{ inputs.beamline_version || 'master' }}
           cmake -B build -S . -DCMAKE_INSTALL_PREFIX=${PREFIX}
           cmake --build build -- install
           popd


### PR DESCRIPTION
This adds default values to the `workflow_dispatch` inputs which are then used with `push` or `pull_request` events. We need `workflow_dispatch` primarily to start pipelines from the `ip6` repository.