### PR TITLE
ci: use recursive xmllint

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -21,7 +21,7 @@ jobs:
     - run: |
         sudo apt-get update
         sudo apt-get install -y libxml2-utils
-        xmllint compact/*.xml > /dev/null
+        find compact/ -name "*.xml" -exec xmllint {} \; > /dev/null
 
   build-test:
     runs-on: ubuntu-latest
@@ -73,7 +73,7 @@ jobs:
     - run: |
         sudo apt-get update
         sudo apt-get install -y libxml2-utils
-        xmllint install/share/ecce/*.xml > /dev/null
+        find install/share -name "*.xml" -exec xmllint {} \; > /dev/null
 
   convert-to-gdml:
     runs-on: ubuntu-latest

--- a/compact/unused/tracking_config_mgpds.xml
+++ b/compact/unused/tracking_config_mgpds.xml
@@ -11,7 +11,7 @@
     This configuration needs attention!
   </documentation>
 
-  <include ref="rwell_tracker_barrel.xml">
+  <include ref="rwell_tracker_barrel.xml"/>
   <!--include ref="compact/ce_GEM.xml"/-->
   <!--include ref="compact/mm_tracker_barrel.xml"/-->
   <!--include ref="compact/cb_VTX_Barrel.xml"/-->


### PR DESCRIPTION
There are some ill-formed xml files that are not caught in the `compact/` tree. That is because we are currently only checking `compact/*.xml` and files are at a deeper level.