### PR TITLE
updated silicon tracker geometry to LBL design with symmetric disks

### DIFF
--- a/compact/tracker.xml
+++ b/compact/tracker.xml
@@ -5,7 +5,8 @@
   <define>
     <comment> Primary directions for the tracker </comment>
     <comment> TODO: use actual design angles rather than calculated projective directions </comment>
-    <constant name="TrackerPrimaryAngle"             value="2*atan(exp(-1.109))" />
+    <comment> projective cone at 45 degree </comment>
+    <constant name="TrackerPrimaryAngle"             value="atan(1)" />
     <constant name="TrackerForwardAngle"             value="2*atan(exp(-1.6472))" />
     <constant name="TrackerBackwardAngle"            value="2*atan(exp(-1.5166))" />
 
@@ -18,7 +19,7 @@
     <constant name="SiBarrel1_rmin"                  value="27.0*cm"/>
     <constant name="SiBarrel2_rmin"                  value="42.0*cm"/>
     <constant name="SiBarrel_angle"                  value="TrackerPrimaryAngle"/>
-    <constant name="SiBarrel_dz"                     value="5.0*cm"/>
+    <constant name="SiBarrel_dz"                     value="2*cm"/>
     <comment> barrel length: 2R/tan(angle) - dz </comment>
 
     <comment> Main parameters for the MPGD layer geometries </comment>
@@ -31,11 +32,9 @@
     <comment> barrel asymmetryc between forward and backward lengths </comment>
 
     <comment> Service/Support setup </comment>
-    <constant name="VertexSupportCyl1_rmin"          value="VertexBarrel_rmin + 2.1*cm"/>
     <constant name="VertexSupportCyl2_thickness"     value="0.3*cm"/>
     <constant name="VertexSupportCylCF_thickness"    value="100.0*um" />
-    <constant name="VertexSupportCyl2_rmin"          value="VertexBarrel_rmax-VertexSupportCyl2_thickness"/>
-    <constant name="TrackerSupportCyl_rmin"          value="41.5*cm"/>
+    <constant name="TrackerSupportCyl_rmin"          value="44.0*cm"/>
     <comment> These may belong in definitions.xml </comment>
     <constant name="InnerTrackerEndcapP_zmax"        value="CentralTrackingRegionP_zmax"/>
     <constant name="InnerTrackerEndcapN_zmax"        value="CentralTrackingRegionN_zmax"/>
@@ -48,19 +47,19 @@
     <comment> Main parameters for the positive silicon disks </comment>
     <constant name="InnerTrackerEndcapP_zmin"        value="25.0*cm" />
     <constant name="InnerTrackerEndcapP_rmin"        value="Beampipe_rmax + 5*mm" />
-    <constant name="InnerTrackerEndcapP_rmax"        value="InnerTrackerEndcapP_zmin * tan(TrackerPrimaryAngle) * .9995" />
+    <constant name="InnerTrackerEndcapP_rmax"        value="24.0*cm" />
     <constant name="TrackerEndcapPDisk1_zmin"        value="45.0*cm" />
     <constant name="TrackerEndcapPDisk1_rmin"        value="Beampipe_rmax + 5*mm" />
-    <constant name="TrackerEndcapPDisk1_rmax"        value="TrackerEndcapPDisk1_zmin * tan(TrackerPrimaryAngle) * .96" />
+    <constant name="TrackerEndcapPDisk1_rmax"        value="TrackerSupportCyl_rmin * .98" />
     <constant name="TrackerEndcapPDisk2_zmin"        value="70.0*cm" />
-    <constant name="TrackerEndcapPDisk2_rmin"        value="Beampipe_rmax + 13.2*mm" />
+    <constant name="TrackerEndcapPDisk2_rmin"        value="Beampipe_rmax + 9*mm" />
     <constant name="TrackerEndcapPDisk2_rmax"        value="TrackerSupportCyl_rmin * .98" />
     <constant name="TrackerEndcapPDisk3_zmin"        value="100.0*cm" />
-    <constant name="TrackerEndcapPDisk3_rmin"        value="Beampipe_rmax + 23.2*mm" />
-    <constant name="TrackerEndcapPDisk3_rmax"        value="TrackerEndcapPDisk3_zmin * tan(TrackerForwardAngle) * 0.98" />
+    <constant name="TrackerEndcapPDisk3_rmin"        value="Beampipe_rmax + 22.0*mm" />
+    <constant name="TrackerEndcapPDisk3_rmax"        value="TrackerSupportCyl_rmin * .98" />
     <constant name="TrackerEndcapPDisk4_zmin"        value="135.0*cm" />
-    <constant name="TrackerEndcapPDisk4_rmin"        value="Beampipe_rmax + 43.2*mm" />
-    <constant name="TrackerEndcapPDisk4_rmax"        value="TrackerEndcapPDisk4_zmin * tan(TrackerForwardAngle) * 0.87" />
+    <constant name="TrackerEndcapPDisk4_rmin"        value="Beampipe_rmax + 39.0*mm" />
+    <constant name="TrackerEndcapPDisk4_rmax"        value="TrackerSupportCyl_rmin * .98" />
 
     <comment> Main parameters for the negative silicon disks (will be reflected, so positive z-values here)
               Values such that the disk dimensions are identical to the positive endcap. 

--- a/compact/tracker.xml
+++ b/compact/tracker.xml
@@ -32,8 +32,9 @@
 
     <comment> Service/Support setup </comment>
     <constant name="VertexSupportCyl1_rmin"          value="VertexBarrel_rmin + 2.1*cm"/>
