### PR TITLE
fix: calculate MGPD stave width based on envelope rmin, not mid-module rmin

### DIFF
--- a/compact/tracker/mpgd_barrel.xml
+++ b/compact/tracker/mpgd_barrel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd>	
+<lccdd>
 <info name="mpgd_barrel.xml"
       title="Micro Pattern Gas Detectors"
       author="mposik1983"
@@ -7,14 +7,14 @@
       status="development"
       version="1.0"
 ><comment/>
-</info>	
+</info>
 
   <define>
     <comment>
       Main parameters - Geo based on the original ECCE design, while for now
                         using the ATHENA MMGAS design for the layers (FIXME)
 
-      Note: the inner and outer layers are implemented as separate detectors, as they 
+      Note: the inner and outer layers are implemented as separate detectors, as they
       belong to different ACTS tracking volumes. If this restriction goes away
       in the future they could be put together in a single tag.
     </comment>
@@ -58,7 +58,7 @@
     <constant name="MMDriftCuElectrode_thickness"           value="5*um"/>
     <constant name="MMDriftKapton_thickness"                value="250*um"/>
     <constant name="MMDriftCuGround_thickness"              value="0.41*um"/>
-    
+
     <comment> FIXME: No support material is here, so fudge factor used to bring material budget to ~0.5% for barrel </comment>
     <constant name="MMFudgeInnerMPGDBarrel_thickness"                      value="570*um"/>
 
@@ -70,9 +70,9 @@
       due to ACTS limitations.
       FIXME: this shouldn't be needed anymore, need to update the cylindrical plugin.
     </comment>
-    <constant name="MPGDBarrelStave_count"       value="128"/>
-    <constant name="InnerMPGDBarrelStave_width"       value="2*InnerMPGDBarrelMod_rmin * tan(180*degree/MPGDBarrelStave_count)"/>
-    <constant name="OuterMPGDBarrelStave_width"       value="2*OuterMPGDBarrelMod_rmin * tan(180*degree/MPGDBarrelStave_count)"/>
+    <constant name="MPGDBarrelStave_count"            value="128"/>
+    <constant name="InnerMPGDBarrelStave_width"       value="2*InnerMPGDBarrelLayer_rmin * tan(180*degree/MPGDBarrelStave_count)"/>
+    <constant name="OuterMPGDBarrelStave_width"       value="2*OuterMPGDBarrelLayer_rmin * tan(180*degree/MPGDBarrelStave_count)"/>
   </define>
 
   <detectors>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This addresses the small overlaps between staves that have been bugging the geant4 overlap checks. We were calculating the width of perfectly-circle-filling staves by using the radius of the center of the middle of the module, but then we were placing them starting at an envelope rmin which was half a thickness smaller. This caused overlaps at the inner corners for both inner and outer MPGD layers.

This change should make the staves a tad bit smaller (ratio of thickness over radius of placement), cause a slightly smaller efficiency, but should improve the pipeline stabilities by not triggering overlaps in the MPGDs.

@mposik1983 I trust this is ok at least as a stopgap while better solutions are developed.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__ unreported)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Slightly narrower MPGD staves.