### PR TITLE
moved outer mpgd barrel to EPIC location

### DIFF
--- a/compact/tracker.xml
+++ b/compact/tracker.xml
@@ -28,7 +28,7 @@
     <comment> barrel length: 2R/tan(angle) - dz </comment>
 
     <comment> Position in center of space behind DIRC </comment>
-    <constant name="OuterMPGDBarrel_rmin"            value="EcalBarrel_rmin - BarrelExtraSpace_thickness / 2."/>
+    <constant name="OuterMPGDBarrel_rmin"            value="74.5*cm"/>
     <comment> barrel asymmetryc between forward and backward lengths </comment>
 
     <comment> Service/Support setup </comment>

--- a/compact/tracker/mpgd_barrel.xml
+++ b/compact/tracker/mpgd_barrel.xml
@@ -42,8 +42,8 @@
     <constant name="OuterMPGDBarrelMod_zoffset"             value="(OuterMPGDBarrelMod_zmin1 - OuterMPGDBarrelMod_zmin2)/2" />
     <constant name="OuterMPGDBarrelLayer_length"            value="OuterMPGDBarrelMod_length + 1*um" />
     <constant name="OuterMPGDBarrelLayer_thickness"         value="2*cm" />
-    <constant name="OuterMPGDBarrelLayer_rmin"              value="OuterMPGDBarrelMod_rmin - OuterMPGDBarrelLayer_thickness / 2.0"/>
-    <constant name="OuterMPGDBarrelLayer_rmax"              value="OuterMPGDBarrelLayer_rmin + OuterMPGDBarrelLayer_thickness"/>
+    <constant name="OuterMPGDBarrelLayer_rmin"              value="OuterMPGDBarrelMod_rmin"/>
+    <constant name="OuterMPGDBarrelLayer_rmax"              value="OuterMPGDBarrelMod_rmin + OuterMPGDBarrelLayer_thickness"/>
 
     <comment> MMGAS tracker parameters </comment>
     <constant name="MMKaptonOverlay_thickness"              value="50*um"/>
@@ -145,7 +145,7 @@
           z_length="OuterMPGDBarrelLayer_length"
           z0="OuterMPGDBarrelMod_zoffset"/>
         <layer_material surface="inner" binning="binPhi,binZ" bins0="MPGDBarrelStave_count" bins1="100" />
-        <rphi_layout phi_tilt="0" nphi="MPGDBarrelStave_count" phi0="0.0" rc="OuterMPGDBarrelMod_rmin" dr="0.0 * mm"/>
+	<rphi_layout phi_tilt="0" nphi="MPGDBarrelStave_count" phi0="0.0" rc="OuterMPGDBarrelMod_rmin + OuterMPGDBarrelLayer_thickness/2" dr="0.0 * mm"/>
         <z_layout dr="0.0 * mm" z0="0.0 * mm" nz="1"/>
       </layer>
     </detector>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Outer mpgd layer has been moved to radial location of 74.5 cm, as listed in table: https://eic.jlab.org/Geometry/Detector/Detector-20220905113308.html

This should avoid overlaps with the different calorimeter technologies being implemented. 

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.
### Does this PR change default behavior?
Only location of mpgd outer barrel