### PR TITLE
feat(dRICH): remove IRT `auxfile` and add constants to facilitate geometry access from reconstruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,11 +60,6 @@ else()
 endif()
 find_package(fmt REQUIRED)
 
-if(IRT_AUXFILE)
-  add_compile_definitions(IRT_AUXFILE)
-  find_package(IRT REQUIRED)
-endif()
-
 #-----------------------------------------------------------------------------------
 set(a_lib_name ${PROJECT_NAME})
 
@@ -78,9 +73,6 @@ dd4hep_add_plugin(${a_lib_name}
 target_link_libraries(${a_lib_name}
   PUBLIC ${DD4hep_required_libraries} fmt::fmt
   )
-if(IRT_AUXFILE)
-  target_link_libraries(${a_lib_name} PUBLIC IRT)
-endif()
 if(EPIC_ECCE_LEGACY_COMPAT)
   target_compile_definitions(${a_lib_name} PUBLIC EPIC_ECCE_LEGACY_COMPAT)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ PROJECT(epic
   )
 
 option(EPIC_ECCE_LEGACY_COMPAT "Preserve some compatibility with ECCE" OFF)
-option(IRT_AUXFILE "Build auxiliary config file for dRICH IRT" OFF)
 
 # C++ standard
 set(CMAKE_CXX_STANDARD 17)

--- a/compact/drich.xml
+++ b/compact/drich.xml
@@ -35,13 +35,10 @@
                            0 = off
 - `DRICH_debug_mirror`:    1 = draw full mirror shape for single sector; 0 = off
 - `DRICH_debug_sensors`:   1 = draw full sensor sphere for a single sector; 0 = off
-- `DRICH_create_irt_file`: 1 = create an auxiliary IRT config ROOT file; 0 = off
-                               - the file name is set by detector attribute `irt_filename` below
 </comment>
 <constant name="DRICH_debug_optics"    value="0"/>
 <constant name="DRICH_debug_mirror"    value="0"/>
 <constant name="DRICH_debug_sensors"   value="0"/>
-<constant name="DRICH_create_irt_file" value="0"/>
 </define>
 
 
@@ -61,7 +58,6 @@
   material="Aluminum"
   vis_vessel="DRICH_vessel_vis"
   vis_gas="DRICH_gas_vis"
-  irt_filename="irt-drich.root"
   >
 
 

--- a/compact/drich.xml
+++ b/compact/drich.xml
@@ -17,8 +17,10 @@
 <constant name="DRICH_rmax1"              value="DRICH_rmax0 + DRICH_SnoutLength * DRICH_SnoutSlope"/>
 <!-- tank geometry: cylinder, holding the majority of detector components -->
 <constant name="DRICH_rmax2"              value="ForwardPIDRegion_rmax"/>  <!-- cylinder radius -->
-<!-- aerogel geometry -->
+<!-- aerogel+filter geometry -->
 <constant name="DRICH_aerogel_thickness"  value="4.0*cm"/>  <!-- aerogel thickness -->
+<constant name="DRICH_filter_thickness"   value="0.3*mm"/>  <!-- filter thickness -->
+<constant name="DRICH_aerogel_filter_gap" value="0.01*mm"/> <!-- air gap between aerogel and filter FIXME: currently a gas gap -->
 <!-- sensor geometry; model = S13361-3050NE-08 SiPM -->
 <constant name="DRICH_sensor_size"           value="25.8*mm"/> <!-- full length of the sensor side FIXME: resin base should be this size -->
 <constant name="DRICH_pixel_gap"             value="0.2*mm"/> <!-- size of gaps between adjacent pixels AND gaps between edge pixels and sensor side -->
@@ -98,7 +100,7 @@
 #### Radiator
 - radiator is defined in a wedge of azimuthal space, composed of aerogel and a
   filter; the filter is applied to the back of the aerogel, so that it separates
-  the aerogel and gas radiators
+  the aerogel and gas radiators; an airgap is defined between the aerogel and filter
 - dimensions:
   - `frontplane`: front of the aerogel, w.r.t. front plane of the vessel envelope
   - `rmin` and `rmax`: inner and outer radius (at the front plane; radial bounds are conical)
@@ -116,10 +118,15 @@
     vis="DRICH_aerogel_vis"
     thickness="DRICH_aerogel_thickness"
     />
+  <airgap
+    material="AirOptical"
+    vis="DRICH_gas_vis"
+    thickness="DRICH_aerogel_filter_gap"
+    />
   <filter
     material="Acrylic_DRICH"
     vis="DRICH_filter_vis"
-    thickness="0.3*mm"
+    thickness="DRICH_filter_thickness"
     />
 </radiator>
 

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -142,7 +142,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
    */
   desc.add(Constant("DRICH_RECON_nSectors", std::to_string(nSectors)));
   desc.add(Constant("DRICH_RECON_zmin", std::to_string(vesselZmin)));
-  desc.add(Constant("DRICH_RECON_gasvolMaterial", gasvolMat.ptr()->GetName()));
+  desc.add(Constant("DRICH_RECON_gasvolMaterial", gasvolMat.ptr()->GetName(), "string"));
 
   // BUILD VESSEL ====================================================================
   /* - `vessel`: aluminum enclosure, the mother volume of the dRICh
@@ -282,10 +282,10 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   double filterZpos  = vesselPos.z() + filterPV.position().z();
   desc.add(Constant("DRICH_RECON_aerogelZpos",      std::to_string(aerogelZpos)));
   desc.add(Constant("DRICH_RECON_aerogelThickness", std::to_string(aerogelThickness)));
-  desc.add(Constant("DRICH_RECON_aerogelMaterial",  aerogelMat.ptr()->GetName()));
+  desc.add(Constant("DRICH_RECON_aerogelMaterial",  aerogelMat.ptr()->GetName(), "string"));
   desc.add(Constant("DRICH_RECON_filterZpos",       std::to_string(filterZpos)));
   desc.add(Constant("DRICH_RECON_filterThickness",  std::to_string(filterThickness)));
-  desc.add(Constant("DRICH_RECON_filterMaterial",   filterMat.ptr()->GetName()));
+  desc.add(Constant("DRICH_RECON_filterMaterial",   filterMat.ptr()->GetName(), "string"));
 
   // SECTOR LOOP //////////////////////////////////////////////////////////////////////
 

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -412,7 +412,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
     // mirror volume, attributes, and placement
     Volume mirrorVol(detName + "_mirror_" + secName, mirrorSolid2, mirrorMat);
     mirrorVol.setVisAttributes(mirrorVis);
-    auto mirrorSectorPlacement = sectorRotation * Translation3D(0, 0, 0); // rotate about beam axis to sector
+    auto mirrorSectorPlacement = Transform3D(sectorRotation); // rotate about beam axis to sector
     auto mirrorPV              = gasvolVol.placeVolume(mirrorVol, mirrorSectorPlacement);
 
     // properties

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -375,6 +375,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
     FocusMirror(zF, xF, B);
 
     // re-define mirror attributes to be w.r.t vessel front plane
+    // - `(zM,xM)` is the mirror center w.r.t. to the IP
     double mirrorCenterZ = zM - vesselZmin;
     double mirrorCenterX = xM;
     double mirrorRadius  = rM;
@@ -394,9 +395,6 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
     // phi limits are increased to fill gaps (overlaps are cut away later)
     Sphere mirrorSolid1(mirrorRadius, mirrorRadius + mirrorThickness, mirrorTheta1, mirrorTheta2, -40 * degree,
                         40 * degree);
-
-    // print mirror attributes for sector 0
-    // if(isec==0) printf("dRICH mirror (zM, xM, rM) = (%f, %f, %f)\n",zM,xM,rM); // coords w.r.t. IP
 
     // mirror placement transformation (note: transformations are in reverse order)
     auto mirrorPos = Position(mirrorCenterX, 0., mirrorCenterZ) + originFront;

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -414,9 +414,9 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
     auto mirrorPV              = gasvolVol.placeVolume(mirrorVol, mirrorSectorPlacement);
 
     // properties
-    DetElement mirrorDE(det, Form("mirror_de%d", isec), isec);
+    DetElement mirrorDE(det, "mirror_de_" + secName, isec);
     mirrorDE.setPlacement(mirrorPV);
-    SkinSurface mirrorSkin(desc, mirrorDE, Form("mirror_optical_surface%d", isec), mirrorSurf, mirrorVol);
+    SkinSurface mirrorSkin(desc, mirrorDE, "mirror_optical_surface_" + secName, mirrorSurf, mirrorVol);
     mirrorSkin.isValid();
 
     // reconstruction constants (w.r.t. IP)
@@ -533,10 +533,11 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
           // properties
           sensorPV.addPhysVolID("sector", isec).addPhysVolID("module", imod); // NOTE: must be consistent with `sensorIDfields`
           auto imodsec = encodeSensorID(sensorPV.volIDs());
-          DetElement sensorDE(det, Form("sensor_de%d_%d", isec, imod), imodsec);
+          std::string modsecName = secName + "_" + std::to_string(imod);
+          DetElement sensorDE(det, "sensor_de_" + modsecName, imodsec);
           sensorDE.setPlacement(sensorPV);
           if (!debugOptics || debugOpticsMode == 3) {
-            SkinSurface sensorSkin(desc, sensorDE, Form("sensor_optical_surface%d", isec), sensorSurf, sensorVol);
+            SkinSurface sensorSkin(desc, sensorDE, "sensor_optical_surface_" + modsecName, sensorSurf, sensorVol);
             sensorSkin.isValid();
           };
 

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -306,9 +306,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
 
   // initialize sensor centroids (used for mirror parameterization below); this is
   // the average (x,y,z) of the placed sensors, w.r.t. originFront
-  // - deprecated, but is still here in case we want it later; the IRT auxfile
-  //   requires sensors to be built after the mirrors, but if we want to use
-  //   `sensorCentroid*`, the sensor positions must be known before mirror focusing
+  // - deprecated, but is still here in case we want it later
   // double sensorCentroidX = 0;
   // double sensorCentroidZ = 0;
   // int    sensorCount     = 0;

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -456,8 +456,10 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
     desc.add(Constant("DRICH_RECON_sensorSphCenterX_"+secName, std::to_string(sensorSphFinalCenter.x())));
     desc.add(Constant("DRICH_RECON_sensorSphCenterY_"+secName, std::to_string(sensorSphFinalCenter.y())));
     desc.add(Constant("DRICH_RECON_sensorSphCenterZ_"+secName, std::to_string(sensorSphFinalCenter.z())));
-    if(isec==0)
+    if(isec==0) {
       desc.add(Constant("DRICH_RECON_sensorSphRadius", std::to_string(sensorSphRadius)));
+      desc.add(Constant("DRICH_RECON_sensorThickness", std::to_string(sensorThickness)));
+    }
 
     // SENSOR MODULE LOOP ------------------------
     /* ALGORITHM: generate sphere of positions
@@ -534,9 +536,10 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
               Translation3D(sensorSphPos.x(), sensorSphPos.y(), sensorSphPos.z()) * // move sphere to reference position
               RotationX(phiGen) *                                                   // rotate about `zGen`
               RotationZ(thetaGen) *                                                 // rotate about `yGen`
-              Translation3D(sensorSphRadius, 0., 0.) * // push radially to spherical surface
-              RotationY(M_PI / 2) *                    // rotate sensor to be compatible with generator coords
-              RotationZ(-M_PI / 2);                    // correction for readout segmentation mapping
+              Translation3D(-sensorThickness / 2.0, 0., 0.) * // pull back so sensor active surface is at spherical surface
+              Translation3D(sensorSphRadius, 0., 0.) *        // push radially to spherical surface
+              RotationY(M_PI / 2) *                           // rotate sensor to be compatible with generator coords
+              RotationZ(-M_PI / 2);                           // correction for readout segmentation mapping
           auto sensorPV = gasvolVol.placeVolume(sensorVol, sensorPlacement);
 
           // generate LUT for module number -> sensor position, for readout mapping tests


### PR DESCRIPTION
### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: removal of `libIRT` dependence

#### Changes:
- removes optional dependence on `IRT` (auxfile creation is [moved to `drich_dev`](https://github.com/eic/drich-dev/pull/32) until integration of `IRT` with `EICrecon` or `algorithms`)
- adds `Constant`s with the unique name prefix `DRICH_RECON_`, which will be used in the reconstruction, since some geometry parameters are otherwise difficult to access from the `Detector` handle (e.g. the mirror centers)
- some `Constant`s are redundant, but we want it to be clear that any `DRICH_RECON_` `Constant` is required for the reconstruction algorithm; thus any changes to these constants' values may need to be accounted for on the reconstructed side (hopefully only major changes)

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added (in `drich-dev`)
- [x] Documentation has been added / updated (in `drich-dev`)
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Only in the IRT reconstruction, which is undergoing refactoring. The IRT geometry creation code is moved to https://github.com/eic/drich-dev/pull/32 and eventually the creation of IRT objects will be integrated into the reconstruction algorithm initialization itself, removing the need for an auxfile altogether (but we can still optionally make auxfiles, as needed).

### Does this PR change default behavior?
See above