### PR TITLE
ci: auto-update pull requests

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - auto-update-pull-requests
 
 jobs:
   auto-update-pull-requests:

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,15 @@
+name: Auto-update pull requests
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  auto-update-pull-requests:
+    name: Auto-update pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/auto-update@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - auto-update-pull-requests
 
 jobs:
   auto-update-pull-requests:


### PR DESCRIPTION
We can set pull requests to automatically squash merge, but we can NOT set it to automatically rebase when the base branch receives a push.

### Briefly, what does this PR introduce?
A new automatic workflow triggered by pushes to the main branch that updates outstanding pull requests which are set to auto-merge.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No changes to geometry code.

This may introduce automatic pull request updates, which will require users to know how to deal with git pulls after a remote branch has been rebased and force pushed. However, this is aimed at branches that are set to auto-merge and therefore intended to have completed development. The use case where this may be an issue is for trivial changes where auto-merge is selected before first checks complete, those checks then fail, a push to main triggers and auto-update, and the user want to fix the code on a locally checked out copy.

### Does this PR change default behavior?
No changes to default behavior of geometry code.