### PR TITLE
fix: introduce DIRC_thickness parameter

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -549,17 +549,22 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="EcalBarrel_offset"              value="(EcalBarrelForward_zmax - EcalBarrelBackward_zmax)/2.0"/>
     <constant name="EcalBarrelReadout_length"       value="20*cm"/>
 
-  <documentation level="3">
-    ## Special DIRC parameters (depend on the ECAL setup)
-  </documentation>
+    <documentation level="3">
+      ## Special DIRC parameters (depend on the ECAL setup)
+    </documentation>
     <constant name="DIRCReadout_length"         value="30*cm"/>
     <constant name="DIRCForward_length"         value="0*cm"/>
     <constant name="DIRCForward_zmax"           value="CentralTrackingRegionP_zmax"/>
     <constant name="DIRCBackward_zmax"          value="287*cm"/>
+    <constant name="DIRC_thickness"             value="3*cm"/>
     <constant name="DIRC_length"                value="DIRCForward_zmax + DIRCBackward_zmax"/>
     <constant name="DIRC_offset"                value="(DIRCForward_zmax - DIRCBackward_zmax)/2"/>
+    <comment>
+      The DIRC_rmin/rmax values are defined at the center of each stave, such that
+      the DIRC_rmax can also be used as the OuterBarrelMPGD_rmin value. 
+    </comment>
     <constant name="DIRC_rmin"                  value="CentralTrackingRegion_rmax"/>
-    <constant name="DIRC_rmax"                  value="DIRC_rmin + BarrelPIDRegion_thickness"/>
+    <constant name="DIRC_rmax"                  value="DIRC_rmin + DIRC_thickness"/>
 
     <documentation>
       ## Hadronic Calorimeter Parameters


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Both the DIRC and OuterBarrelMPGD are currently placed at the same rmin of `CentralTrackingRegion_rmax`. This PR introduces the 'correct' DIRC_rmax based on a new parameter `DIRC_thickness` to allow for room for the OuterBarrelMPGD.

### What kind of change does this PR introduce?
- [X] Bug fix (issue: overlap between DIRC and MPGD)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, place the MPGD further out radially than currently.