-    <constant name="VertexSupportCyl2_rmin"          value="VertexBarrel_rmax-0.3*cm"/>
+    <constant name="VertexSupportCyl2_thickness"     value="0.3*cm"/>
     <constant name="VertexSupportCylCF_thickness"    value="100.0*um" />
+    <constant name="VertexSupportCyl2_rmin"          value="VertexBarrel_rmax-VertexSupportCyl2_thickness"/>
     <constant name="TrackerSupportCyl_rmin"          value="41.5*cm"/>
     <comment> These may belong in definitions.xml </comment>
     <constant name="InnerTrackerEndcapP_zmax"        value="CentralTrackingRegionP_zmax"/>

--- a/compact/tracker.xml
+++ b/compact/tracker.xml
@@ -32,8 +32,8 @@
 
     <comment> Service/Support setup </comment>
     <constant name="VertexSupportCyl1_rmin"          value="VertexBarrel_rmin + 2.1*cm"/>
-    <constant name="VertexSupportCyl2_rmin"          value="VertexBarrel_rmax"/>
-    <constant name="VertexSupportCylCF_thickness"    value="300.0*um" />
+    <constant name="VertexSupportCyl2_rmin"          value="VertexBarrel_rmax-0.3*cm"/>
+    <constant name="VertexSupportCylCF_thickness"    value="100.0*um" />
     <constant name="TrackerSupportCyl_rmin"          value="41.5*cm"/>
     <comment> These may belong in definitions.xml </comment>
     <constant name="InnerTrackerEndcapP_zmax"        value="CentralTrackingRegionP_zmax"/>
@@ -48,16 +48,16 @@
     <constant name="InnerTrackerEndcapP_zmin"        value="25.0*cm" />
     <constant name="InnerTrackerEndcapP_rmin"        value="Beampipe_rmax + 3.2*mm" />
     <constant name="InnerTrackerEndcapP_rmax"        value="InnerTrackerEndcapP_zmin * tan(TrackerPrimaryAngle) * .9995" />
-    <constant name="TrackerEndcapPDisk1_zmin"        value="52.0*cm" />
+    <constant name="TrackerEndcapPDisk1_zmin"        value="45.0*cm" />
     <constant name="TrackerEndcapPDisk1_rmin"        value="Beampipe_rmax + 3.2*mm" />
     <constant name="TrackerEndcapPDisk1_rmax"        value="TrackerEndcapPDisk1_zmin * tan(TrackerPrimaryAngle) * .96" />
-    <constant name="TrackerEndcapPDisk2_zmin"        value="73.0*cm" />
+    <constant name="TrackerEndcapPDisk2_zmin"        value="70.0*cm" />
     <constant name="TrackerEndcapPDisk2_rmin"        value="Beampipe_rmax + 13.2*mm" />
     <constant name="TrackerEndcapPDisk2_rmax"        value="TrackerSupportCyl_rmin * .98" />
-    <constant name="TrackerEndcapPDisk3_zmin"        value="106.0*cm" />
+    <constant name="TrackerEndcapPDisk3_zmin"        value="100.0*cm" />
     <constant name="TrackerEndcapPDisk3_rmin"        value="Beampipe_rmax + 23.2*mm" />
     <constant name="TrackerEndcapPDisk3_rmax"        value="TrackerEndcapPDisk3_zmin * tan(TrackerForwardAngle) * 0.98" />
-    <constant name="TrackerEndcapPDisk4_zmin"        value="125.0*cm" />
+    <constant name="TrackerEndcapPDisk4_zmin"        value="135.0*cm" />
     <constant name="TrackerEndcapPDisk4_rmin"        value="Beampipe_rmax + 43.2*mm" />
     <constant name="TrackerEndcapPDisk4_rmax"        value="TrackerEndcapPDisk4_zmin * tan(TrackerForwardAngle) * 0.87" />
 
@@ -77,7 +77,9 @@
     <constant name="TrackerEndcapNDisk3_zmin"        value="TrackerEndcapPDisk3_zmin" />
     <constant name="TrackerEndcapNDisk3_rmin"        value="TrackerEndcapPDisk3_rmin" />
     <constant name="TrackerEndcapNDisk3_rmax"        value="TrackerEndcapPDisk3_rmax" />
-
+    <constant name="TrackerEndcapNDisk4_zmin"        value="TrackerEndcapPDisk4_zmin" />
+    <constant name="TrackerEndcapNDisk4_rmin"        value="TrackerEndcapPDisk4_rmin" />
+    <constant name="TrackerEndcapNDisk4_rmax"        value="TrackerEndcapPDisk4_rmax" />
   </define>
 
   <detectors>

--- a/compact/tracker.xml
+++ b/compact/tracker.xml
@@ -47,10 +47,10 @@
 
     <comment> Main parameters for the positive silicon disks </comment>
     <constant name="InnerTrackerEndcapP_zmin"        value="25.0*cm" />
-    <constant name="InnerTrackerEndcapP_rmin"        value="Beampipe_rmax + 3.2*mm" />
+    <constant name="InnerTrackerEndcapP_rmin"        value="Beampipe_rmax + 5*mm" />
     <constant name="InnerTrackerEndcapP_rmax"        value="InnerTrackerEndcapP_zmin * tan(TrackerPrimaryAngle) * .9995" />
     <constant name="TrackerEndcapPDisk1_zmin"        value="45.0*cm" />
