### PR TITLE
DRAFT Planar micro-RWell MPGDs for DIRC

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -146,15 +146,19 @@ The unused IDs below are saved for future use.
     <documentation>
     #### (90-99) Barrel PID IDs
 
-    - DIRC subsystem       ID: 90
-    - Barrel TRD subsystem ID: 91
-    - Barrel TOF subsystem ID: 92
-    - Unused IDs: 93-99
+    - DIRC subsystem         ID: 90
+    - Barrel TRD subsystem   ID: 91
+    - Barrel TOF subsystem   ID: 92
+    - TOF sub assembly       ID: 93
+    - MPGD for use with DIRC ID: 94
+    - Unused IDs: 96-99
     </documentation>
-    <constant name="BarrelDIRC_ID" value="90"/>
-    <constant name="BarrelTRD_ID"  value="91"/>
-    <constant name="BarrelTOF_ID"  value="92"/>
-    <constant name="TOFSubAssembly_ID" value="93"/>
+    <constant name="BarrelDIRC_ID"         value="90"/>
+    <constant name="BarrelTRD_ID"          value="91"/>
+    <constant name="BarrelTOF_ID"          value="92"/>
+    <constant name="TOFSubAssembly_ID"     value="93"/>
+    <constant name="BarrelmRwellDIRC_0_ID" value="94"/>
+    <constant name="BarrelmRwellDIRC_1_ID" value="95"/>
 
     <documentation>
       #### (100-109) Electromagnetic Calorimeter

--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -284,12 +284,6 @@
     <composite n="1" ref="W"/>
     <composite n="4" ref="O"/>
   </material>
-  <material name="Ar80CO220">
-    <D type="density" value="1.823" unit="mg/cm3"/>
-    <composit n="0.783"  ref="Argon"/>
-    <composit n="0.073"  ref="C"/>
-    <composit n="0.144"  ref="O"/>
-    </material>  
   <material name="Ar10CO2">
     <D type="density" value="1.802" unit="mg / cm3"/>
     <composite n="0.891" ref="Argon"/>

--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -284,6 +284,12 @@
     <composite n="1" ref="W"/>
     <composite n="4" ref="O"/>
   </material>
+  <material name="Ar80CO220">
+    <D type="density" value="1.823" unit="mg/cm3"/>
+    <composit n="0.783"  ref="Argon"/>
+    <composit n="0.073"  ref="C"/>
+    <composit n="0.144"  ref="O"/>
+    </material>  
   <material name="Ar10CO2">
     <D type="density" value="1.802" unit="mg / cm3"/>
     <composite n="0.891" ref="Argon"/>

--- a/compact/tracker.xml
+++ b/compact/tracker.xml
@@ -137,10 +137,10 @@
     </plugin>
   </plugins>
 
-  <include ref="tracker/vertex_barrel.xml"/>
-  <include ref="tracker/silicon_barrel.xml"/>
-  <include ref="tracker/mpgd_barrel.xml"/>
-  <include ref="tracker/silicon_disks.xml"/>
-  <include ref="tracker/support_service_assembly.xml"/>
+	    <include ref="tracker/vertex_barrel.xml"/>  
+	    <include ref="tracker/silicon_barrel.xml"/>
+	    <include ref="tracker/mpgd_barrel.xml"/> 
+	    <include ref="tracker/silicon_disks.xml"/>
+	    <include ref="tracker/support_service_assembly.xml"/>
 
 </lccdd>

--- a/compact/tracker.xml
+++ b/compact/tracker.xml
@@ -137,10 +137,10 @@
     </plugin>
   </plugins>
 
-  <include ref="tracker/vertex_barrel.xml"/>
-  <include ref="tracker/silicon_barrel.xml"/>
+	    <!--<include ref="tracker/vertex_barrel.xml"/>-->
+	    <!--<include ref="tracker/silicon_barrel.xml"/>-->
   <include ref="tracker/mpgd_barrel.xml"/>
-  <include ref="tracker/silicon_disks.xml"/>
-  <include ref="tracker/support_service_assembly.xml"/>
+	    <!--  <include ref="tracker/silicon_disks.xml"/>-->
+	    <!--  <include ref="tracker/support_service_assembly.xml"/>-->
 
 </lccdd>

--- a/compact/tracker.xml
+++ b/compact/tracker.xml
@@ -137,10 +137,10 @@
     </plugin>
   </plugins>
 
-	    <!--<include ref="tracker/vertex_barrel.xml"/>-->
-	    <!--<include ref="tracker/silicon_barrel.xml"/>-->
+  <include ref="tracker/vertex_barrel.xml"/>
+  <include ref="tracker/silicon_barrel.xml"/>
   <include ref="tracker/mpgd_barrel.xml"/>
-	    <!--  <include ref="tracker/silicon_disks.xml"/>-->
-	    <!--  <include ref="tracker/support_service_assembly.xml"/>-->
+  <include ref="tracker/silicon_disks.xml"/>
+  <include ref="tracker/support_service_assembly.xml"/>
 
 </lccdd>

--- a/compact/tracker.xml
+++ b/compact/tracker.xml
@@ -136,11 +136,13 @@
       <arg value="url:https://eicweb.phy.anl.gov/EIC/detectors/athena/uploads/4a4e7c8eb6089b634d762d112c89bd5d/material-maps.cbor"/>
     </plugin>
   </plugins>
-
+  <!--
 	    <include ref="tracker/vertex_barrel.xml"/>  
 	    <include ref="tracker/silicon_barrel.xml"/>
 	    <include ref="tracker/mpgd_barrel.xml"/> 
 	    <include ref="tracker/silicon_disks.xml"/>
 	    <include ref="tracker/support_service_assembly.xml"/>
-
+  -->
+            <include ref="tracker/mrwell_dirc.xml"/>
+	    <!--<include ref="fake_dirc.xml"/>-->
 </lccdd>

--- a/compact/tracker/mpgd_barrel.xml
+++ b/compact/tracker/mpgd_barrel.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd>
+<lccdd>	
+<info name="mpgd_barrel.xml"
+      title="Micro Pattern Gas Detectors"
+      author="mposik1983"
+      url="https://github.com/mposik1983"
+      status="development"
+      version="1.0"
+><comment/>
+</info>	
+
   <define>
     <comment>
       Main parameters - Geo based on the original ECCE design, while for now

