### PR TITLE
Imaging Barrel Calorimeter Geometry and Readout Update

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -508,7 +508,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
   <documentation level="3">
 ## Calorimeter Parameters
   </documentation>
-    <constant name="CaloSides"                      value="12"/>
+    <constant name="CaloSides"                      value="24"/>
 
     <constant name="EcalEndcapP_zmin"               value="ForwardServiceGap_zmax" />
     <constant name="EcalEndcapP_length"             value="30*cm" />

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -508,7 +508,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
   <documentation level="3">
 ## Calorimeter Parameters
   </documentation>
-    <constant name="CaloSides"                      value="24"/>
+    <constant name="EcalBarrelStavesN"              value="24"/>
 
     <constant name="EcalEndcapP_zmin"               value="ForwardServiceGap_zmax" />
     <constant name="EcalEndcapP_length"             value="30*cm" />
@@ -554,6 +554,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
       ## Hadronic Calorimeter Parameters
     </documentation>
 
+    <constant name="HcalBarrelStavesN"          value="12"/>
     <constant name="HcalEndcapP_zmin"     value="EcalEndcapP_zmin + EcalEndcapP_length"/>
     <constant name="HcalEndcapP_length"   value="120.0*cm"/>
     <constant name="HcalEndcapP_zmax"     value="HcalEndcapP_zmin + HcalEndcapP_length"/>

--- a/compact/ecal_barrel.xml
+++ b/compact/ecal_barrel.xml
@@ -18,7 +18,7 @@
     <constant name="EcalBarrel_CarbonSpacerWidth"    value="4*mm"/>
     <constant name="EcalBarrel_LayerSpacing"         value="10.0*mm"/>
     <constant name="EcalBarrel_TungstenThickness"    value="4.0*mm"/>
-    <constant name="EcalBarrel_ModRepeat"            value="CaloSides"/>
+    <constant name="EcalBarrel_ModRepeat"            value="EcalBarrelStavesN"/>
     <constant name="EcalBarrel_ModLength"            value="0.5*m"/>
     <constant name="EcalBarrel_ModWidth"             value="0.5*m"/>
     <constant name="EcalBarrel_AvailThickness"       value="EcalBarrelRegion_thickness-EcalBarrel_Support_thickness"/>

--- a/compact/ecal_barrel_interlayers.xml
+++ b/compact/ecal_barrel_interlayers.xml
@@ -32,7 +32,7 @@
       For W/SiFi (sPHENIX): X0 ~ 0.7 cm (but different fiber orientation)
     </comment>
     <constant name="EcalBarrel_RadiatorThickness"    value="EcalBarrel_FiberZSpacing*13"/>
-    <constant name="EcalBarrel_ModRepeat"            value="CaloSides"/>
+    <constant name="EcalBarrel_ModRepeat"            value="EcalBarrelStavesN"/>
     <constant name="EcalBarrel_ModLength"            value="0.5*m"/>
     <constant name="EcalBarrel_ModWidth"             value="0.5*m"/>
     <constant name="EcalBarrel_AvailThickness"       value="EcalBarrelRegion_thickness-EcalBarrel_Support_thickness"/>

--- a/compact/ecal_barrel_interlayers.xml
+++ b/compact/ecal_barrel_interlayers.xml
@@ -172,7 +172,7 @@
     </readout>
     <readout name="EcalBarrelScFiHits">
       <segmentation type="CartesianStripZ" strip_size_x="1.0*cm" identifier_x="z"/>
-      <id>system:8,module:6,layer:6,slice:6,grid:10,fiber:16,z:-12</id>
+      <id>system:8,module:6,layer:6,slice:4,grid:10,fiber:16,z:-14</id>
     </readout>
   </readouts>
 

--- a/compact/ecal_barrel_interlayers.xml
+++ b/compact/ecal_barrel_interlayers.xml
@@ -171,8 +171,8 @@
       <id>system:8,module:8,layer:8,slice:8,x:32:-16,y:-16</id>
     </readout>
     <readout name="EcalBarrelScFiHits">
