### PR TITLE
fix(dRICH): remove `RINDEX` tables from dRICH sensor optical surfaces

### DIFF
--- a/compact/optical_materials.xml
+++ b/compact/optical_materials.xml
@@ -861,32 +861,12 @@
         4*eV  1
         7*eV  1
         "/>
-      <property name="IMAGINARYRINDEX" coldim="2" values="
-        1*eV  1.69
-        4*eV  1.69
-        7*eV  1.69
-        "/>
-      <property name="REALRINDEX" coldim="2" values="
-        1*eV  1.92
-        4*eV  1.92
-        7*eV  1.92
-        "/>
     </opticalsurface>
     <opticalsurface name="SensorSurface_PFRICH" model="glisur" finish="polished" type="dielectric_dielectric">
       <property name="EFFICIENCY" coldim="2" values="
         1*eV  1
         4*eV  1
         7*eV  1
-        "/>
-      <property name="IMAGINARYRINDEX" coldim="2" values="
-        1*eV  1.69
-        4*eV  1.69
-        7*eV  1.69
-        "/>
-      <property name="REALRINDEX" coldim="2" values="
-        1*eV  1.92
-        4*eV  1.92
-        7*eV  1.92
         "/>
     </opticalsurface>
     <!-- END dRICh surface definitions -->

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -40,7 +40,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   xml::Component        dims    = detElem.dimensions();
   OpticalSurfaceManager surfMgr = desc.surfaceManager();
   DetElement            det(detName, detID);
-  sens.setType("opticaltracker");
+  sens.setType("tracker");
 
   // attributes, from compact file =============================================
   // - vessel

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -40,7 +40,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   xml::Component        dims    = detElem.dimensions();
   OpticalSurfaceManager surfMgr = desc.surfaceManager();
   DetElement            det(detName, detID);
-  sens.setType("tracker");
+  sens.setType("opticaltracker");
 
   // attributes, from compact file =============================================
   // - vessel


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The dRICH sensitive detector now uses `Geant4OpticalTrackingAction` (see https://github.com/AIDASoft/DD4hep/pull/967 and https://eicweb.phy.anl.gov/EIC/NPDet/-/merge_requests/270/). This PR removes `RINDEX` tables from the RICH sensor surfaces, as it's not clear where they came from and they weren't needed in the ATHENA proposal (which effectively also used `Geant4OpticalTrackerAction`).

@alexander-kiselev @chchatte92 @ajitkmaurya 
With these changes, we go from about 60 raw dRICH hits to almost 300, for a 40 GeV pion.

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Not beyond the dRICH