--- a/compact/tracker/mpgd_barrel.xml
+++ b/compact/tracker/mpgd_barrel.xml
@@ -3,7 +3,8 @@
   <info name="mpgd_barrel.xml"
         title="Micropattern gas detector barrel layers"
         author="mposik1983"
-        url="https://github.com/mposik1983"
+	url="https://github.com/mposik1983"
+        status="development"
   />
   <define>
     <comment>

--- a/compact/tracker/mpgd_barrel.xml
+++ b/compact/tracker/mpgd_barrel.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd>
+  <info name="mpgd_barrel.xml"
+        title="Micropattern gas detector barrel layers"
+        author="mposik1983"
+        url="https://github.com/mposik1983"
+  />
   <define>
     <comment>
       Main parameters - Geo based on the original ECCE design, while for now

--- a/compact/tracker/mpgd_barrel.xml
+++ b/compact/tracker/mpgd_barrel.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd>
-  <info name="mpgd_barrel.xml"
-        title="Micropattern gas detector barrel layers"
-        author="mposik1983"
-	url="https://github.com/mposik1983"
-	version="1.0"
-        status="development"
-  />
   <define>
     <comment>
       Main parameters - Geo based on the original ECCE design, while for now
@@ -56,6 +49,12 @@
     <constant name="MMDriftCuElectrode_thickness"           value="5*um"/>
     <constant name="MMDriftKapton_thickness"                value="250*um"/>
     <constant name="MMDriftCuGround_thickness"              value="0.41*um"/>
+    
+    <comment> FIXME: No support material is here, so fudge factor used to bring material budget to ~0.5% for barrel </comment>
+    <constant name="MMFudgeInnerMPGDBarrel_thickness"                      value="570*um"/>
+
+    <comment> FIXME: No support material is here, so fudge factor used to bring material budget to ~1% for barrel </comment>
+    <constant name="MMFudgeOuterMPGDBarrel_thickness"                      value="2.50*mm"/>
 
     <comment>
       Extra parameters to approximate a cylinder as a set of skinny staves
@@ -84,7 +83,8 @@
         <module_component name="DriftKapton" thickness="MMDriftKapton_thickness" material="Kapton" width="InnerMPGDBarrelStave_width" length="InnerMPGDBarrelMod_length"/>
         <module_component name="DriftCuElectrode" thickness="MMDriftCuElectrode_thickness" material="Copper" width="InnerMPGDBarrelStave_width" length="InnerMPGDBarrelMod_length"/>
         <module_component name="GasGap" thickness="MMGasGap_thickness" material="Ar90IsoButane" sensitive="True" width="InnerMPGDBarrelStave_width" length="InnerMPGDBarrelMod_length"/>
-        <module_component name="Mesh" thickness="MMMesh_thickness" material="MMGAS_InoxForMesh" width="InnerMPGDBarrelStave_width" length="InnerMPGDBarrelMod_length"/>
+	<module_component name="Mesh" thickness="MMMesh_thickness" material="MMGAS_InoxForMesh" width="InnerMPGDBarrelStave_width" length="InnerMPGDBarrelMod_length"/>
+        <module_component name="Fudge" thickness="MMFudgeInnerMPGDBarrel_thickness" material="Kapton" width="InnerMPGDBarrelStave_width" length="InnerMPGDBarrelMod_length"/>
         <module_component name="Gas" thickness="MMGas_thickness" material="Ar90IsoButane" width="InnerMPGDBarrelStave_width" length="InnerMPGDBarrelMod_length"/>
         <module_component name="ResistiveStrips" thickness="MMResistiveStrip_thickness" material="MMGAS_ResistivePaste" width="InnerMPGDBarrelStave_width" length="InnerMPGDBarrelMod_length"/>
         <module_component name="KaptonStrips" thickness="MMKaptonStrip_thickness" material="Kapton" width="InnerMPGDBarrelStave_width" length="InnerMPGDBarrelMod_length"/>
@@ -120,6 +120,7 @@
         <module_component name="DriftCuElectrode" thickness="MMDriftCuElectrode_thickness" material="Copper" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
         <module_component name="GasGap" thickness="MMGasGap_thickness" material="Ar90IsoButane" sensitive="True" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
         <module_component name="Mesh" thickness="MMMesh_thickness" material="MMGAS_InoxForMesh" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
+        <module_component name="Fudge" thickness="MMFudgeOuterMPGDBarrel_thickness" material="Kapton" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
         <module_component name="Gas" thickness="MMGas_thickness" material="Ar90IsoButane" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
         <module_component name="ResistiveStrips" thickness="MMResistiveStrip_thickness" material="MMGAS_ResistivePaste" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
         <module_component name="KaptonStrips" thickness="MMKaptonStrip_thickness" material="Kapton" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>

--- a/compact/tracker/mpgd_barrel.xml
+++ b/compact/tracker/mpgd_barrel.xml
@@ -4,6 +4,7 @@
         title="Micropattern gas detector barrel layers"
         author="mposik1983"
 	url="https://github.com/mposik1983"
+	version="1.0"
         status="development"
   />
   <define>

--- a/compact/tracker/mpgd_barrel.xml
+++ b/compact/tracker/mpgd_barrel.xml
@@ -54,7 +54,7 @@
     <constant name="MMFudgeInnerMPGDBarrel_thickness"                      value="570*um"/>
 
     <comment> FIXME: No support material is here, so fudge factor used to bring material budget to ~1% for barrel </comment>
-    <constant name="MMFudgeOuterMPGDBarrel_thickness"                      value="2.50*mm"/>
+    <constant name="MMFudgeOuterMPGDBarrel_thickness"                      value="115*um"/>
 
     <comment>
       Extra parameters to approximate a cylinder as a set of skinny staves
@@ -120,7 +120,7 @@
         <module_component name="DriftCuElectrode" thickness="MMDriftCuElectrode_thickness" material="Copper" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
         <module_component name="GasGap" thickness="MMGasGap_thickness" material="Ar90IsoButane" sensitive="True" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
         <module_component name="Mesh" thickness="MMMesh_thickness" material="MMGAS_InoxForMesh" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-        <module_component name="Fudge" thickness="MMFudgeOuterMPGDBarrel_thickness" material="Kapton" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