-    <constant name="TrackerEndcapPDisk1_rmin"        value="Beampipe_rmax + 3.2*mm" />
+    <constant name="TrackerEndcapPDisk1_rmin"        value="Beampipe_rmax + 5*mm" />
     <constant name="TrackerEndcapPDisk1_rmax"        value="TrackerEndcapPDisk1_zmin * tan(TrackerPrimaryAngle) * .96" />
     <constant name="TrackerEndcapPDisk2_zmin"        value="70.0*cm" />
     <constant name="TrackerEndcapPDisk2_rmin"        value="Beampipe_rmax + 13.2*mm" />
@@ -72,7 +72,7 @@
     <constant name="TrackerEndcapNDisk1_zmin"        value="TrackerEndcapPDisk1_zmin" />
     <constant name="TrackerEndcapNDisk1_rmin"        value="TrackerEndcapPDisk1_rmin" />
     <constant name="TrackerEndcapNDisk1_rmax"        value="TrackerEndcapPDisk1_rmax" />
-    <constant name="TrackerEndcapNDisk2_zmin"        value="79.0*cm" />
+    <constant name="TrackerEndcapNDisk2_zmin"        value="TrackerEndcapPDisk2_zmin" />
     <constant name="TrackerEndcapNDisk2_rmin"        value="TrackerEndcapPDisk2_rmin" />
     <constant name="TrackerEndcapNDisk2_rmax"        value="TrackerEndcapPDisk2_rmax" />
     <constant name="TrackerEndcapNDisk3_zmin"        value="TrackerEndcapPDisk3_zmin" />

--- a/compact/tracker/silicon_barrel.xml
+++ b/compact/tracker/silicon_barrel.xml
@@ -5,8 +5,8 @@
       Main parameters - this is for the more realistic June 2022 design
     </comment>
 
-    <constant name="SiBarrelMod1_rmin"             value="SiBarrel1_rmin"/>
-    <constant name="SiBarrelMod2_rmin"             value="SiBarrel2_rmin"/>
+    <constant name="SiBarrelMod1_rmin"             value="SiBarrel1_rmin+1*mm"/>
+    <constant name="SiBarrelMod2_rmin"             value="SiBarrel2_rmin+1*cm"/>
     <constant name="SiBarrelMod_angle"             value="SiBarrel_angle"/>
     <constant name="SiBarrelMod_dz"                value="SiBarrel_dz"/>
 
@@ -26,7 +26,8 @@
     </comment>
 
     <constant name="SiBarrelMod1_length"        value="2 * SiBarrelMod1_rmin / tan(SiBarrelMod_angle) - SiBarrel_dz"/>
-    <constant name="SiBarrelMod2_length"        value="2 * SiBarrelMod2_rmin / tan(SiBarrelMod_angle) - SiBarrel_dz"/>
+    <comment> 84cm=2*42cm is the engineer max </comment>
+    <constant name="SiBarrelMod2_length"        value="84*cm"/>
 
     <constant name="SiBarrelLayer1_length"      value="SiBarrelMod1_length + 1*um"/>
     <constant name="SiBarrelLayer2_length"      value="SiBarrelMod2_length + 1*um"/>

--- a/compact/tracker/silicon_barrel.xml
+++ b/compact/tracker/silicon_barrel.xml
@@ -12,9 +12,8 @@
 
     <constant name="SiBarrelSensor_thickness"      value="40*um"/>
 
-    <comment> Module one has roughlty 50% of the support/service thickness compared to module two </comment>
-    <constant name="SiBarrelMod1Service_thickness" value="0.2*mm"/>
-    <constant name="SiBarrelMod2Service_thickness" value="0.4*mm"/>
+    <constant name="SiBarrelMod1Service_thickness" value="0.15*mm"/>
+    <constant name="SiBarrelMod2Service_thickness" value="0.37*mm"/>
     <constant name="SiBarrelMod1Frame_thickness"   value="0.06*mm"/>
     <constant name="SiBarrelMod2Frame_thickness"   value="0.12*mm"/>
     <constant name="SiBarrelMod1Frame_height"      value="0.8*cm"/>
@@ -34,11 +33,11 @@
     <constant name="SiBarrelEnvelope_length"    value="SiBarrelLayer2_length + 1*um" />
 
     <constant name="SiBarrelLayer_thickness"    value="2.0*cm"/>
-
-    <constant name="SiBarrelLayer1_rmin"        value="SiBarrelMod1_rmin - SiBarrelLayer_thickness/2.0"/>
-    <constant name="SiBarrelLayer1_rmax"        value="SiBarrelLayer1_rmin + SiBarrelLayer_thickness"/>
-    <constant name="SiBarrelLayer2_rmin"        value="SiBarrelMod2_rmin - SiBarrelLayer_thickness/2.0"/>
-    <constant name="SiBarrelLayer2_rmax"        value="SiBarrelLayer2_rmin + SiBarrelLayer_thickness"/>
+    <comment> the sensitive layer (silicon) is at the bottom of the truss triangle stave (rmin) </comment>
+    <constant name="SiBarrelLayer1_rmin"        value="SiBarrelMod1_rmin"/>
+    <constant name="SiBarrelLayer1_rmax"        value="SiBarrelLayer1_rmin + SiBarrelLayer_thickness*1.5"/>
+    <constant name="SiBarrelLayer2_rmin"        value="SiBarrelMod2_rmin "/>
+    <constant name="SiBarrelLayer2_rmax"        value="SiBarrelLayer2_rmin + SiBarrelLayer_thickness*1.5"/>
 
     <constant name="SiBarrelStaveTilt_angle"     value="3.0*degree"/>
     <constant name="SiBarrelStave1_count"        value="floor(180.*degree/asin(SiBarrelStave1_width*cos(SiBarrelStaveTilt_angle)/2/SiBarrelMod1_rmin))+2"/>
