### PR TITLE
fix: remove SupportServiceMaterial debug output

### DIFF
--- a/src/SupportServiceMaterial_geo.cpp
+++ b/src/SupportServiceMaterial_geo.cpp
@@ -41,7 +41,6 @@ namespace {
       const double thickness = getAttrOrDefault(x_child, _U(thickness), x_support.thickness());
       const double length    = getAttrOrDefault(x_child, _U(length), x_support.length());
       const double rmin      = getAttrOrDefault(x_child, _U(rmin), x_support.rmin()) + offset;
-      // std::cout << rmin << " " << length << std::endl;
       solid = Tube(rmin, rmin + thickness, length / 2);
     }
     // A disk is a cylinder, constructed differently
@@ -51,7 +50,6 @@ namespace {
       const double rmax      = getAttrOrDefault(x_child, _U(rmax), x_support.rmax());
       pos3D                  = pos3D + Position(0, 0, -x_support.thickness()/2 + thickness / 2 + offset);
       solid                  = Tube(rmin, rmax, thickness / 2);
-      std::cout << pos3D << std::endl;
     } else if (type == "Cone") {
       const double base_rmin1     = getAttrOrDefault(x_child, _U(rmin1), x_support.rmin1());
       const double base_rmin2     = getAttrOrDefault(x_child, _U(rmin2), x_support.rmin2());


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This removes debugging output that has been showing up on every geometry load.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes, removes output that was shown before, i.e.
```console
(0,0,13.6753)
(0,0,-0.0751)
(0,0,0.0999)
(0,0,-13.6753)
(0,0,-0.1001)
(0,0,0.0749)
(0,0,173.3)
(0,0,-0.2)
(0,0,0.1)
```