### PR TITLE
fix: non-zero return for plugin success as of dd4hep-1.22

### DIFF
--- a/src/FileLoader.cpp
+++ b/src/FileLoader.cpp
@@ -54,16 +54,14 @@ long load_file(Detector& /* desc */, int argc, char** argv)
   // if file or url is empty, do nothing
   if (file.empty()) {
     printout(WARNING, "FileLoader", "no file specified");
-    return 0;
   }
   if (url.empty()) {
     printout(WARNING, "FileLoader", "no url specified");
-    return 0;
   }
 
   EnsureFileFromURLExists(url, file, cache, cmd);
 
-  return 0;
+  return 1;
 }
 
 #ifdef EPIC_ECCE_LEGACY_COMPAT


### PR DESCRIPTION
As of DD4hep-1.22, https://github.com/AIDASoft/DD4hep/pull/936, any plugin returning a zero return value is assumed to have failed. This is somewhat counter-intuitive for plugins that simply return a long status code, but it is inteded to allow recursive calls and is in line with what other plugins already do, e.g. `return field` or `return sdet`.