@@ -88,7 +87,7 @@
           inner_r="SiBarrelLayer1_rmin"
           outer_r="SiBarrelLayer1_rmax"
           z_length="SiBarrelLayer1_length" />
-        <layer_material surface="outer" binning="binPhi,binZ" bins0="SiBarrelStave1_count" bins1="100" />
+        <layer_material surface="inner" binning="binPhi,binZ" bins0="SiBarrelStave1_count" bins1="100" />
         <comment>
           phi0     : Starting phi of first module.
           phi_tilt : Phi tilt of a module.
@@ -145,7 +144,7 @@
           inner_r="SiBarrelLayer2_rmin"
           outer_r="SiBarrelLayer2_rmax"
           z_length="SiBarrelLayer2_length" />
-        <layer_material surface="outer" binning="binPhi,binZ" bins0="SiBarrelStave2_count" bins1="100" />
+        <layer_material surface="inner" binning="binPhi,binZ" bins0="SiBarrelStave2_count" bins1="100" />
         <comment>
           phi0     : Starting phi of first module.
           phi_tilt : Phi tilt of a module.

--- a/compact/tracker/silicon_barrel.xml
+++ b/compact/tracker/silicon_barrel.xml
@@ -32,12 +32,11 @@
     <constant name="SiBarrelLayer2_length"      value="SiBarrelMod2_length + 1*um"/>
     <constant name="SiBarrelEnvelope_length"    value="SiBarrelLayer2_length + 1*um" />
 
-    <constant name="SiBarrelLayer_thickness"    value="2.0*cm"/>
-    <comment> the sensitive layer (silicon) is at the bottom of the truss triangle stave (rmin) </comment>
-    <constant name="SiBarrelLayer1_rmin"        value="SiBarrelMod1_rmin"/>
-    <constant name="SiBarrelLayer1_rmax"        value="SiBarrelLayer1_rmin + SiBarrelLayer_thickness*1.5"/>
+    <constant name="SiBarrelLayer_thickness"    value="3.0*cm"/>
+    <constant name="SiBarrelLayer1_rmin"        value="SiBarrelMod1_rmin "/>
+    <constant name="SiBarrelLayer1_rmax"        value="SiBarrelLayer1_rmin + SiBarrelLayer_thickness"/>
     <constant name="SiBarrelLayer2_rmin"        value="SiBarrelMod2_rmin "/>
-    <constant name="SiBarrelLayer2_rmax"        value="SiBarrelLayer2_rmin + SiBarrelLayer_thickness*1.5"/>
+    <constant name="SiBarrelLayer2_rmax"        value="SiBarrelLayer2_rmin + SiBarrelLayer_thickness"/>
 
     <constant name="SiBarrelStaveTilt_angle"     value="3.0*degree"/>
     <constant name="SiBarrelStave1_count"        value="floor(180.*degree/asin(SiBarrelStave1_width*cos(SiBarrelStaveTilt_angle)/2/SiBarrelMod1_rmin))+2"/>
@@ -84,7 +83,7 @@
       <comment> Layers composed of many arrayed modules  </comment>
       <layer module="Module1" id="1" vis="TrackerLayerVis">
         <barrel_envelope
-          inner_r="SiBarrelLayer1_rmin"
+          inner_r="SiBarrelLayer1_rmin-0.5*mm"
           outer_r="SiBarrelLayer1_rmax"
           z_length="SiBarrelLayer1_length" />
         <layer_material surface="inner" binning="binPhi,binZ" bins0="SiBarrelStave1_count" bins1="100" />
@@ -141,7 +140,7 @@
       <comment> Layers composed of many arrayed modules  </comment>
       <layer module="Module1" id="1" vis="TrackerLayerVis">
         <barrel_envelope
-          inner_r="SiBarrelLayer2_rmin"
+          inner_r="SiBarrelLayer2_rmin-1.0*mm"
           outer_r="SiBarrelLayer2_rmax"
           z_length="SiBarrelLayer2_length" />
         <layer_material surface="inner" binning="binPhi,binZ" bins0="SiBarrelStave2_count" bins1="100" />

--- a/compact/tracker/silicon_disks.xml
+++ b/compact/tracker/silicon_disks.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd>
   <comment>
-    Main parameters. This is the setup from the ECCE proposal combined with the
-    June 2022 barrel setup. Here to comply with the ACTS translation onion structure we have:
+    Main parameters. June 2022 setup with symmetric disk locations.
+    Here to comply with the ACTS translation onion structure we have:
       - the first disk in the inner tracking assembly, 
       - the second silicon disk in the middle silicon tracking assembly
       - the and the following 3 disks in the outer silicon tracking assembly
@@ -74,7 +74,7 @@
           rmax="InnerTrackerEndcapPLayer1_rmax"
           length="SiTrackerEndcapLayer_thickness"
           zstart="InnerTrackerEndcapPLayer1_zmin" />
-        <layer_material surface="representing" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
         <ring
           r="InnerTrackerEndcapPMod1_rmin + InnerTrackerEndcapPMod1_y/2"
           zstart="0"
@@ -102,7 +102,7 @@
           rmax="InnerTrackerEndcapNLayer1_rmax"
           length="SiTrackerEndcapLayer_thickness"
           zstart="InnerTrackerEndcapNLayer1_zmin" />
-        <layer_material surface="representing" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
         <ring
           r="InnerTrackerEndcapNMod1_rmin + InnerTrackerEndcapNMod1_y/2"
           zstart="0"
