### PR TITLE
ci: use a dedicated PAT for auto-update resubmit

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: tibdex/auto-update@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.AUTO_UPDATE_PULL_REQUESTS_TOKEN }}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Using a standard GitHub workflow token for the pull request auto-updates does not allow resubmitting the workflows after the updates. This is annoying since it prevents auto-merges from actually merging. This replaces the use of a standard token with a personal access token that has these permissions.

### What kind of change does this PR introduce?
- [X] Bug fix (issue: workflows do no restart when pull requests are auto-updated)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.