### PR TITLE
feat: update solenoid offset and length

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -374,10 +374,10 @@ Examples:
     </documentation>
 
     <comment>Solenoid option (BaBar magnet)</comment>
-    <constant name="Solenoid_length"           value="3790.0*mm"/>
+    <constant name="Solenoid_length"           value="3840.0*mm"/>
     <constant name="Solenoid_rmin"             value="1420.0*mm"/>
     <constant name="Solenoid_thickness"        value="350*mm"/>
-    <constant name="Solenoid_offset"           value="0*mm"/>
+    <constant name="Solenoid_offset"           value="-100*mm"/>
 
     <comment>Solenoid option (ATHENA design)</comment>
     <comment>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The solenoid is now slightly longer (5 cm) and shifted to the backward region by -10 cm, according to https://eic.jlab.org/Geometry/Detector/Detector-20220929172703.html. The magnetic field remains unchanged.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #201)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, slightly different solenoid material locations.