@@ -182,6 +182,17 @@
     <constant name="TrackerEndcapNLayer3_rmin" value="TrackerEndcapNMod3_rmin - 1*um" />
     <constant name="TrackerEndcapNLayer3_rmax" value="TrackerEndcapNMod3_rmax + 1*um" />
     <constant name="TrackerEndcapNLayer3_zmin" value="TrackerEndcapNMod3_zmin - SiTrackerEndcapLayer_thickness/2" />
+    <commnet> symmetric N and P disks (5 each)</commnet>
+    <constant name="TrackerEndcapNMod4_zmin"   value="TrackerEndcapNDisk4_zmin" />
+    <constant name="TrackerEndcapNMod4_rmin"   value="TrackerEndcapNDisk4_rmin" />
+    <constant name="TrackerEndcapNMod4_rmax"   value="TrackerEndcapNDisk4_rmax" />
+    <constant name="TrackerEndcapNMod4_x1"     value="2 * TrackerEndcapNMod4_rmin * tan(SiTrackerEndcapMod_angle/2)" />
+    <constant name="TrackerEndcapNMod4_x2"     value="2 * TrackerEndcapNMod4_rmax * sin(SiTrackerEndcapMod_angle/2)" />
+    <constant name="TrackerEndcapNMod4_y"      value="TrackerEndcapNMod4_rmax * cos(SiTrackerEndcapMod_angle/2) - TrackerEndcapNMod4_rmin" />
+    <constant name="TrackerEndcapNLayer4_rmin" value="TrackerEndcapNMod4_rmin - 1*um" />
+    <constant name="TrackerEndcapNLayer4_rmax" value="TrackerEndcapNMod4_rmax + 1*um" />
+    <constant name="TrackerEndcapNLayer4_zmin" value="TrackerEndcapNMod4_zmin - SiTrackerEndcapLayer_thickness/2" />
+
   </define>
   <detectors>
     <detector
@@ -203,7 +214,7 @@
           rmax="TrackerEndcapPLayer1_rmax"
           length="SiTrackerEndcapLayer_thickness"
           zstart="TrackerEndcapPLayer1_zmin" />
-        <layer_material surface="representing" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
         <ring
           r="TrackerEndcapPMod1_rmin + TrackerEndcapPMod1_y/2"
           zstart="0"
@@ -231,7 +242,7 @@
           rmax="TrackerEndcapNLayer1_rmax"
           length="SiTrackerEndcapLayer_thickness"
           zstart="TrackerEndcapNLayer1_zmin" />
-        <layer_material surface="representing" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
         <ring
           r="TrackerEndcapNMod1_rmin + TrackerEndcapNMod1_y/2"
           zstart="0"
@@ -271,7 +282,7 @@
           rmax="TrackerEndcapPLayer2_rmax"
           length="SiTrackerEndcapLayer_thickness"
           zstart="TrackerEndcapPLayer2_zmin" />
-        <layer_material surface="representing" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
         <ring
           r="TrackerEndcapPMod2_rmin + TrackerEndcapPMod2_y/2"
           zstart="0"
@@ -285,7 +296,7 @@
           rmax="TrackerEndcapPLayer3_rmax"
           length="SiTrackerEndcapLayer_thickness"
           zstart="TrackerEndcapPLayer3_zmin" />
-        <layer_material surface="representing" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
         <ring
           r="TrackerEndcapPMod3_rmin + TrackerEndcapPMod3_y/2"
           zstart="0"
@@ -299,7 +310,7 @@
           rmax="TrackerEndcapPLayer4_rmax"
           length="SiTrackerEndcapLayer_thickness"
           zstart="TrackerEndcapPLayer4_zmin" />
-        <layer_material surface="representing" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
         <ring
           r="TrackerEndcapPMod4_rmin + TrackerEndcapPMod4_y/2"
           zstart="0"
@@ -327,13 +338,19 @@
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
         <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
       </module>
+          <module name="Module4" vis="TrackerModuleVis">
+        <trd x1="TrackerEndcapNMod4_x1/2" x2="TrackerEndcapNMod4_x2/2" z="TrackerEndcapNMod4_y/2" />
+        <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
+        <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
+        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+      </module>
       <layer id="2">
         <envelope vis="TrackerLayerVis"
           rmin="TrackerEndcapNLayer2_rmin"
           rmax="TrackerEndcapNLayer2_rmax"
           length="SiTrackerEndcapLayer_thickness"
           zstart="TrackerEndcapNLayer2_zmin" />
-        <layer_material surface="representing" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
         <ring
           r="TrackerEndcapNMod2_rmin + TrackerEndcapNMod2_y/2"
           zstart="0"
@@ -347,13 +364,27 @@
           rmax="TrackerEndcapNLayer3_rmax"
           length="SiTrackerEndcapLayer_thickness"
           zstart="TrackerEndcapNLayer3_zmin" />
-        <layer_material surface="representing" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
         <ring
           r="TrackerEndcapNMod3_rmin + TrackerEndcapNMod3_y/2"
           zstart="0"
           nmodules="SiTrackerEndcapMod_count"
           dz="SiTrackerEndcapMod_dz"
           module="Module3" />
+      </layer>
+      <layer id="4">
+        <envelope vis="TrackerLayerVis"
+          rmin="TrackerEndcapNLayer4_rmin"
+          rmax="TrackerEndcapNLayer4_rmax"
+          length="SiTrackerEndcapLayer_thickness"
+          zstart="TrackerEndcapNLayer4_zmin" />
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*SiTrackerEndcapMod_count" bins1="256"/>
+        <ring
+          r="TrackerEndcapNMod4_rmin + TrackerEndcapNMod4_y/2"
+          zstart="0"
+          nmodules="SiTrackerEndcapMod_count"
+          dz="SiTrackerEndcapMod_dz"
+          module="Module4" />
       </layer>
     </detector>
   </detectors>

