### PR TITLE
doc(dRICH): generation of dRICH and pfRICH material property tables 

### DIFF
--- a/compact/drich.xml
+++ b/compact/drich.xml
@@ -6,8 +6,8 @@
 <constant name="DRICH_Length"             value="ForwardRICHRegion_length"/>  <!-- overall vessel length -->
 <constant name="DRICH_zmin"               value="ForwardRICHRegion_zmin"/>
 <constant name="DRICH_zmax"               value="DRICH_zmin + DRICH_Length"/>
-<constant name="DRICH_rmin0"              value="DRICH_zmin * ForwardRICHRegion_tan1"/>  <!-- bore radius at dRICh entrance -->
-<constant name="DRICH_rmin1"              value="DRICH_zmax * ForwardRICHRegion_tan2"/>  <!-- bore radius at dRICh exit -->
+<constant name="DRICH_rmin0"              value="DRICH_zmin * ForwardRICHRegion_tan1"/>  <!-- bore radius at dRICH entrance -->
+<constant name="DRICH_rmin1"              value="DRICH_zmax * ForwardRICHRegion_tan2"/>  <!-- bore radius at dRICH exit -->
 <constant name="DRICH_wall_thickness"     value="0.5*cm"/>  <!-- thickness of radial walls -->
 <constant name="DRICH_window_thickness"   value="0.1*cm"/>  <!-- thickness of entrance and exit walls -->
 <!-- snout geometry: cone with front radius rmax0 and back radius of rmax1 -->
@@ -49,7 +49,7 @@
 
 <!-- /detectors/detector -->
 <documentation level="10">
-### dRICh: ***d***ual ***R***ing ***I***maging ***Ch***erenkov detector
+### dRICH: ***d***ual ***R***ing ***I***maging ***Ch***erenkov detector
 </documentation>
 <detector
   id="ForwardRICH_ID"
@@ -66,7 +66,7 @@
 <!-- /detectors/detector/dimensions -->
 <documentation level="10">
 #### Vessel
-- the dRICh vessel is composed of two parts:
+- the dRICH vessel is composed of two parts:
   - tank: cylindrical region containing most of the detector components
   - snout: conical region at the front of the vessel, containing the aerogel
 - dimensions:

--- a/compact/optical_materials.xml
+++ b/compact/optical_materials.xml
@@ -373,11 +373,11 @@
       1240*eV/210  10*mm
       1240*eV/200  0*mm
       "/>
-    <!-- BEGIN dRICh and pfRICh material properties
+    <!-- BEGIN dRICH and pfRICH material properties
          - dumped from fun4all implementation
          - see https://github.com/cisbani/dRICh/blob/main/share/source/g4dRIChOptics.hh
          -->
-    <!-- dRICh gas -->
+    <!-- dRICH gas -->
     <matrix name="RINDEX__C2F6_DRICH" coldim="2" values="
       1.7712*eV   1.00075
       1.92389*eV  1.00075
@@ -402,7 +402,7 @@
       4.85156*eV  10.0*m
       6.19921*eV  10.0*m
       "/>
-    <!-- pfRICh gas -->
+    <!-- pfRICH gas -->
     <matrix name="RINDEX__C4F10_PFRICH" coldim="2" values="
       1.7712*eV   1.0013
       1.92389*eV  1.0013
@@ -427,7 +427,7 @@
       4.85156*eV  6.0*m
       6.19921*eV  6.0*m
       "/>
-    <!-- dRICh aerogel, for density=0.11 g/cm3 -->
+    <!-- dRICH aerogel, for density=0.11 g/cm3 -->
     <matrix name="RINDEX__Aerogel_DRICH" coldim="2" values="
       1.87855*eV  1.01852
       1.96673*eV  1.01856
@@ -584,7 +584,7 @@
       6.11103*eV    2.510*mm
       6.19921*eV    2.370*mm
       "/>
-    <!-- dRICh acrylic -->
+    <!-- dRICH acrylic -->
     <matrix name="RINDEX__Acrylic_DRICH" coldim="2" values="
       4.13281*eV  1.5017
       4.22099*eV  1.5017
@@ -689,7 +689,7 @@
       8.36529*eV  0.166779*mm
       8.45347*eV  0.166779*mm
       "/>
-    <!-- END dRICh optical properties -->
+    <!-- END dRICH optical properties -->
   </properties>
   <materials>
     <material name="AirOptical">
@@ -738,7 +738,7 @@
       <property name="RINDEX" ref="RINDEX__Acrylic"/>
       <property name="ABSLENGTH" ref="ABSLENGTH__Acrylic"/>
     </material>
-    <!-- BEGIN dRICh and pfRICh material definitions -->
+    <!-- BEGIN dRICH and pfRICH material definitions -->
     <material name="C2F6_DRICH">
       <D type="density" value="0.005734" unit="g/cm3"/>
       <composite n="2" ref="C"/>
@@ -770,7 +770,7 @@
       <property name="RINDEX"    ref="RINDEX__Acrylic_DRICH"/>
       <property name="ABSLENGTH" ref="ABSLENGTH__Acrylic_DRICH"/>
     </material>
-    <!-- END dRICh material definitions -->
+    <!-- END dRICH material definitions -->
     <material name="QuartzOptical">
       <D type="density" value="2.2" unit="g/cm3"/>
       <composite n="1" ref="Si"/>
