### PR TITLE
Add cladding to fibers

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -103,7 +103,7 @@ jobs:
         if-no-files-found: error
     - run: |
         source install/setup.sh
-        sed -i '/<fiber/,+6d' ${DETECTOR_PATH}/compact/ecal/barrel_interlayers.xml
+        sed -z 's|\(<fiber\)|<comment>\1|g; s|\(/fiber>\)|\1</comment>|g'
         sed -i '/<fiber/,+4d' ${DETECTOR_PATH}/compact/ecal/forward_scfi.xml
         sed -i '/<fiber/,+4d' ${DETECTOR_PATH}/compact/far_forward/ZDC_Ecal_WSciFi.xml
         sed -i '/<lens/,+4d' ${DETECTOR_PATH}/compact/pid/mrich.xml

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -27,7 +27,7 @@
     <constant name="EcalBarrel_Calorimeter_offset"
       value="(EcalBarrel_Calorimeter_zmax - EcalBarrel_Calorimeter_zmin)/2.0"/>
 
-    <constant name="EcalBarrel_Support_thickness"    value="5*cm"/>
+    <constant name="EcalBarrel_Support_thickness"    value="0*cm"/>
     <constant name="EcalBarrel_SiliconThickness"     value="500*um"/>
     <constant name="EcalBarrel_ElectronicsThickness" value="150*um"/>
     <constant name="EcalBarrel_CopperThickness"      value="100*um"/>
@@ -143,11 +143,7 @@
       <dimensions numsides="EcalBarrel_ModRepeat"
         rmin="EcalBarrel_rmin"
         z="EcalBarrel_Calorimeter_length"/>
-      <staves vis="EcalBarrelStaveVis">
-        <support material="Steel235" vis="EcalBarrelSupportVis" n_beams="3" grid_size="25.0*cm"
-          thickness="EcalBarrel_Support_thickness" beam_thickness="EcalBarrel_Support_thickness/4" >
-        </support>
-      </staves>
+      <staves vis="EcalBarrelStaveVis"/>
       <layer repeat="EcalBarrelImagingLayers_num-1" vis="EcalBarrelLayerVis"
        space_between="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween"
        space_before="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween/2.">

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -39,6 +39,7 @@
     <constant name="EcalBarrel_FiberRadius"          value="0.5*mm"/>
     <constant name="EcalBarrel_FiberXSpacing"        value="1.34*mm"/>
     <constant name="EcalBarrel_FiberZSpacing"        value="1.22*mm"/>
+    <constant name="EcalBarrel_CladdingThickness"    value="0.04*mm"/>
     <constant name="EcalBarrel_SpaceBetween"         value="0.1*mm"/>
     <comment>
       For Pb/SiFi (GlueX):  X0 ~ 1.45 cm
@@ -154,6 +155,7 @@
           <fiber material="SciFiPb_Scintillator"
             sensitive="yes"
             radius="EcalBarrel_FiberRadius"
+            cladding_thickness="EcalBarrel_CladdingThickness"
             spacing_x="EcalBarrel_FiberXSpacing"
             spacing_z="EcalBarrel_FiberZSpacing"
             vis="EcalBarrelFiberLayerVis">
@@ -170,6 +172,7 @@
           <fiber material="SciFiPb_Scintillator"
             sensitive="yes"
             radius="EcalBarrel_FiberRadius"
+            cladding_thickness="EcalBarrel_CladdingThickness"
             spacing_x="EcalBarrel_FiberXSpacing"
             spacing_z="EcalBarrel_FiberZSpacing"
             vis="EcalBarrelFiberLayerVis">

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -45,8 +45,8 @@
       For Pb/SiFi (GlueX):  X0 ~ 1.45 cm
       For W/SiFi (sPHENIX): X0 ~ 0.7 cm (but different fiber orientation)
     </comment>
-    <constant name="EcalBarrel_RadiatorThickness"    value="EcalBarrel_FiberZSpacing*16"/>
-    <constant name="EcalBarrel_TotalFiberLayers_num" value="16"/>
+    <constant name="EcalBarrel_RadiatorThickness"    value="EcalBarrel_FiberZSpacing*17"/>
+    <constant name="EcalBarrel_TotalFiberLayers_num" value="15"/>
     <constant name="EcalBarrel_ModRepeat"            value="EcalBarrelStavesN"/>
     <constant name="EcalBarrel_ModLength"            value="0.5*m"/>
     <constant name="EcalBarrel_ModWidth"             value="0.5*m"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR implements the cladding of the Sci Fibers in the SciFi/Pb barrel Calorimeter. Now the fibers are implemented in assemblies of fiber cores (sensitive) and cladding (insensitive) and placed inside the lead slice. This resulted in the fastest geometry implementation I could achieve (no significant change wrt the previous implementation).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [x] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No

### Does this PR change default behavior?

No