--- a/compact/tracker/support_service_assembly.xml
+++ b/compact/tracker/support_service_assembly.xml
@@ -1,24 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd>
   <comment>
-    Tracker support as in the ECCE proposal.
+    <!-- Tracker support as in the ECCE proposal. -->
+    Tracker support optimized from ECCE proposal.
   </comment>
   <define>
-    <comment> Inner vertex Support </comment>
-    <constant name="VertexSupportCyl1_length"             value="2*VertexSupportCyl1_rmin/tan(TrackerPrimaryAngle)" />
+    <comment> Inner vertex Support</comment>
+    <comment> get rid of the inner vertex support barrel </comment>
+<!--     <constant name="VertexSupportCyl1_length"             value="2*VertexSupportCyl1_rmin/tan(TrackerPrimaryAngle)" />
     <constant name="VertexSupportCyl1_zmax"               value="VertexSupportCyl1_length/2." />
     <constant name="VertexSupportCyl1_thickness"          value="VertexSupportCylCF_thickness" />
-
-    <comment> Outer Vertex Support </comment>
+ -->
+    <comment> Outer Vertex Support Barrel</comment>
     <constant name="VertexSupportCyl2_length"             value="2*VertexSupportCyl2_rmin/tan(TrackerPrimaryAngle) - SiBarrel_dz" />
     <constant name="VertexSupportCyl2_zmax"               value="VertexSupportCyl2_length/2." />
     <constant name="VertexSupportCyl2_thickness"          value="VertexSupportCylCF_thickness" />
 
+    <comment> use a disk to connect vertex barrels to cone</comment>
+    <constant name="VertexSupportRingCF_thickness"         value="2.0*mm" />
+    <constant name="VertexSupportRingAl_thickness"         value="1.5*mm" />
+    <constant name="VertexSupportRing_thickness"           value="VertexSupportRingCF_thickness+VertexSupportRingAl_thickness+2*um" />
+    <constant name="VertexSupportRing_zmin"        value="VertexBarrel_length/2.+ 2*um" />
+    <constant name="VertexSupportRing_zmax"        value="VertexSupportRing_zmin + VertexSupportRing_thickness" />
+    <constant name="VertexSupportRing_rmin"        value="VertexBarrel_rmin+2*um" />
+    <constant name="VertexSupportRing_rmax"        value="VertexSupportCyl2_rmin-2*um" />
+    <constant name="VertexSupportRing_z"           value="0.5*(VertexSupportRing_zmin + VertexSupportRing_zmax)" />
 
     <comment> Inner tracker service/support cone </comment>
-    <constant name="InnerSupportCone_rmin1"               value="VertexSupportCyl1_rmin" />
+    <constant name="InnerSupportCone_rmin1"               value="VertexSupportCyl2_rmin" />
     <constant name="InnerSupportCone_rmin2"               value="TrackerSupportCyl_rmin" />
-    <constant name="InnerSupportCone_zmin"                value="VertexSupportCyl1_zmax" />
+    <constant name="InnerSupportCone_zmin"                value="VertexSupportCyl2_zmax" />
     <constant name="InnerSupportCone_zmax"                value="InnerSupportCone_rmin2/tan(TrackerPrimaryAngle)" />
     <constant name="InnerSupportCone_z"                   value="0.5*(InnerSupportCone_zmax + InnerSupportCone_zmin)" />
     <constant name="InnerSupportCone_length"              value="InnerSupportCone_zmax - InnerSupportCone_zmin" />
@@ -37,7 +48,7 @@
     <constant name="TrackerSupportCylEndcapN_length"      value="TrackerSupportCylEndcapN_zmax - TrackerSupportCyl_zmin" />
     <constant name="TrackerSupportCylCF_thickness"        value="InnerSupportConeCF_thickness" />
     <comment> Effective Aluminum for services for now </comment>
-    <constant name="TrackerSupportCylAl_thickness"        value="InnerSupportConeAl_thickness" />
+    <constant name="TrackerSupportCylAl_thickness"        value="4*mm" />
     <constant name="TrackerSupportCyl_thickness"          value="TrackerSupportCylAl_thickness + TrackerSupportCylCF_thickness" />
 
     <comment> Tracker endcap cones </comment>
@@ -91,7 +102,7 @@
       name="InnerTrackerSupport"
       id="84"
     >
-      <support type="Cylinder"
+<!--       <support type="Cylinder"
         name="VertexSupportCyl1"
         vis="TrackerSupportVis"
         rmin="VertexSupportCyl1_rmin"
@@ -99,6 +110,28 @@
         thickness="VertexSupportCyl1_thickness">
           <position x="0*cm" y="0*cm" z="0*cm" />
           <component material="CarbonFiber" thickness="VertexSupportCylCF_thickness" name="Carbon Fiber Shell" vis="TrackerSupportVis"/>