+	<module_component name="Fudge" thickness="MMFudgeOuterMPGDBarrel_thickness" material="Copper" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
         <module_component name="Gas" thickness="MMGas_thickness" material="Ar90IsoButane" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
         <module_component name="ResistiveStrips" thickness="MMResistiveStrip_thickness" material="MMGAS_ResistivePaste" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
         <module_component name="KaptonStrips" thickness="MMKaptonStrip_thickness" material="Kapton" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>

--- a/compact/tracker/mrwell_dirc.xml
+++ b/compact/tracker/mrwell_dirc.xml
@@ -9,34 +9,25 @@
 </info>
 
   <define>
-    
+	  <!--
     <comment> Needed constants if DIRC is not used </comment>
     <constant name="DIRCFrame_rmax"                   value="75.5*cm"/>
-    <constant name="DIRCFrame_thickness"               value="4.0*cm"/>
+    <constant name="DIRCFrame_thickness"              value="4.0*cm"/>
+    <constant name="DIRC_rmax"                        value="78.5*cm"/>
     <constant name="DIRCModule_rmin"                  value="72.5*cm"/>
     <constant name="DIRCBar_length"                   value="507.0*cm"/>
     <constant name="DIRCModule_count"                 value="12"/>
     <constant name="DIRCModule_width"                 value="38.317*cm"/>
     <comment> End DIRC constants </comment>
-    
-
+	  -->
     <constant name="mRwellDIRCFrame_width"            value="20*mm"/>
     <constant name="mRwellDIRCFrame_thickness"        value="7*mm"/>
     <constant name="mRwellDIRCModule_allowed_space"   value="2*cm"/>
 
-    <constant name="mRwellDIRC_rmin"                  value="DIRCModule_rmin + DIRCFrame_thickness/2"/>-->
-	  <!--<constant name="mRwellDIRC_rmax"                  value="mRwellDIRC_rmin + DIRCBar_thickness/2" /> works -->
-    <constant name="mRwellDIRC_rmax"                  value="DIRCFrame_rmax" />
-	  <!--<constant name="mRwellDIRC_length"                value="DIRCBar_length/2 + mRwellDIRCFrame_width" />-->
-    <constant name="mRwellDIRC_length"                value="DIRCBar_length/2" />
-    <constant name="mRwellDIRCModule_count"           value="DIRCModule_count" />
-
-    <constant name="mRwellDIRCModule_rmin"            value="mRwellDIRC_rmin + mRwellDIRCFrame_thickness"/>
-    <constant name="mRwellDIRCModule_length"          value="mRwellDIRC_length + 2*mRwellDIRCFrame_width" />
-
-    <constant name="mRwellDIRCModule_halfangle"       value="180*degree/mRwellDIRCModule_count" />
-    <constant name="mRwellDIRCModule_width"           value="DIRCModule_width - 2*mRwellDIRCFrame_width"/>
-	  <!--<constant name="mRwellDIRCModule_width"           value="2*(DIRC_rmin) * tan(mRwellDIRCModule_halfangle)"/>-->
+    <constant name="mRwellDIRC_rmin"                  value="74.5*cm"/>
+    <!--<constant name="mRwellDIRC_rmax"                  value="mRwellDIRC_rmin + 3*mRwellDIRCModule_allowed_space" />-->
+    <constant name="mRwellDIRC_rmax"                  value="sqrt((mRwellDIRC_rmin + 2.0*cm)^2 + 0.25*(2.0*cm)^2) + 2.0*cm" />
+    <constant name="mRwellDIRC_length"                value="0.5*367.5*cm" />
 
     <constant name="mRwellDIRCWindow_thickness"	          value="50*um"/>
     <constant name="mRwellDIRCWindowGap_thickness"        value="2*mm"/>
@@ -55,6 +46,13 @@
 	                                                         mRwellDIRCFoil_thickness + mRwellDIRCReadOut_thickness + 
 	                                                         mRwellDIRCPCB_thickness + mRwellDIRCFrame_thickness" />
  
+    <constant name="mRwellDIRCModule_count"           value="12" />
+    <constant name="mRwellDIRCModule_rmin"            value="mRwellDIRC_rmin"/>
+    <constant name="mRwellDIRCModule_rmax"            value="sqrt((mRwellDIRC_rmin + mRwellDIRCModule_thickness)^2 + 0.25*(mRwellDIRCModule_thickness)^2 )"/>
+    <constant name="mRwellDIRCModule_length"          value="367.5/2.0*cm" />
+	    <!--<constant name="mRwellDIRCModule_halfangle"       value="180*degree/mRwellDIRCModule_count" />-->
+	    <!--<constant name="mRwellDIRCModule_width"           value="2*mRwellDIRC_rmin * tan(mRwellDIRCModule_halfangle)"/>-->
+    <constant name="mRwellDIRCModule_width"           value="36.2*cm"/>
   </define>
 
 
@@ -70,34 +68,36 @@
   <display>
   </display>
 
-  <detectors>
+	  <detectors>
     <detector id="BarrelmRwellDIRC_0_ID" name="mRwellDIRC_0" type="epic_mRwellDIRC" readout="mRwellDIRCBarHits" vis="TrackerVis">
-	    <dimensions rmin="mRwellDIRC_rmin" rmax="mRwellDIRC_rmax" length="mRwellDIRCModule_length/2" />
-	    <position x="0" y="0" z="mRwellDIRCModule_length/2 + DIRC_offset" />
+	    <dimensions rmin="mRwellDIRC_rmin" rmax="mRwellDIRC_rmax" length="mRwellDIRC_length" />
+	    <position x="0" y="0" z="0" />
       <comment> mRwell DIRC modules </comment>
     
       <module name="mRwellDIRCModule" vis="TrackerVis">
         <module_component name="DriftGap"
-               material="Ar80CO220"
+               material="Ar"
                sensitive="true"
                width="mRwellDIRCModule_width"
-               thickness="mRwellDIRCDriftGap_thickness"
+	       thickness="mRwellDIRCDriftGap_thickness"
                vis="TrackerMPGDGasVis"
-               length="mRwellDIRCModule_length" />
+	       length="mRwellDIRCModule_length"/>
+	
         <module_component name="WindowGasGap"
-               material="Ar80CO220"
+               material="Ar"
                sensitive="false"
                width="mRwellDIRCModule_width"
 	       thickness="mRwellDIRCWindowGap_thickness"
                vis="TrackerMPGDGasVis"
 		length="mRwellDIRCModule_length" />
