### PR TITLE
feat: run epic_sciglass and _imaging benchmarks

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -291,7 +291,7 @@ jobs:
         ref_name: master
         variables: |
           DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
-          DETECTOR_VERSION=${{ github.ref_name }}
+          DETECTOR_VERSION=${{ github.event.pull_request.head.ref || github.ref_name }}
           DETECTOR_CONFIG=${{ matrix.detector_config }}
           GITHUB_REPOSITORY=${{ inputs.github_repository || github.repository }}
           GITHUB_SHA=${{ inputs.github_sha || github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -278,6 +278,9 @@ jobs:
   trigger-detector-benchmarks:
     runs-on: ubuntu-latest
     needs: [check-overlap-tgeo, check-overlap-geant4-fast]
+    strategy:
+      matrix:
+        detector_config: [epic_sciglass, epic_imaging]
     steps:
     - uses: eic/trigger-gitlab-ci@v2
       id: trigger
@@ -287,8 +290,9 @@ jobs:
         token: ${{ secrets.EICWEB_DETECTOR_BENCHMARK_TRIGGER }}
         ref_name: master
         variables: |
-          JUGGLER_DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
-          JUGGLER_DETECTOR_VERSION=${{ github.ref_name }}
+          DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
+          DETECTOR_VERSION=${{ github.ref_name }}
+          DETECTOR_CONFIG=${{ matrix.detector_config }}
           GITHUB_REPOSITORY=${{ inputs.github_repository || github.repository }}
           GITHUB_SHA=${{ inputs.github_sha || github.event.pull_request.head.sha || github.sha }}
     - run: |
@@ -298,8 +302,8 @@ jobs:
           /repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha || github.sha }} \
           -f state='pending' \
           -f target_url=${{ steps.trigger.outputs.web_url }} \
-          -f description='The detector benchmarks have been triggered...' \
-          -f context='eicweb/detector_benchmarks'
+          -f description='The detector benchmarks for ${{ matrix.detector_config }} have been triggered...' \
+          -f context='eicweb/detector_benchmarks (${{ matrix.detector_config }})'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In the past (ATHENA, ECCE) we were running benchmarks for multiple configurations. This brings back that functionality for EPIC on GitHub. At this point, the matrix is just epic_sciglass and epic_imaging, as the likely two configurations in the October 2022 campaign.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #114)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Multiple detector configurations will be tested by default, including barrel imaging calorimeter, which has not been included in tests for a while.