-      <segmentation type="NoSegmentation"/>
-      <id>system:8,module:8,layer:8,slice:8,grid:16,fiber:16</id>
+      <segmentation type="CartesianStripZ" strip_size_x="1.0*cm" identifier_x="z"/>
+      <id>system:8,module:6,layer:6,slice:6,grid:10,fiber:16,z:-12</id>
     </readout>
   </readouts>
 

--- a/compact/hcal/hcal_backward.xml
+++ b/compact/hcal/hcal_backward.xml
@@ -40,7 +40,7 @@
       calorimeterType="HAD_ENDCAP" reflect="true">
       <position x="0" y="0" z="0"/>
       <dimensions
-        numsides="CaloSides"
+        numsides="HcalBarrelStavesN"
         zmin="HcalEndcapN_zmin"
         rmin="HcalEndcapN_rmin"
         rmax="HcalBarrel_rmax"/>

--- a/compact/hcal/hcal_barrel.xml
+++ b/compact/hcal/hcal_barrel.xml
@@ -43,7 +43,7 @@
       gap="0.*cm"
       material="Steel235">
       <dimensions
-        numsides="CaloSides"
+        numsides="HcalBarrelStavesN"
         rmin="HcalBarrel_rmin"
         z="HcalBarrel_length"/>
       <staves vis="HcalBarrelStaveVis"/>

--- a/compact/hcal/hcal_barrel.xml
+++ b/compact/hcal/hcal_barrel.xml
@@ -58,7 +58,7 @@
   <readouts>
     <readout name="HcalBarrelHits">
       <segmentation type="CartesianGridXY" grid_size_x="100* mm" grid_size_y="100 * mm"/>
-      <id>system:8,barrel:6,module:4,layer:8,slice:6,x:32:-16,y:-16</id>
+      <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>
     </readout>
   </readouts>
 

--- a/compact/hcal/hcal_barrel.xml
+++ b/compact/hcal/hcal_barrel.xml
@@ -58,7 +58,7 @@
   <readouts>
     <readout name="HcalBarrelHits">
       <segmentation type="CartesianGridXY" grid_size_x="100* mm" grid_size_y="100 * mm"/>
-      <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>
+      <id>system:8,barrel:6,module:4,layer:8,slice:6,x:32:-16,y:-16</id>
     </readout>
   </readouts>
 

--- a/compact/hcal/hcal_forward.xml
+++ b/compact/hcal/hcal_forward.xml
@@ -75,7 +75,7 @@
       reflect="false">
       <position x="0" y="0" z="0"/>
       <dimensions
-        numsides="CaloSides"
+        numsides="HcalBarrelStavesN"
         zmin="EcalEndcapP_zmin"
         rmin="EcalEndcapP_rmax"
         rmax="HcalBarrel_rmax"/>

--- a/compact/unused/ecal_barrel_hybrid.xml
+++ b/compact/unused/ecal_barrel_hybrid.xml
@@ -29,7 +29,7 @@
       For W/SiFi (sPHENIX): X0 ~ 0.7 cm (but different fiber orientation)
     </comment>
     <constant name="EcalBarrel_RadiatorThickness"    value="EcalBarrel_FiberZSpacing*12"/>
-    <constant name="EcalBarrel_ModRepeat"            value="CaloSides"/>
+    <constant name="EcalBarrel_ModRepeat"            value="EcalBarrelStavesN"/>
     <constant name="EcalBarrel_ModLength"            value="0.5*m"/>
     <constant name="EcalBarrel_ModWidth"             value="0.5*m"/>
     <constant name="EcalBarrel_AvailThickness"       value="EcalBarrelEnvelope_thickness-EcalBarrel_Support_thickness"/>


### PR DESCRIPTION
Change number of staves to 24
Add z-segmentation for fibers

### Briefly, what does this PR introduce?
Geometry and readout update for the imaging barrel calorimeter.
Resolve issue #119 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other: geometry and readout update

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
This PR requires the implementation of waveform signals in the digitization step for the hits separation in fibers.

### Does this PR change default behavior?
No