+	
         <module_component name="Window"
                material="Kapton"
                sensitive="false"
                width="mRwellDIRCModule_width"
 	       thickness="mRwellDIRCWindow_thickness"
                vis="TrackerVis"
-               length="mRwellDIRCModule_length" />
+		length="mRwellDIRCModule_length" />
         <module_component name="Cathode_Kapton"
                material="Kapton"
                sensitive="false"
@@ -146,7 +146,8 @@
                width="mRwellDIRCModule_width"
 	       thickness="mRwellDIRCReadOutKapton_thickness" 
                vis="TrackerVis"
-               length="mRwellDIRCModule_length" />
+		length="mRwellDIRCModule_length" />
+	
         <module_component name="PCB"
                material="Fr4"
                sensitive="false"
@@ -154,51 +155,52 @@
 	       thickness="mRwellDIRCPCB_thickness" 
                vis="TrackerVis"
 	       length="mRwellDIRCModule_length" />
-
-        <comment> Frame width gets subtracted from the gas module volumes
+	
+	<comment> Frame width gets subtracted from the gas module volumes
 		see src/BarrelBarwithFrame.cpp 
         </comment>
+	
         <frame material="Fr4"
                width="mRwellDIRCFrame_width"
                vis="TrackerSupportVis"
-		thickness="mRwellDIRCFrame_thickness"/>
+	       thickness="mRwellDIRCFrame_thickness"/>
+	
+</module>
+<comment> mRwell DIRC layers </comment>
 
-      </module>
-      <comment> mRwell DIRC layers </comment>
-      <layer module="mRwellDIRCModule" id="0" vis="TrackerVis">
+      <layer module="mRwellDIRCModule" id="0" vis="TrackerSupportVis">
         <barrel_envelope
           inner_r="mRwellDIRC_rmin"
           outer_r="mRwellDIRC_rmax"
-          z_length="mRwellDIRCModule_length" />
-        <rphi_layout
+          z_length="mRwellDIRC_length " />
+	<rphi_layout
           phi_tilt="0"
-          nphi="mRwellDIRCModule_count"
+          nphi="12"
           phi0="0"
-          rc="0.5*(mRwellDIRC_rmin + mRwellDIRC_rmax)"
+	  rc="0.5*(mRwellDIRCModule_rmin + mRwellDIRCModule_rmax + mRwellDIRCFrame_width/2.0)"
           dr="0" />
         <z_layout
-          dr="0.0*mm"
-          z0="mRwellDIRCFrame_width"
-          nz="1" />
-      </layer>
+          dr="0*mm"
+          z0="0*mm"
+	  nz="1" />
+	</layer>
     </detector>
-
-
         <detector id="BarrelmRwellDIRC_1_ID" name="mRwellDIRC_1" type="epic_mRwellDIRC" readout="mRwellDIRCBarHits" vis="TrackerVis">
-	    <dimensions rmin="mRwellDIRC_rmin" rmax="mRwellDIRC_rmax" length="mRwellDIRCModule_length/2" />
-	    <position x="0" y="0" z="-mRwellDIRCModule_length/2  + DIRC_offset" />
+		<dimensions rmin="mRwellDIRC_rmin" rmax="mRwellDIRC_rmax" length="mRwellDIRC_length" />
+		<!--<position x="0" y="0" z="-mRwellDIRCModule_length/2  + DIRC_offset" />-->
+		<position x="0" y="0" z="-mRwellDIRC_length" />
       <comment> mRwell DIRC modules </comment>
 
       <module name="mRwellDIRCModule" vis="TrackerVis">
         <module_component name="DriftGap"
-               material="Ar80CO220"
+               material="Ar"
                sensitive="true"
                width="mRwellDIRCModule_width"
                thickness="mRwellDIRCDriftGap_thickness"
                vis="TrackerMPGDGasVis"
                length="mRwellDIRCModule_length" />
         <module_component name="WindowGasGap"
-               material="Ar80CO220"
+               material="Ar"
                sensitive="false"
                width="mRwellDIRCModule_width"
 	       thickness="mRwellDIRCWindowGap_thickness"
@@ -283,19 +285,20 @@
         <barrel_envelope
           inner_r="mRwellDIRC_rmin"
           outer_r="mRwellDIRC_rmax"
-          z_length="mRwellDIRCModule_length" />
+          z_length="mRwellDIRC_length " />
         <rphi_layout
           phi_tilt="0"
           nphi="mRwellDIRCModule_count"
           phi0="0"
-          rc="0.5*(mRwellDIRC_rmin + mRwellDIRC_rmax) + mRwellDIRCModule_thickness/2"
+	  rc="0.5*(mRwellDIRCModule_rmin + mRwellDIRCModule_rmax + mRwellDIRCFrame_width/2.0)"
           dr="0" />
-        <z_layout
-          dr="0.0*mm"
-          z0="-mRwellDIRCFrame_width"
+	<z_layout
+          dr="0*mm"
+          z0="0*mm"
           nz="1" />
       </layer>
-   </detector>
+	    </detector>
+  
   </detectors>
 
   <readouts>

