### PR TITLE
Add SciFi/Pb materials

### DIFF
--- a/compact/ecal_barrel_interlayers.xml
+++ b/compact/ecal_barrel_interlayers.xml
@@ -136,8 +136,8 @@
       <layer repeat="EcalBarrelImagingLayers_num-1" vis="EcalBarrelLayerVis"
        space_between="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween"
        space_before="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween/2.">
-        <slice material="Lead" thickness="EcalBarrel_RadiatorThickness" vis="EcalBarrelFiberLayerVis">
-          <fiber material="PlasticScint"
+        <slice material="SciFiPb_PbGlue" thickness="EcalBarrel_RadiatorThickness" vis="EcalBarrelFiberLayerVis">
+          <fiber material="SciFiPb_Scintillator"
             sensitive="yes"
             radius="EcalBarrel_FiberRadius"
             spacing_x="EcalBarrel_FiberXSpacing"
@@ -150,10 +150,10 @@
       </layer>
       <layer repeat="EcalBarrel_FiberChunkLayers_num" vis="EcalBarrelLayerVis"
           space_before="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween">
-        <slice material="Lead"
+        <slice material="SciFiPb_PbGlue"
           thickness="EcalBarrel_ScFiPartThickness/EcalBarrel_FiberChunkLayers_num"
           vis="EcalBarrelFiberLayerVis">
-          <fiber material="PlasticScint"
+          <fiber material="SciFiPb_Scintillator"
             sensitive="yes"
             radius="EcalBarrel_FiberRadius"
             spacing_x="EcalBarrel_FiberXSpacing"

--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -399,4 +399,23 @@
     <fraction n="0.96" ref="W"/>
     <fraction n="0.04" ref="Polystyrene"/>
   </material>
+  <material name="SciFiPb_Glue">
+    <D type="density" value="1.180" unit="g / cm3"/>
+    <fraction n="0.077" ref="H"/>
+  	<fraction n="0.921" ref="C"/>
+   	<fraction n="0.001" ref="N"/>
+   	<fraction n="0.001" ref="O"/>
+  </material>
+  <material name="SciFiPb_Scintillator">
+    <D type="density" value="1.049" unit="g / cm3"/>
+    <fraction n="0.091" ref="H"/>
+  	<fraction n="0.822" ref="C"/>
+   	<fraction n="0.032" ref="N"/>
+   	<fraction n="0.055" ref="O"/>
+  </material>
+  <material name="SciFiPb_PbGlue">
+    <D type="density" value="8.558" unit="g / cm3"/>
+    <fraction n="0.9622" ref="Pb"/>
+  	<fraction n="0.0378" ref="SciFiPb_Glue"/>
+  </material>
 </materials>

--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -412,6 +412,7 @@
   	<fraction n="0.822" ref="C"/>
    	<fraction n="0.032" ref="N"/>
    	<fraction n="0.055" ref="O"/>
+     <constant name="BirksConstant" value="0.126*mm/MeV"/>
   </material>
   <material name="SciFiPb_PbGlue">
     <D type="density" value="8.558" unit="g / cm3"/>

--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -402,21 +402,21 @@
   <material name="SciFiPb_Scintillator">
     <D type="density" value="1.049" unit="g / cm3"/>
     <fraction n="0.077" ref="H"/>
-  	<fraction n="0.921" ref="C"/>
-   	<fraction n="0.001" ref="N"/>
-   	<fraction n="0.001" ref="O"/>
+    <fraction n="0.921" ref="C"/>
+    <fraction n="0.001" ref="N"/>
+    <fraction n="0.001" ref="O"/>
     <constant name="BirksConstant" value="0.126*mm/MeV"/>
   </material>
   <material name="SciFiPb_Glue">
     <D type="density" value="1.180" unit="g / cm3"/>
     <fraction n="0.091" ref="H"/>
-  	<fraction n="0.822" ref="C"/>
-   	<fraction n="0.032" ref="N"/>
-   	<fraction n="0.055" ref="O"/>   
+    <fraction n="0.822" ref="C"/>
+    <fraction n="0.032" ref="N"/>
+    <fraction n="0.055" ref="O"/>   
   </material>
   <material name="SciFiPb_PbGlue">
     <D type="density" value="8.558" unit="g / cm3"/>
     <fraction n="0.9622" ref="Pb"/>
-  	<fraction n="0.0378" ref="SciFiPb_Glue"/>
+    <fraction n="0.0378" ref="SciFiPb_Glue"/>
   </material>
 </materials>

--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -399,20 +399,20 @@
     <fraction n="0.96" ref="W"/>
     <fraction n="0.04" ref="Polystyrene"/>
   </material>
-  <material name="SciFiPb_Glue">
-    <D type="density" value="1.180" unit="g / cm3"/>
+  <material name="SciFiPb_Scintillator">
+    <D type="density" value="1.049" unit="g / cm3"/>
     <fraction n="0.077" ref="H"/>
   	<fraction n="0.921" ref="C"/>
    	<fraction n="0.001" ref="N"/>
    	<fraction n="0.001" ref="O"/>
+    <constant name="BirksConstant" value="0.126*mm/MeV"/>
   </material>
-  <material name="SciFiPb_Scintillator">
-    <D type="density" value="1.049" unit="g / cm3"/>
+  <material name="SciFiPb_Glue">
+    <D type="density" value="1.180" unit="g / cm3"/>
     <fraction n="0.091" ref="H"/>
   	<fraction n="0.822" ref="C"/>
    	<fraction n="0.032" ref="N"/>
-   	<fraction n="0.055" ref="O"/>
-     <constant name="BirksConstant" value="0.126*mm/MeV"/>
+   	<fraction n="0.055" ref="O"/>   
   </material>
   <material name="SciFiPb_PbGlue">
     <D type="density" value="8.558" unit="g / cm3"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR adjusts the material of the SciFi/Pb matrix by including glue with properties like in: Z. Papandreou. BCAL Calorimetry Response. Technical report, GlueX Collaboration, 2007. [GlueX-doc-840-v2](https://halldweb.jlab.org/doc-public/DocDB/ShowDocument?docid=840). The mixture of Pb and Glue is implemented as radiator, and SciFi material has been also adjusted to match better the GlueX one as described in the cited note.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (as described above)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

no

### Does this PR change default behavior?

no
