### PR TITLE
Hotfix: Add B0ECal system id to definitions

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -259,7 +259,8 @@ The unused IDs below are saved for future use.
     <constant name="ZDC_PbSi_ID"                 value="166"/>
     <constant name="ZDC_PbSci_ID"                value="167"/>
     <constant name="VacuumMagnetElement_1_ID"        value="168"/>
-
+    <constant name="B0ECal_ID" value="169"/>
+    
     <documentation>
       #### (170-189) Far Forward Beamline Magnets
     </documentation>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Add B0ECal system id to definitions

### What kind of change does this PR introduce?
- [X] Bug fix (issue: B0 Ecal ID is used by ip6 but not defined here)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators @rahmans1 @veprbl 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.