### PR TITLE
fix(dRICH): initialize `irt` object pointers

### DIFF
--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -152,9 +152,9 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   /* - optionally generate an auxiliary ROOT file, storing geometry objects for IRT
    * - use compact file variable `DRICH_create_irt_file` to control this
    */
-  TFile*                       irtAuxFile = nullptr;
-  CherenkovDetectorCollection* irtGeometry;
-  CherenkovDetector*           irtDetector;
+  TFile*                       irtAuxFile  = nullptr;
+  CherenkovDetectorCollection* irtGeometry = nullptr;
+  CherenkovDetector*           irtDetector = nullptr;
   if (createIrtFile) {
     irtAuxFile = new TFile(irtAuxFileName.c_str(), "RECREATE");
     printout(ALWAYS, "IRTLOG", "Producing auxiliary ROOT file for IRT: %s", irtAuxFileName.c_str());


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fixes new build errors such as
```
error: ‘irtDetector’ may be used uninitialized
```

This issue only impacts builds with `cmake` option `-DIRT_AUXFILE=ON` (which will be removed soon in #6 anyway)

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [x] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no