### PR TITLE
cmake: use EPIC_ECCE_LEGACY_COMPAT=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ PROJECT(epic
   DESCRIPTION "DD4hep Geometry Description of the EPIC Experiment"
   )
 
-option(EPIC_ECCE_LEGACY_COMPAT "Preserve some compatibility with ECCE" ON)
+option(EPIC_ECCE_LEGACY_COMPAT "Preserve some compatibility with ECCE" OFF)
 option(IRT_AUXFILE "Build auxiliary config file for dRICH IRT" OFF)
 
 # C++ standard

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ ln -s ../ip6/ip6 epic/ip6
 
 To configure, build, and install the geometry (to the `install` directory), use the following commands:
 ```bash
-cmake -B build -S . -DCMAKE_INSTALL_PREFIX=install -DEPIC_ECCE_LEGACY_COMPAT=OFF
+cmake -B build -S . -DCMAKE_INSTALL_PREFIX=install
 cmake --build build
 cmake --install build
 ```


### PR DESCRIPTION
Ideally, there would have been a warning message for users living with EPIC_ECCE_LEGACY_COMPAT=ON. But since many are only now learning things through the tutorials it makes sense to drop ECCE ASAP and reduce the confusion.

### Briefly, what does this PR introduce?

A small follow up to yesterday's tutorial session. This removes unnecessary symlinks for users that are now just learning things.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Supposedly, yes.