### PR TITLE
MPGDDIRC: fix compilation error and some format strings

### DIFF
--- a/src/BarrelTrackerWithFrame_geo.cpp
+++ b/src/BarrelTrackerWithFrame_geo.cpp
@@ -62,8 +62,7 @@ static Ref_t create_BarrelTrackerWithFrame(Detector& description, xml_h e, Sensi
   map<string, std::vector<VolPlane>> volplane_surfaces;
   map<string, std::array<double, 2>> module_thicknesses;
 
-  PlacedVolume           pv;
-  dd4hep::xml::Dimension dimensions(x_det.dimensions());
+  PlacedVolume pv;
 
   // ACTS extension
   {
@@ -77,8 +76,9 @@ static Ref_t create_BarrelTrackerWithFrame(Detector& description, xml_h e, Sensi
     sdet.addExtension<Acts::ActsExtension>(detWorldExt);
   }
 
-  //Tube topVolumeShape(dimensions.rmin(), dimensions.rmax(), dimensions.length() * 0.5);
-  //Volume assembly(det_name,topVolumeShape,air);
+  // dd4hep::xml::Dimension dimensions(x_det.dimensions());
+  // Tube topVolumeShape(dimensions.rmin(), dimensions.rmax(), dimensions.length() * 0.5);
+  // Volume assembly(det_name,topVolumeShape,air);
   Assembly assembly(det_name);
 
   sens.setType("tracker");
@@ -153,7 +153,7 @@ static Ref_t create_BarrelTrackerWithFrame(Detector& description, xml_h e, Sensi
       double frame_width     = m_frame.width();
       double frame_height    = getAttrOrDefault<double>(m_frame, _U(height), 5.0 * mm);
       double tanth           = frame_height / (frame_width / 2.0);
-      double costh           = 1./sqrt(1+tanth*tanth);
+      double costh           = 1. / sqrt(1 + tanth * tanth);
       double frame_height2   = frame_height - frame_thickness - frame_thickness / costh;
       double frame_width2    = 2.0 * frame_height2 / tanth;
 
@@ -334,7 +334,7 @@ static Ref_t create_BarrelTrackerWithFrame(Detector& description, xml_h e, Sensi
     }
     // Create the PhysicalVolume for the layer.
     pv = assembly.placeVolume(lay_vol, lay_pos); // Place layer in mother
-    pv.addPhysVolID("layer", lay_id);   // Set the layer ID.
+    pv.addPhysVolID("layer", lay_id);            // Set the layer ID.
     lay_elt.setAttributes(description, lay_vol, x_layer.regionStr(), x_layer.limitsStr(), x_layer.visStr());
     lay_elt.setPlacement(pv);
   }

--- a/src/MPGDDIRC_geo.cpp
+++ b/src/MPGDDIRC_geo.cpp
@@ -123,13 +123,13 @@ static Ref_t create_MPGDDIRC_geo(Detector& description, xml_h e, SensitiveDetect
         max_component_length = box_length;
         gas_thickness += x_comp.thickness();
         c_box = {box_width / 2, box_length / 2, x_comp.thickness() / 2};
-        printout(DEBUG, "MPGDDIRC_geo", "gas: %f", comp_name);
+        printout(DEBUG, "MPGDDIRC_geo", "gas: %s", comp_name.c_str());
         printout(DEBUG, "MPGDDIRC_geo", "box_width: %f", box_width);
-        printout(DEBUG, "MPGDDIRC_geo", "box_length: %%f", box_length);
+        printout(DEBUG, "MPGDDIRC_geo", "box_length: %f", box_length);
         printout(DEBUG, "MPGDDIRC_geo", "box_thickness: %f", x_comp.thickness());
       } else {
         c_box = {x_comp.width() / 2, x_comp.length() / 2, x_comp.thickness() / 2};
-        printout(DEBUG, "MPGDDIRC_geo", "Not gas: %f", comp_name);
+        printout(DEBUG, "MPGDDIRC_geo", "Not gas: %s", comp_name.c_str());
         printout(DEBUG, "MPGDDIRC_geo", "box_comp_width: %f", x_comp.width());
         printout(DEBUG, "MPGDDIRC_geo", "box_comp_length: %f", x_comp.length());
         printout(DEBUG, "MPGDDIRC_geo", "box_comp_thickness: %f", x_comp.thickness());

--- a/src/TrapEndcapTracker_geo.cpp
+++ b/src/TrapEndcapTracker_geo.cpp
@@ -126,7 +126,6 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       total_thickness += xml_comp_t(ci).thickness();
 
     double    thickness_so_far = 0.0;
-    double    thickness_sum    = -total_thickness / 2.0;
     double    y1               = total_thickness / 2;
     double    y2               = total_thickness / 2;
     Trapezoid m_solid(x1, x2, y1, y2, z);
@@ -208,7 +207,6 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
         //--------------------------------------------
       }
       posY += c_thick;
-      thickness_sum += c_thick;
       thickness_so_far += c_thick;
     }
     modules[m_nam] = m_volume;


### PR DESCRIPTION
```output
src/MPGDDIRC_geo.cpp:126:52: error: cannot pass object of non-trivial type 'std::__1::string' (aka 'basic_string<char, char_traits<char>, allocator<char>>') through variadic function; call will abort at runtime [-Wnon-pod-varargs]
        printout(DEBUG, "MPGDDIRC_geo", "gas: %f", comp_name);
                                                   ^
```
### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