--- a/compact/tracker/mrwell_dirc.xml
+++ b/compact/tracker/mrwell_dirc.xml
@@ -1,0 +1,313 @@
+<lccdd>
+<info name="mrwell_dirc.xml"
+      title="Micro Resistive Well Gas Detector for aiding DIRC PID"
+      author="mposik1983"
+      url="https://github.com/mposik1983"
+      status="development"
+      version="1.0"
+><comment/>
+</info>
+
+  <define>
+    
+    <comment> Needed constants if DIRC is not used </comment>
+    <constant name="DIRCFrame_rmax"                   value="75.5*cm"/>
+    <constant name="DIRCFrame_thickness"               value="4.0*cm"/>
+    <constant name="DIRCModule_rmin"                  value="72.5*cm"/>
+    <constant name="DIRCBar_length"                   value="507.0*cm"/>
+    <constant name="DIRCModule_count"                 value="12"/>
+    <constant name="DIRCModule_width"                 value="38.317*cm"/>
+    <comment> End DIRC constants </comment>
+    
+
+    <constant name="mRwellDIRCFrame_width"            value="20*mm"/>
+    <constant name="mRwellDIRCFrame_thickness"        value="7*mm"/>
+    <constant name="mRwellDIRCModule_allowed_space"   value="2*cm"/>
+
+    <constant name="mRwellDIRC_rmin"                  value="DIRCModule_rmin + DIRCFrame_thickness/2"/>-->
+	  <!--<constant name="mRwellDIRC_rmax"                  value="mRwellDIRC_rmin + DIRCBar_thickness/2" /> works -->
+    <constant name="mRwellDIRC_rmax"                  value="DIRCFrame_rmax" />
+	  <!--<constant name="mRwellDIRC_length"                value="DIRCBar_length/2 + mRwellDIRCFrame_width" />-->
+    <constant name="mRwellDIRC_length"                value="DIRCBar_length/2" />
+    <constant name="mRwellDIRCModule_count"           value="DIRCModule_count" />
+
+    <constant name="mRwellDIRCModule_rmin"            value="mRwellDIRC_rmin + mRwellDIRCFrame_thickness"/>
+    <constant name="mRwellDIRCModule_length"          value="mRwellDIRC_length + 2*mRwellDIRCFrame_width" />
+
+    <constant name="mRwellDIRCModule_halfangle"       value="180*degree/mRwellDIRCModule_count" />
+    <constant name="mRwellDIRCModule_width"           value="DIRCModule_width - 2*mRwellDIRCFrame_width"/>
+	  <!--<constant name="mRwellDIRCModule_width"           value="2*(DIRC_rmin) * tan(mRwellDIRCModule_halfangle)"/>-->
+
+    <constant name="mRwellDIRCWindow_thickness"	          value="50*um"/>
+    <constant name="mRwellDIRCWindowGap_thickness"        value="2*mm"/>
+    <constant name="mRwellDIRCDriftGap_thickness"         value="3*mm"/>
+    <constant name="mRwellDIRCFoilCu_thickness"	          value="5*um"/>
+    <constant name="mRwellDIRCReadOutElectrode_thickness" value="10*um"/>
+    <constant name="mRwellDIRCFoilKapton_thickness"       value="50*um"/>
+    <constant name="mRwellDIRCReadOutNomex_thickness"     value="50*um"/>
+    <constant name="mRwellDIRCReadOutKapton_thickness"    value="50*um"/>
+    <constant name="mRwellDIRCPCB_thickness"              value="3*mm"/>
+
+    <constant name="mRwellDIRCCathode_thickness"          value="mRwellDIRCFoilKapton_thickness + mRwellDIRCFoilCu_thickness"/>
+    <constant name="mRwellDIRCFoil_thickness"             value="mRwellDIRCFoilKapton_thickness + mRwellDIRCFoilCu_thickness"/>
+    <constant name="mRwellDIRCReadOut_thickness"          value="mRwellDIRCReadOutNomex_thickness + mRwellDIRCReadOutElectrode_thickness + mRwellDIRCReadOutKapton_thickness"/> 
+    <constant name="mRwellDIRCModule_thickness"           value="mRwellDIRCWindow_thickness + mRwellDIRCCathode_thickness + 
+	                                                         mRwellDIRCFoil_thickness + mRwellDIRCReadOut_thickness + 
+	                                                         mRwellDIRCPCB_thickness + mRwellDIRCFrame_thickness" />
+ 
+  </define>
+
+
+  <materials>
+  </materials>
+
+  <limits>
+  </limits>
+
+  <regions>
+  </regions>
+
+  <display>
+  </display>
+
+  <detectors>
+    <detector id="BarrelmRwellDIRC_0_ID" name="mRwellDIRC_0" type="epic_mRwellDIRC" readout="mRwellDIRCBarHits" vis="TrackerVis">
+	    <dimensions rmin="mRwellDIRC_rmin" rmax="mRwellDIRC_rmax" length="mRwellDIRCModule_length/2" />
+	    <position x="0" y="0" z="mRwellDIRCModule_length/2 + DIRC_offset" />
+      <comment> mRwell DIRC modules </comment>
+    
+      <module name="mRwellDIRCModule" vis="TrackerVis">
+        <module_component name="DriftGap"
+               material="Ar80CO220"
+               sensitive="true"
+               width="mRwellDIRCModule_width"
+               thickness="mRwellDIRCDriftGap_thickness"
+               vis="TrackerMPGDGasVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="WindowGasGap"
+               material="Ar80CO220"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCWindowGap_thickness"
+               vis="TrackerMPGDGasVis"
+		length="mRwellDIRCModule_length" />
+        <module_component name="Window"
+               material="Kapton"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCWindow_thickness"
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="Cathode_Kapton"
+               material="Kapton"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCFoilKapton_thickness"
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="Cathode_Cu"
+               material="Copper"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCFoilCu_thickness"
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="RWELL_Cu"
+               material="Copper"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCFoilCu_thickness"
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="RWELL_Kapton"
+               material="Kapton"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCFoilKapton_thickness"
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="Nomex"
+               material="Nomex"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCReadOutNomex_thickness"
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="ReadOutElectrodes"
+               material="Copper"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCReadOutElectrode_thickness" 
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="ReadOutKapton"
+               material="Kapton"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCReadOutKapton_thickness" 
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="PCB"
+               material="Fr4"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCPCB_thickness" 
+               vis="TrackerVis"
+	       length="mRwellDIRCModule_length" />
+
+        <comment> Frame width gets subtracted from the gas module volumes
+		see src/BarrelBarwithFrame.cpp 
+        </comment>
+        <frame material="Fr4"
+               width="mRwellDIRCFrame_width"
+               vis="TrackerSupportVis"
+		thickness="mRwellDIRCFrame_thickness"/>
+
+      </module>
+      <comment> mRwell DIRC layers </comment>
+      <layer module="mRwellDIRCModule" id="0" vis="TrackerVis">
+        <barrel_envelope
+          inner_r="mRwellDIRC_rmin"
+          outer_r="mRwellDIRC_rmax"
+          z_length="mRwellDIRCModule_length" />
+        <rphi_layout
+          phi_tilt="0"
+          nphi="mRwellDIRCModule_count"
+          phi0="0"
+          rc="0.5*(mRwellDIRC_rmin + mRwellDIRC_rmax)"
+          dr="0" />
+        <z_layout
+          dr="0.0*mm"
+          z0="mRwellDIRCFrame_width"
+          nz="1" />
+      </layer>
+    </detector>
+
+
+        <detector id="BarrelmRwellDIRC_1_ID" name="mRwellDIRC_1" type="epic_mRwellDIRC" readout="mRwellDIRCBarHits" vis="TrackerVis">
+	    <dimensions rmin="mRwellDIRC_rmin" rmax="mRwellDIRC_rmax" length="mRwellDIRCModule_length/2" />
+	    <position x="0" y="0" z="-mRwellDIRCModule_length/2  + DIRC_offset" />
+      <comment> mRwell DIRC modules </comment>
+
+      <module name="mRwellDIRCModule" vis="TrackerVis">
+        <module_component name="DriftGap"
+               material="Ar80CO220"
+               sensitive="true"
+               width="mRwellDIRCModule_width"
+               thickness="mRwellDIRCDriftGap_thickness"
+               vis="TrackerMPGDGasVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="WindowGasGap"
+               material="Ar80CO220"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCWindowGap_thickness"
+               vis="TrackerMPGDGasVis"
+		length="mRwellDIRCModule_length" />
+        <module_component name="Window"
+               material="Kapton"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCWindow_thickness"
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="Cathode_Kapton"
+               material="Kapton"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCFoilKapton_thickness"
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="Cathode_Cu"
+               material="Copper"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCFoilCu_thickness"
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="RWELL_Cu"
+               material="Copper"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCFoilCu_thickness"
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="RWELL_Kapton"
+               material="Kapton"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCFoilKapton_thickness"
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="Nomex"
+               material="Nomex"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCReadOutNomex_thickness"
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="ReadOutElectrodes"
+               material="Copper"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCReadOutElectrode_thickness" 
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="ReadOutKapton"
+               material="Kapton"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCReadOutKapton_thickness" 
+               vis="TrackerVis"
+               length="mRwellDIRCModule_length" />
+        <module_component name="PCB"
+               material="Fr4"
+               sensitive="false"
+               width="mRwellDIRCModule_width"
+	       thickness="mRwellDIRCPCB_thickness" 
+               vis="TrackerVis"
+	       length="mRwellDIRCModule_length" />
+
+        <comment> Frame width gets subtracted from the gas module volumes
+		see src/BarrelBarwithFrame.cpp 
+        </comment>
+        <frame material="Fr4"
+               width="mRwellDIRCFrame_width"
+               vis="TrackerSupportVis"
+		thickness="mRwellDIRCFrame_thickness"/>
+
+      </module>
+
+      <comment> mRwell DIRC layers </comment>
+      <layer module="mRwellDIRCModule" id="1" vis="TrackerVis">
+        <barrel_envelope
+          inner_r="mRwellDIRC_rmin"
+          outer_r="mRwellDIRC_rmax"
+          z_length="mRwellDIRCModule_length" />
+        <rphi_layout
+          phi_tilt="0"
+          nphi="mRwellDIRCModule_count"
+          phi0="0"
+          rc="0.5*(mRwellDIRC_rmin + mRwellDIRC_rmax) + mRwellDIRCModule_thickness/2"
+          dr="0" />
+        <z_layout
+          dr="0.0*mm"
+          z0="-mRwellDIRCFrame_width"
+          nz="1" />
+      </layer>
+   </detector>
+  </detectors>
+
+  <readouts>
+    <readout name="mRwellDIRCBarHits">
+      <segmentation type="CartesianGridXY" grid_size_x="1.0*mm" grid_size_y="1.0*mm" />
+      <id>system:8,layer:4,module:8,section:4,x:32:-16,y:-16</id>
+    </readout>
+  </readouts>
+
+  <plugins>
+  </plugins>
+
+  <fields>
+  </fields>
+</lccdd>

