### PR TITLE
ci: allow repository+sha worklow_dispatch inputs

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -19,6 +19,16 @@ on:
         required: false
         default: 'master'
         type: string
+      github_repository:
+        description: 'Submitting GitHub repository'
+        required: false
+        default: ''
+        type: string
+      github_sha:
+        description: 'Submitting GitHub sha'
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -279,8 +289,8 @@ jobs:
         variables: |
           JUGGLER_DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
           JUGGLER_DETECTOR_VERSION=${{ github.ref_name }}
-          GITHUB_REPOSITORY=${{ github.repository }}
-          GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
+          GITHUB_REPOSITORY=${{ inputs.github_repository || github.repository }}
+          GITHUB_SHA=${{ inputs.github_sha || github.event.pull_request.head.sha || github.sha }}
     - run: |
         gh api \
            --method POST \


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This allows for forwarding status reporting callback location to external pipelines triggered by this repository.

In particular, a pull request in eic/ip6 could now trigger eic/epic, and eicweb/detector_benchmarks, eicweb/reconstruction_benchmarks, and eicweb/physics_benchmarks. The reports from the eicweb benchmarks will be reported back to the original ip6 pull request.

(Yes, all of this is still easier than moving ip6 into epic right now.)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.