### PR TITLE
Ensure magnetic fields and other artifacts are retrieved from cache

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -232,7 +232,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
-        network_types: "none"
+        network_types: "bridge" # this job must succeed even when new artifacts
         setup: install/setup.sh
         run: |
           mkdir -p doc
@@ -253,7 +253,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
-        network_types: "none"
+        network_types: "bridge" # this job must succeed even when new artifacts
         setup: install/setup.sh
         run: |
           mkdir -p doc

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -274,7 +274,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
-        network_types: "none"
+        network_types: "bridge" # this job must succeed even when new artifacts
         setup: install/setup.sh
         run: |
           mkdir -p doc

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -53,6 +53,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
+        network_types: "none"
         run: |
           PREFIX=${PWD}/install
           # install ip6 repo
@@ -110,6 +111,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
+        network_types: "none"
         setup: install/setup.sh
         run: |
           root -b -q "scripts/test_ACTS.cxx+(\"${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml\")" | tee check_tracking_geometry.out
@@ -128,6 +130,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
+        network_types: "none"
         setup: install/setup.sh
         run: |
           mkdir -p geo
@@ -151,6 +154,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
+        network_types: "none"
         setup: install/setup.sh
         run: |
           mkdir -p geo
@@ -174,6 +178,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
+        network_types: "none"
         setup: install/setup.sh
         run: |
           mkdir -p doc
@@ -197,6 +202,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
+        network_types: "none"
         setup: install/setup.sh
         run: |
           mkdir -p doc
@@ -226,6 +232,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
+        network_types: "none"
         setup: install/setup.sh
         run: |
           mkdir -p doc
@@ -246,6 +253,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
+        network_types: "none"
         setup: install/setup.sh
         run: |
           mkdir -p doc
@@ -266,6 +274,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
+        network_types: "none"
         setup: install/setup.sh
         run: |
           mkdir -p doc
@@ -286,6 +295,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
+        network_types: "none"
         setup: install/setup.sh
         run: |
           mkdir -p doc
@@ -338,6 +348,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
+        network_types: "none"
         setup: install/setup.sh
         run: |
           bin/generate_prim_file -o prim -D -t detector_view
@@ -365,6 +376,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
+        network_types: "none"
         run: |
           mkdir -p images
           bin/make_dawn_views -i prim/detector_view.prim -t ${{ matrix.view }} -d scripts/${{ matrix.view }} -D
@@ -392,6 +404,7 @@ jobs:
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
+        network_types: "none"
         run: |
           mkdir -p images
           bin/make_dawn_views -i prim/detector_view.prim -t ${{ matrix.view }} -d scripts/${{ matrix.view }} -D -- ${{ matrix.slice }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -67,6 +67,9 @@ jobs:
           cmake --build build -- install
           # link ip6 into install
           ln -sf ../ip6/ip6 ${PREFIX}/share/epic/ip6
+          # link artifacts into install
+          ln -sf /opt/detector/epic-nightly/share/epic/fieldmaps ${PREFIX}/share/epic/fieldmaps
+          ln -sf /opt/detector/epic-nightly/share/epic/calibrations ${PREFIX}/share/epic/calibrations
     - uses: actions/upload-artifact@v3
       with:
         name: build-full-eic-shell

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -67,9 +67,6 @@ jobs:
           cmake --build build -- install
           # link ip6 into install
           ln -sf ../ip6/ip6 ${PREFIX}/share/epic/ip6
-          # link artifacts into install
-          ln -sf /opt/detector/epic-nightly/share/epic/fieldmaps ${PREFIX}/share/epic/fieldmaps
-          ln -sf /opt/detector/epic-nightly/share/epic/calibrations ${PREFIX}/share/epic/calibrations
     - uses: actions/upload-artifact@v3
       with:
         name: build-full-eic-shell

--- a/compact/solenoid.xml
+++ b/compact/solenoid.xml
@@ -329,6 +329,7 @@
     <field type="epic_FieldMapBrBz" name="GlobalSolenoid" field_type="magnetic"
            field_map="fieldmaps/sPHENIX.2d.dat"
            url="https://eicweb.phy.anl.gov/EIC/detectors/ecce/uploads/f8d8ab9f8d8353a84862584bf1d2d27f/sPHENIX.2d.dat"
+           cache="$DETECTOR_PATH"
            scale="1.0">
       <dimensions>
         <transverse step="2.0*cm" rmin="0*cm" rmax="300*cm" />

--- a/compact/solenoid.xml
+++ b/compact/solenoid.xml
@@ -329,7 +329,7 @@
     <field type="epic_FieldMapBrBz" name="GlobalSolenoid" field_type="magnetic"
            field_map="fieldmaps/sPHENIX.2d.dat"
            url="https://eicweb.phy.anl.gov/EIC/detectors/ecce/uploads/f8d8ab9f8d8353a84862584bf1d2d27f/sPHENIX.2d.dat"
-           cache="$DETECTOR_PATH"
+           cache="$DETECTOR_PATH:/opt/detector"
            scale="1.0">
       <dimensions>
         <transverse step="2.0*cm" rmin="0*cm" rmax="300*cm" />

--- a/compact/tracker.xml
+++ b/compact/tracker.xml
@@ -133,7 +133,7 @@
   </documentation>
   <plugins>
     <plugin name="epic_FileLoader">
-      <arg value="cache:${DETECTOR_PATH}"/>
+      <arg value="cache:$DETECTOR_PATH:/opt/detector"/>
       <arg value="file:calibrations/materials-map.cbor"/>
       <arg value="url:https://eicweb.phy.anl.gov/EIC/detectors/athena/uploads/56b64d544442a93904488e7292aa509d/material-maps.cbor"/>
     </plugin>

--- a/compact/tracker.xml
+++ b/compact/tracker.xml
@@ -133,7 +133,7 @@
   </documentation>
   <plugins>
     <plugin name="epic_FileLoader">
-      <arg value="cache:$DETECTOR_PATH"/>
+      <arg value="cache:${DETECTOR_PATH}"/>
       <arg value="file:calibrations/materials-map.cbor"/>
       <arg value="url:https://eicweb.phy.anl.gov/EIC/detectors/athena/uploads/56b64d544442a93904488e7292aa509d/material-maps.cbor"/>
     </plugin>

--- a/src/FieldMapBrBz.cpp
+++ b/src/FieldMapBrBz.cpp
@@ -183,10 +183,11 @@ static Ref_t create_field_map_brbz(Detector& /*lcdd*/, xml::Handle_t handle)
   xml_comp_t r_dim = x_dim.child(_Unicode(transverse));
   xml_comp_t z_dim = x_dim.child(_Unicode(longitudinal));
 
-  std::string field_map_file = x_par.attr<std::string>(_Unicode(field_map));
-  std::string field_map_url  = x_par.attr<std::string>(_Unicode(url));
+  std::string field_map_file  = x_par.attr<std::string>(_Unicode(field_map));
+  std::string field_map_url   = x_par.attr<std::string>(_Unicode(url));
+  std::string field_map_cache = getAttrOrDefault<std::string>(x_par, _Unicode(cache), "");
 
-  EnsureFileFromURLExists(field_map_url, field_map_file);
+  EnsureFileFromURLExists(field_map_url, field_map_file, field_map_cache);
 
   double field_map_scale = x_par.attr<double>(_Unicode(scale));
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of downloading artifacts, we should use the cached versions. This ensures that is the case for
- magnetic field maps,
- tracking material maps,
- any other potential large artifacts.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #181)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.