+      </support> -->
+      <comment> Forward </comment>
+      <support type="Disk"
+        name="VertexSupportRingForward"
+        vis="TrackerSupportVis"
+        rmin="VertexSupportRing_rmin"
+        rmax="VertexSupportRing_rmax"
+        thickness="VertexSupportRing_thickness">
+          <position x="0*cm" y="0*cm" z="VertexSupportRing_z" />
+          <component material="CarbonFiber" thickness="VertexSupportRingCF_thickness" name="Support" vis="TrackerSupportVis"/>
+          <component material="Aluminum" thickness="VertexSupportRingAl_thickness" name="Services" vis="TrackerServiceVis" />
+      </support>
+      <comment> Backward </comment>
+      <support type="Disk"
+        name="VertexSupportRingBackward"
+        vis="TrackerSupportVis"
+        rmin="VertexSupportRing_rmin"
+        rmax="VertexSupportRing_rmax"
+        thickness="VertexSupportRing_thickness">
+          <position x="0*cm" y="0*cm" z="-VertexSupportRing_z-VertexSupportRingAl_thickness-VertexSupportRingCF_thickness" />
+          <component material="Aluminum" thickness="VertexSupportRingAl_thickness" name="Services" vis="TrackerServiceVis" />
+          <component material="CarbonFiber" thickness="VertexSupportRingCF_thickness" name="Support" vis="TrackerSupportVis"/>
       </support>
       <support type="Cylinder"
         name="VertexSupportCyl2"

--- a/compact/tracker/support_service_assembly.xml
+++ b/compact/tracker/support_service_assembly.xml
@@ -5,10 +5,11 @@
   </comment>
   <define>
     <comment> Inner vertex Support</comment>
-    <comment> get rid of the inner vertex support barrel </comment>
-    <comment> Outer Vertex Support Barrel</comment>
-    <constant name="VertexSupportCyl2_length"             value="2*VertexSupportCyl2_rmin/tan(TrackerPrimaryAngle) - SiBarrel_dz" />
-    <constant name="VertexSupportCyl2_zmax"               value="VertexSupportCyl2_length/2." />
+
+    <comment> Vertex Support Barrel to the 2nd vertex layer</comment>
+    <constant name="VertexSupportCyl2_zmax"               value="VertexBarrel_length/2.0" />
+    <constant name="VertexSupportCyl2_rmin"               value="VertexSupportCyl2_zmax*tan(TrackerPrimaryAngle)"/>
+    <constant name="VertexSupportCyl2_length"             value="VertexSupportCyl2_zmax*2.0" />
 
     <comment> use a disk to connect vertex barrels to cone</comment>
     <constant name="VertexSupportRingCF_thickness"         value="2.0*mm" />
@@ -20,17 +21,18 @@
     <constant name="VertexSupportRing_rmax"        value="VertexSupportCyl2_rmin-2*um" />
     <constant name="VertexSupportRing_z"           value="0.5*(VertexSupportRing_zmin + VertexSupportRing_zmax)" />
 
+
     <comment> Inner tracker service/support cone </comment>
-    <constant name="InnerSupportCone_rmin1"               value="VertexSupportCyl2_rmin" />
-    <constant name="InnerSupportCone_rmin2"               value="TrackerSupportCyl_rmin" />
-    <constant name="InnerSupportCone_zmin"                value="VertexSupportCyl2_zmax" />
-    <constant name="InnerSupportCone_zmax"                value="InnerSupportCone_rmin2/tan(TrackerPrimaryAngle)" />
-    <constant name="InnerSupportCone_z"                   value="0.5*(InnerSupportCone_zmax + InnerSupportCone_zmin)" />
-    <constant name="InnerSupportCone_length"              value="InnerSupportCone_zmax - InnerSupportCone_zmin" />
     <constant name="InnerSupportConeCF_thickness"         value="2.0*mm" />
     <comment> Effective Aluminum for services for now </comment>
     <constant name="InnerSupportConeAl_thickness"         value="2.5*mm" />
     <constant name="InnerSupportCone_thickness"           value="InnerSupportConeAl_thickness + InnerSupportConeCF_thickness" />
+    <constant name="InnerSupportCone_rmin2"               value="TrackerSupportCyl_rmin-InnerSupportCone_thickness" />
+    <constant name="InnerSupportCone_zmin"                value="VertexSupportCyl2_zmax+2*um" />
+    <constant name="InnerSupportCone_zmax"                value="InnerSupportCone_rmin2/tan(TrackerPrimaryAngle)" />
+    <constant name="InnerSupportCone_z"                   value="0.5*(InnerSupportCone_zmax + InnerSupportCone_zmin)" />
+    <constant name="InnerSupportCone_length"              value="InnerSupportCone_zmax - InnerSupportCone_zmin" />
+    <constant name="InnerSupportCone_rmin1"               value="InnerSupportCone_zmin/tan(TrackerPrimaryAngle)" />
 
     <comment> Tracker disk support cylinder </comment>
     <constant name="TrackerSupportCyl_zmin"               value="InnerSupportCone_zmax" />
@@ -114,7 +116,7 @@
         rmin="VertexSupportRing_rmin"
         rmax="VertexSupportRing_rmax"
         thickness="VertexSupportRing_thickness">
-          <position x="0*cm" y="0*cm" z="-VertexSupportRing_z-VertexSupportRingAl_thickness-VertexSupportRingCF_thickness" />
+          <position x="0*cm" y="0*cm" z="-VertexSupportRing_z" />
           <component material="Aluminum" thickness="VertexSupportRingAl_thickness" name="Services" vis="TrackerServiceVis" />
           <component material="CarbonFiber" thickness="VertexSupportRingCF_thickness" name="Support" vis="TrackerSupportVis"/>
       </support>

--- a/compact/tracker/support_service_assembly.xml
+++ b/compact/tracker/support_service_assembly.xml
@@ -14,7 +14,7 @@
     <comment> Outer Vertex Support Barrel</comment>
     <constant name="VertexSupportCyl2_length"             value="2*VertexSupportCyl2_rmin/tan(TrackerPrimaryAngle) - SiBarrel_dz" />
     <constant name="VertexSupportCyl2_zmax"               value="VertexSupportCyl2_length/2." />