--- a/src/BarrelBarDetectorWithFrame.cpp
+++ b/src/BarrelBarDetectorWithFrame.cpp
@@ -1,0 +1,288 @@
+/** \addtogroup PID
+ * \brief Type: **Barrel bar detector (rectangular geom.) with frames surrounding the perimeter.
+ * \author S. Joosten
+ *
+ * \ingroup PID 
+ * \ingroup Tracking
+ *
+ *
+ * \code
+ * \endcode
+ *
+ * @{
+*/
+  
+#include "DD4hep/DetFactoryHelper.h"
+#include "DD4hep/Printout.h"
+#include "DD4hep/Shapes.h"
+#include "DDRec/DetectorData.h"
+#include "DDRec/Surface.h"
+#include "XML/Layering.h"
+#include <array>
+
+using namespace std;
+using namespace dd4hep;
+
+/** Barrel Bar detector with optional frame
+ *
+ * - Optional "frame" tag within the module element (frame eats part of the module width and length
+ *   and surrounds the rectangular perimeter) 
+ * - Detector is setup as a "tracker" so we can use the hits
+ *
+ */
+static Ref_t create_BarrelDetectorWithFrame(Detector& description, xml_h e, SensitiveDetector sens)
+{
+  typedef vector<PlacedVolume>            Placements;
+  xml_det_t                               x_det    = e;
+  Material                                air      = description.air();
+  int                                     det_id   = x_det.id();
+  string                                  det_name = x_det.nameStr();
+  DetElement                              sdet(det_name, det_id);
+  map<string, Volume>                     volumes;
+  map<string, Placements>                 sensitives;
+  map<string, std::vector<rec::VolPlane>> volplane_surfaces;
+  PlacedVolume                            pv;
+  dd4hep::xml::Dimension                  dimensions(x_det.dimensions());
+  xml_dim_t                               dirc_pos = x_det.position();
+
+  map<string, std::array<double, 2>> module_thicknesses;
+
+  Tube   topVolumeShape(dimensions.rmin(), dimensions.rmax(), dimensions.length() * 0.5);
+  Volume assembly(det_name, topVolumeShape, air);
+
+  sens.setType("tracker");
+
+  // loop over the modules
+  for (xml_coll_t mi(x_det, _U(module)); mi; ++mi) {
+    xml_comp_t x_mod = mi;
+    string     m_nam = x_mod.nameStr();
+
+    if (volumes.find(m_nam) != volumes.end()) {
+      printout(ERROR, "BarrelDetectorWithFrame",
+               string((string("Module with named ") + m_nam + string(" already exists."))).c_str());
+      throw runtime_error("Logics error in building modules.");
+    }
+
+    int    ncomponents     = 0;
+    double total_thickness = 0;
+
+    // Compute module total thickness from components
+    xml_coll_t ci(x_mod, _U(module_component));
+    for (ci.reset(), total_thickness = 0.0; ci; ++ci) {
+      total_thickness += xml_comp_t(ci).thickness();
+    }
+    // the module assembly volume
+    Assembly m_vol(m_nam);
+    volumes[m_nam] = m_vol;
+    m_vol.setVisAttributes(description, x_mod.visStr());
+
+    // Optional module frame.
+    // frame is 4  bars around the perimeter of the rectangular module. The frame will eat the
+    // overlapping module area
+    //
+    //  ___
+    // |___| <-- example module cross section (x-y plane), frame is flush with the
+    //           bottom of the module and protrudes on the top if needed
+    
+    // Get frame width, as it impacts the main module for being built. We
+    // construct the actual frame structure later (once we know the module width)
+    double frame_width = 0;
+    if (x_mod.hasChild(_U(frame))) {
+      xml_comp_t m_frame = x_mod.child(_U(frame));
+      frame_width        = m_frame.width();
+    }
+
+    double thickness_so_far    = 0.0;
+    double thickness_sum       = -total_thickness / 2.0;
+    double max_component_width = 0;
+    double max_component_length = 0;
+
+    for (xml_coll_t mci(x_mod, _U(module_component)); mci; ++mci, ++ncomponents) {
+      xml_comp_t x_comp = mci;
+      string     c_nam  = _toString(ncomponents, "component%d");
+      string  comp_name = x_comp.nameStr();
+
+      double box_width = x_comp.width();
+      double box_length = x_comp.length();
+
+      Box c_box;
+      //Since MPGD frames are layed over the MPGD foils, the foil material is pressent under the frame as well. 
+      //The gas volumes are not present under the frames, so our frames must eat only the gas module areas
+      //
+      //  ------------------- MPGD foil 
+      //  --               -- Frame
+      //  --  gas volume   -- Frame
+      //  --               -- Frame
+      //  ------------------- MPGD foil
+
+      //Look for gas modules to subtract frame thickness from
+      //FIXME: these module names are hard coded for now. Should find 
+      //a way to set a arribut via the moduel tag to flag what components 
+      //need to have frame thickness subtracted.
+      if( (comp_name == "DriftGap" || comp_name == "WindowGasGap") ){
+	box_width = x_comp.width() - 2.0 * frame_width;
+	box_length = x_comp.length() - 2.0 * frame_width;
+	max_component_width = box_width;
+	max_component_length = box_length;
+        c_box = {box_width / 2, box_length / 2, x_comp.thickness() / 2};
+      }else{
+        c_box = {x_comp.width() / 2, x_comp.length() / 2, x_comp.thickness() / 2};
+      }
+      Volume c_vol{c_nam, c_box, description.material(x_comp.materialStr())};
+      pv = m_vol.placeVolume(c_vol, Position(0, 0, thickness_sum + x_comp.thickness() / 2.0));
+
+      c_vol.setRegion(description, x_comp.regionStr());
+      c_vol.setLimitSet(description, x_comp.limitsStr());
+      c_vol.setVisAttributes(description, x_comp.visStr());
+      if (x_comp.isSensitive()) {
+        c_vol.setSensitiveDetector(sens);
+        sensitives[m_nam].push_back(pv);
+        module_thicknesses[m_nam] = {thickness_so_far + x_comp.thickness() / 2.0,
+                                     total_thickness - thickness_so_far - x_comp.thickness() / 2.0};
+        // -------- create a measurement plane for the tracking surface attched to the sensitive volume -----
+        rec::Vector3D u(0., 1., 0.);
+        rec::Vector3D v(0., 0., 1.);
+        rec::Vector3D n(1., 0., 0.);
+
+        // compute the inner and outer thicknesses that need to be assigned to the tracking surface
+        // depending on wether the support is above or below the sensor
+        double inner_thickness = module_thicknesses[m_nam][0];
+        double outer_thickness = module_thicknesses[m_nam][1];
+
+        rec::SurfaceType type(rec::SurfaceType::Sensitive);
+
+        rec::VolPlane surf(c_vol, type, inner_thickness, outer_thickness, u, v, n); //,o ) ;
+        volplane_surfaces[m_nam].push_back(surf);
+      }
+      thickness_sum += x_comp.thickness();
+      thickness_so_far += x_comp.thickness();
+    }
+    // Now add-on the frame
+    if (x_mod.hasChild(_U(frame))) {
+      xml_comp_t m_frame         = x_mod.child(_U(frame));
+      double     frame_thickness = getAttrOrDefault<double>(m_frame, _U(thickness), total_thickness);
+
+        Box lframe_box{m_frame.width() / 2., (max_component_length + 2*m_frame.width()) / 2., frame_thickness / 2.};
+        Box rframe_box{m_frame.width() / 2., (max_component_length + 2*m_frame.width()) / 2., frame_thickness / 2.};
+        Box tframe_box{max_component_width / 2., m_frame.width() / 2., frame_thickness / 2.};
+        Box bframe_box{max_component_width / 2., m_frame.width() / 2., frame_thickness / 2.};
+      
+      // Keep track of frame with so we can adjust the module bars appropriately
+
+        Volume lframe_vol{"left_frame", lframe_box, description.material(m_frame.materialStr())};
+        Volume rframe_vol{"right_frame", rframe_box, description.material(m_frame.materialStr())};
+        Volume tframe_vol{"top_frame",    tframe_box, description.material(m_frame.materialStr())};
+        Volume bframe_vol{"bottom_frame", bframe_box, description.material(m_frame.materialStr())};
+
+        lframe_vol.setVisAttributes(description, m_frame.visStr());
+        rframe_vol.setVisAttributes(description, m_frame.visStr());
+        tframe_vol.setVisAttributes(description, m_frame.visStr());
+        bframe_vol.setVisAttributes(description, m_frame.visStr());
+
+
+        m_vol.placeVolume(lframe_vol, Position(frame_width / 2. + max_component_width / 2, 0.,
+                                               frame_thickness / 2. - total_thickness / 2.0));
+        m_vol.placeVolume(rframe_vol, Position(-frame_width / 2. - max_component_width / 2, 0.,
+                                                frame_thickness / 2. - total_thickness / 2.0));
+        m_vol.placeVolume(tframe_vol, Position(0,frame_width / 2. + max_component_length/2,
+                                               frame_thickness / 2. - total_thickness / 2.0));
+        m_vol.placeVolume(bframe_vol, Position(0,-frame_width / 2. - max_component_length/2,
+                                               frame_thickness / 2. - total_thickness / 2.0));
+					       
+    }
+  }
+
+  // now build the layers
+  for (xml_coll_t li(x_det, _U(layer)); li; ++li) {
+    xml_comp_t x_layer  = li;
+    xml_comp_t x_barrel = x_layer.child(_U(barrel_envelope));
+    xml_comp_t x_layout = x_layer.child(_U(rphi_layout));
+    xml_comp_t z_layout = x_layer.child(_U(z_layout)); // Get the <z_layout> element.
+    int        lay_id   = x_layer.id();
+    string     m_nam    = x_layer.moduleStr();
+    string     lay_nam  = _toString(x_layer.id(), "layer%d");
+    Tube       lay_tub(x_barrel.inner_r(), x_barrel.outer_r(), x_barrel.z_length() / 2.0);
+    Volume     lay_vol(lay_nam, lay_tub, air); // Create the layer envelope volume.
+    lay_vol.setVisAttributes(description, x_layer.visStr());
+
+    double phi0     = x_layout.phi0();     // Starting phi of first module.
+    double phi_tilt = x_layout.phi_tilt(); // Phi tilt of a module.
+    double rc       = x_layout.rc();       // Radius of the module center.
+    int    nphi     = x_layout.nphi();     // Number of modules in phi.
+    double rphi_dr  = x_layout.dr();       // The delta radius of every other module.
+    double phi_incr = (M_PI * 2) / nphi;   // Phi increment for one module.
+    double phic     = phi0;                // Phi of the module center.
+    double z0       = z_layout.z0();       // Z position of first module in phi.
+    double nz       = z_layout.nz();       // Number of modules to place in z.
+    double z_dr     = z_layout.dr();       // Radial displacement parameter, of every other module.
+
+    Volume      module_env = volumes[m_nam];
+    DetElement  lay_elt(sdet, _toString(x_layer.id(), "layer%d"), lay_id);
+    Placements& sensVols = sensitives[m_nam];
+
+    // Z increment for module placement along Z axis.
+    // Adjust for z0 at center of module rather than
+    // the end of cylindrical envelope.
+    double z_incr = nz > 1 ? (2.0 * z0) / (nz - 1) : 0.0;
+    // Starting z for module placement along Z axis.
+    double module_z = -z0;
+    int    module   = 1;
+
+    // Loop over the number of modules in phi.
+    for (int ii = 0; ii < nphi; ii++) {
+      double dx = z_dr * std::cos(phic + phi_tilt); // Delta x of module position.
+      double dy = z_dr * std::sin(phic + phi_tilt); // Delta y of module position.
+      double x  = rc * std::cos(phic);              // Basic x module position.
+      double y  = rc * std::sin(phic);              // Basic y module position.
+
+      // Loop over the number of modules in z.
+      for (int j = 0; j < nz; j++) {
+        string     module_name = _toString(module, "module%d");
+        DetElement mod_elt(lay_elt, module_name, module);
+
+        Transform3D tr(RotationZYX(0, ((M_PI / 2) - phic - phi_tilt), -M_PI / 2), Position(x, y, module_z));
+
+        pv = lay_vol.placeVolume(module_env, tr);
+        pv.addPhysVolID("module", module);
+        pv.addPhysVolID("section", j);
+        mod_elt.setPlacement(pv);
+        for (size_t ic = 0; ic < sensVols.size(); ++ic) {
+          PlacedVolume sens_pv = sensVols[ic];
+          DetElement   comp_de(mod_elt, std::string("de_") + sens_pv.volume().name(), module);
+          comp_de.setPlacement(sens_pv);
+          rec::volSurfaceList(comp_de)->push_back(volplane_surfaces[m_nam][ic]);
+        }
+
+        /// Increase counters etc.
+        module++;
+        // Adjust the x and y coordinates of the module.
+        x += dx;
+        y += dy;
+        // Flip sign of x and y adjustments.
+        dx *= -1;
+        dy *= -1;
+        // Add z increment to get next z placement pos.
+        module_z += z_incr;
+      }
+      phic += phi_incr; // Increment the phi placement of module.
+      rc += rphi_dr;    // Increment the center radius according to dr parameter.
+      rphi_dr *= -1;    // Flip sign of dr parameter.
+      module_z = -z0;   // Reset the Z placement parameter for module.
+    }
+    // Create the PhysicalVolume for the layer.
+    pv = assembly.placeVolume(lay_vol); // Place layer in mother
+    pv.addPhysVolID("layer", lay_id);   // Set the layer ID.
+    lay_elt.setAttributes(description, lay_vol, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
+    lay_elt.setPlacement(pv);
+  }
+  sdet.setAttributes(description, assembly, x_det.regionStr(), x_det.limitsStr(), x_det.visStr());
+  assembly.setVisAttributes(description.invisible());
+  pv = description.pickMotherVolume(sdet).placeVolume(assembly, Position(0, 0, dirc_pos.z()));
+  pv.addPhysVolID("system", det_id); // Set the subdetector system ID.
+  sdet.setPlacement(pv);
+  return sdet;
+}
+
+//@}
+// clang-format off
+DECLARE_DETELEMENT(epic_mRwellDIRC, create_BarrelDetectorWithFrame)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Creates planar micro-RWell MPGDs that match DIRC bar geometry for use behind the DIRC bars.
These MPGDs use the source file src/BarrelBarwithFrame.cpp and the compact/tracker/mrwell_dirc.xml file

The gas ArCO2 (80/20) was also added to compact/materials.xml

### What kind of change does this PR introduce?
- [x] Beginning to address New feature (issue #76 )

There are several items that still need to be addressed:
- [x] Create planar geometry template
- [x] Eliminate internal detector overlaps
- [x] Implement ACTs for planar micro-RWell to provide tracking -- addressed in https://github.com/eic/epic/pull/342
- [x] Integrate planar micro-RWell MPGDs into DIRC volume 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
As of now, no changes are needed, as long as mrwell_dirc.xml is not used in the detector. More work is needed not to break the current setup (see above)

### Does this PR change default behavior?
No