@@ -847,7 +847,7 @@
       -->
     </opticalsurface>
 
-    <!-- BEGIN dRICh surface definitions -->
+    <!-- BEGIN dRICH surface definitions -->
     <opticalsurface name="MirrorSurface_DRICH" model="unified" finish="polished" type="dielectric_metal">
       <property name="REFLECTIVITY" coldim="2" values="
         1*eV  0.9
@@ -869,7 +869,7 @@
         7*eV  1
         "/>
     </opticalsurface>
-    <!-- END dRICh surface definitions -->
+    <!-- END dRICH surface definitions -->
 
   </surfaces>
 </lccdd>

--- a/compact/optical_materials.xml
+++ b/compact/optical_materials.xml
@@ -770,7 +770,7 @@
       <property name="RINDEX"    ref="RINDEX__Acrylic_DRICH"/>
       <property name="ABSLENGTH" ref="ABSLENGTH__Acrylic_DRICH"/>
     </material>
-    <!-- END dRICH material definitions -->
+    <!-- END dRICH and pfRICH material definitions -->
     <material name="QuartzOptical">
       <D type="density" value="2.2" unit="g/cm3"/>
       <composite n="1" ref="Si"/>

--- a/compact/optical_materials.xml
+++ b/compact/optical_materials.xml
@@ -373,10 +373,10 @@
       1240*eV/210  10*mm
       1240*eV/200  0*mm
       "/>
-    <!-- BEGIN dRICH and pfRICH material properties
-         - dumped from fun4all implementation
-         - see https://github.com/cisbani/dRICh/blob/main/share/source/g4dRIChOptics.hh
-         -->
+    <!-- BEGIN dRICH and pfRICH material optical properties
+      - to generate, follow: https://github.com/eic/drich-dev/blob/main/doc/material_tables.md
+      - original source for ATHENA/ECCE: https://github.com/cisbani/dRICh/blob/main/share/source/g4dRIChOptics.hh
+    -->
     <!-- dRICH gas -->
     <matrix name="RINDEX__C2F6_DRICH" coldim="2" values="
       1.7712*eV   1.00075
@@ -584,7 +584,7 @@
       6.11103*eV    2.510*mm
       6.19921*eV    2.370*mm
       "/>
-    <!-- dRICH acrylic -->
+    <!-- dRICH acrylic filter -->
     <matrix name="RINDEX__Acrylic_DRICH" coldim="2" values="
       4.13281*eV  1.5017
       4.22099*eV  1.5017
@@ -689,7 +689,7 @@
       8.36529*eV  0.166779*mm
       8.45347*eV  0.166779*mm
       "/>
-    <!-- END dRICH optical properties -->
+    <!-- END dRICH and pfRICH material optical properties -->
   </properties>
   <materials>
     <material name="AirOptical">
@@ -847,7 +847,10 @@
       -->
     </opticalsurface>
 
-    <!-- BEGIN dRICH surface definitions -->
+    <!-- BEGIN dRICH and pfRICH optical surface properties
+      - to generate, follow: https://github.com/eic/drich-dev/blob/main/doc/material_tables.md
+      - original source for ATHENA/ECCE: https://github.com/cisbani/dRICh/blob/main/share/source/g4dRIChOptics.hh
+    -->
     <opticalsurface name="MirrorSurface_DRICH" model="unified" finish="polished" type="dielectric_metal">
       <property name="REFLECTIVITY" coldim="2" values="
         1*eV  0.9
@@ -869,7 +872,7 @@
         7*eV  1
         "/>
     </opticalsurface>
-    <!-- END dRICH surface definitions -->
+    <!-- END dRICH and pfRICH optical surface properties -->
 
   </surfaces>
 </lccdd>

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -1,5 +1,5 @@
 //==========================================================================
-//  dRICh: Dual Ring Imaging Cherenkov Detector
+//  dRICH: Dual Ring Imaging Cherenkov Detector
 //--------------------------------------------------------------------------
 //
 // Author: Christopher Dilks (Duke University)
@@ -163,10 +163,10 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   desc.add(Constant("DRICH_RECON_cellMask",       std::to_string(cellMask)));
 
   // BUILD VESSEL ====================================================================
-  /* - `vessel`: aluminum enclosure, the mother volume of the dRICh
+  /* - `vessel`: aluminum enclosure, the mother volume of the dRICH
    * - `gasvol`: gas volume, which fills `vessel`; all other volumes defined below
    *   are children of `gasvol`
-   * - the dRICh vessel geometry has two regions: the snout refers to the conic region
+   * - the dRICH vessel geometry has two regions: the snout refers to the conic region
    *   in the front, housing the aerogel, while the tank refers to the cylindrical
    *   region, housing the rest of the detector components
    */


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Document how to generate material property tables for the dRICH and pfRICH.

Close #105 

Alternatively, we could consider moving this generation code here to `epic`. Another possibility is removing these XML tables and use the material property table generation code directly as a plugin here, but I think for that we would need to be able to convert a `G4Material` to a `TGeoMaterial` (the reverse is done when converting `TGeo`->`Geant4`). Anyway, better documentation is a start in the right direction.

This also makes the change `dRICh` -> `dRICH` everywhere; despite attempts from some to call it "dRICh", it seems "dRICH" is much more popular...

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [x] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No