-    <constant name="VertexSupportCyl2_thickness"          value="VertexSupportCylCF_thickness" />
+    <!-- <constant name="VertexSupportCyl2_thickness"          value="VertexSupportCylCF_thickness" /> -->
 
     <comment> use a disk to connect vertex barrels to cone</comment>
     <constant name="VertexSupportRingCF_thickness"         value="2.0*mm" />

--- a/compact/tracker/support_service_assembly.xml
+++ b/compact/tracker/support_service_assembly.xml
@@ -1,20 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd>
   <comment>
-    <!-- Tracker support as in the ECCE proposal. -->
     Tracker support optimized from ECCE proposal.
   </comment>
   <define>
     <comment> Inner vertex Support</comment>
     <comment> get rid of the inner vertex support barrel </comment>
-<!--     <constant name="VertexSupportCyl1_length"             value="2*VertexSupportCyl1_rmin/tan(TrackerPrimaryAngle)" />
-    <constant name="VertexSupportCyl1_zmax"               value="VertexSupportCyl1_length/2." />
-    <constant name="VertexSupportCyl1_thickness"          value="VertexSupportCylCF_thickness" />
- -->
     <comment> Outer Vertex Support Barrel</comment>
     <constant name="VertexSupportCyl2_length"             value="2*VertexSupportCyl2_rmin/tan(TrackerPrimaryAngle) - SiBarrel_dz" />
     <constant name="VertexSupportCyl2_zmax"               value="VertexSupportCyl2_length/2." />
-    <!-- <constant name="VertexSupportCyl2_thickness"          value="VertexSupportCylCF_thickness" /> -->
 
     <comment> use a disk to connect vertex barrels to cone</comment>
     <constant name="VertexSupportRingCF_thickness"         value="2.0*mm" />
@@ -102,15 +96,6 @@
       name="InnerTrackerSupport"
       id="84"
     >
-<!--       <support type="Cylinder"
-        name="VertexSupportCyl1"
-        vis="TrackerSupportVis"
-        rmin="VertexSupportCyl1_rmin"
-        length="VertexSupportCyl1_length"
-        thickness="VertexSupportCyl1_thickness">
-          <position x="0*cm" y="0*cm" z="0*cm" />
-          <component material="CarbonFiber" thickness="VertexSupportCylCF_thickness" name="Carbon Fiber Shell" vis="TrackerSupportVis"/>
-      </support> -->
       <comment> Forward </comment>
       <support type="Disk"
         name="VertexSupportRingForward"

--- a/compact/tracker/vertex_barrel.xml
+++ b/compact/tracker/vertex_barrel.xml
@@ -13,7 +13,7 @@
 
     <constant name="VertexBarrelMod1_rmin"              value="VertexBarrelMod_rmin"/>
     <constant name="VertexBarrelMod2_rmin"              value="VertexBarrelMod_rmin + 1.2*cm"/>
-    <constant name="VertexBarrelMod3_rmin"              value="12.3*cm"/>
+    <constant name="VertexBarrelMod3_rmin"              value="12.0*cm"/>
 
     <comment> ensure we are within the vertex envelope with some margin. </comment>
     <constant name="VertexCheck"                        value="sqrt(VertexBarrel_rmax - VertexBarrelMod3_rmin - .1*cm)"/>
@@ -98,7 +98,7 @@
           inner_r="VertexBarrelLayer1_rmin"
           outer_r="VertexBarrelLayer1_rmax"
           z_length="VertexBarrelLayer_length" />
-        <layer_material surface="outer" binning="binPhi,binZ" bins0="VertexBarrelStave_count" bins1="100" />
+        <layer_material surface="inner" binning="binPhi,binZ" bins0="VertexBarrelStave_count" bins1="100" />
         <comment>
           phi0     : Starting phi of first module.
           phi_tilt : Phi tilt of a module.
@@ -117,7 +117,7 @@
           inner_r="VertexBarrelLayer2_rmin"
           outer_r="VertexBarrelLayer2_rmax"
           z_length="VertexBarrelLayer_length" />
-        <layer_material surface="outer" binning="binPhi,binZ" bins0="VertexBarrelStave_count" bins1="100" />
+        <layer_material surface="inner" binning="binPhi,binZ" bins0="VertexBarrelStave_count" bins1="100" />
         <rphi_layout phi_tilt="0.0*degree" nphi="VertexBarrelStave_count" phi0="0.0" rc="VertexBarrelMod2_rmin" dr="0.0 * mm"/>
         <z_layout dr="0.0 * mm" z0="0.0 * mm" nz="1"/>
       </layer>
@@ -126,7 +126,7 @@
           inner_r="VertexBarrelLayer3_rmin"
           outer_r="VertexBarrelLayer3_rmax"
           z_length="VertexBarrelLayer_length" />
-        <layer_material surface="outer" binning="binPhi,binZ" bins0="VertexBarrelStave_count" bins1="100" />
+        <layer_material surface="inner" binning="binPhi,binZ" bins0="VertexBarrelStave_count" bins1="100" />
         <rphi_layout phi_tilt="0.0*degree" nphi="VertexBarrelStave_count" phi0="0.0" rc="VertexBarrelMod3_rmin" dr="0.0 * mm"/>
         <z_layout dr="0.0 * mm" z0="0.0 * mm" nz="1"/>
       </layer>


### PR DESCRIPTION
Vertex barrel: removed support cylinder outside the 2nd vertex layer, and connect vertex layers to cone with disks.
Silicon disks: adjusted z positions, and make the backward design symmetric to forward region. 5 disks on each side.