### PR TITLE
update backward silicon disk positions

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -442,3 +442,43 @@ jobs:
         if-no-files-found: error
 
 #TODO view20
+
+  build-artifacts-page:
+    runs-on: ubuntu-latest
+    needs:
+    - dawn-view
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: view1
+        path: html/
+    - uses: actions/download-artifact@v3
+      with:
+        name: view2
+        path: html/
+    - uses: actions/upload-artifact@v3
+      with:
+        name: artifacts-page
+        path: html/
+        if-no-files-found: error
+    - uses: actions/upload-pages-artifact@v1
+      if: github.ref == 'refs/heads/main'
+      with:
+        path: html/
+        retention-days: 7
+
+  deploy-artifacts-page:
+    needs:
+    - build-artifacts-page
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,6 @@ common:setup:
   before_script:
     - git clone https://eicweb.phy.anl.gov/EIC/benchmarks/common_bench.git setup
   script:
-    - export JUGGLER_DETECTOR="ecce"
     - |
       #      if [[ "x${CI_PIPELINE_SOURCE}" == "xmerge_request_event"  || "$CI_COMMIT_BRANCH" == "main" ]]; then
         export JUGGLER_DETECTOR_VERSION="${CI_COMMIT_REF_NAME}"
@@ -153,7 +152,7 @@ detector_documentation:
     - mkdir -p doc
     - bash bin/build_documentation | tee doc/detector.md
       #- |
-      #  xmllint --format --xpath '//comment/text()' ${DETECTOR_PATH}/ecce.xml | sed -re 's/<\/?\w+>//g' | sed 's/^[[:space:]]*#/#/' | tee  doc/detector.md
+      #  xmllint --format --xpath '//comment/text()' ${DETECTOR_PATH}/epic.xml | sed -re 's/<\/?\w+>//g' | sed 's/^[[:space:]]*#/#/' | tee  doc/detector.md
       #  xmllint --format --xpath '//comment/text()' ${DETECTOR_PATH}/ip6/definitions.xml | sed -re 's/<\/?\w+>//g' | sed 's/^[[:space:]]*#/#/' | tee -a doc/detector.md || true
       #  for afile in ${DETECTOR_PATH}/compact/*.xml ; do
       #    xmllint --format --xpath '//comment/text()' ${afile} | sed -re 's/<\/?\w+>//g' | sed 's/^[[:space:]]*#/#/' | tee -a doc/detector.md || true
@@ -187,14 +186,14 @@ dump_constants:
   needs:
     - ["common:detector"]
   script:
-    - npdet_info dump ${DETECTOR_PATH}/ecce.xml | tee doc/constants.out
+    - npdet_info dump ${DETECTOR_PATH}/epic.xml | tee doc/constants.out
 
 dump_parameter_table:
   stage: test
   needs:
     - ["common:detector"]
   script:
-    - npdet_info dump ${DETECTOR_PATH}/ecce.xml | grep -v '^\s' | grep '=' | cut -d= -f1-2 | tee doc/constants.toml
+    - npdet_info dump ${DETECTOR_PATH}/epic.xml | grep -v '^\s' | grep '=' | cut -d= -f1-2 | tee doc/constants.toml
     - python bin/make_detector_parameter_table
 
 overlap_check_tgeo:
@@ -205,7 +204,7 @@ overlap_check_tgeo:
     ## disable fibers in ECAL for normal overlap check
     - sed -i '/<fiber/,+6d' ${DETECTOR_PATH}/compact/ecal_barrel_interlayers.xml
     - sed -i '/<fiber/,+4d' ${DETECTOR_PATH}/ip6/far_forward/ZDC_Ecal_WSciFi.xml
-    - checkOverlaps -c ${DETECTOR_PATH}/ecce.xml  | tee doc/overlap_check_tgeo.out
+    - checkOverlaps -c ${DETECTOR_PATH}/epic.xml  | tee doc/overlap_check_tgeo.out
     - echo "$(cat doc/overlap_check_tgeo.out | grep ovlp | wc -l) overlaps..."
     - if [[ "$(cat doc/overlap_check_tgeo.out | grep ovlp | wc -l)" -gt "0" ]] ; then echo "Overlaps exist!" && false ; fi
 
@@ -220,7 +219,7 @@ overlap_check_geant4:full_fast:
     ## reduce the number of fibers in Hadron EMCal for overlap check
     ## not needed, as we are running with a different setup now
     #- sed -i 's/radius="EcalEndcapP_FiberRadius"/radius="EcalEndcapP_FiberRadius*10"/' ${DETECTOR_PATH}/compact/ci_ecal_scfi.xml
-    - python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/ecce.xml | tee doc/overlap_check_geant4.out
+    - python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/epic.xml | tee doc/overlap_check_geant4.out
     - echo "$(cat doc/overlap_check_geant4.out | grep GeomVol1002 | wc -l) overlaps..."
     - if [[ "$(cat doc/overlap_check_geant4.out | grep GeomVol1002 | wc -l)" -gt "0" ]] ; then echo "Overlaps exist!" && false ; fi
 
@@ -231,7 +230,7 @@ overlap_check_geant4:inner_detector:
   needs:
     - ["common:detector"]
   script:
-    - python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/ecce_inner_detector.xml | tee doc/overlap_check_geant4.out
+    - python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/epic_inner_detector.xml | tee doc/overlap_check_geant4.out
     - echo "$(cat doc/overlap_check_geant4.out | grep GeomVol1002 | wc -l) overlaps..."
     - if [[ "$(cat doc/overlap_check_geant4.out | grep GeomVol1002 | wc -l)" -gt "0" ]] ; then echo "Overlaps exist!" && false ; fi
 
@@ -241,14 +240,14 @@ convert_to_gdml:
     - ["common:detector"]
   script:
     - mkdir -p geo
-    - python scripts/convert_to_gdml.py --compact ${DETECTOR_PATH}/ecce.xml --output geo/ecce.gdml
+    - python scripts/convert_to_gdml.py --compact ${DETECTOR_PATH}/epic.xml --output geo/epic.gdml
 
 tracking_geometry_debug:
   stage: test
   needs:
     - ["common:detector"]
   script:
-    - root -b -q "scripts/test_ACTS.cxx+(\"${DETECTOR_PATH}/ecce.xml\")" | tee geo/tracking_geometry_debug.out
+    - root -b -q "scripts/test_ACTS.cxx+(\"${DETECTOR_PATH}/epic.xml\")" | tee geo/tracking_geometry_debug.out
     - ./bin/acts_geo_check geo/tracking_geometry_debug.out
 
 detector:config_testing:
@@ -256,7 +255,7 @@ detector:config_testing:
   needs:
     - ["common:detector"]
   script:
-    - checkOverlaps -o 's' -c ${DETECTOR_PATH}/ecce.xml  | tee doc/overlap_check.out | wc -l
+    - checkOverlaps -o 's' -c ${DETECTOR_PATH}/epic.xml  | tee doc/overlap_check.out | wc -l
     - cat doc/overlap_check.out
 
 benchmarks:detector:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ PROJECT(epic
   DESCRIPTION "DD4hep Geometry Description of the EPIC Experiment"
   )
 
-option(EPIC_ECCE_LEGACY_COMPAT "Preserve some compatibility with ECCE" OFF)
-
 # C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "Set the C++ standard to be used")
@@ -76,9 +74,6 @@ dd4hep_add_plugin(${a_lib_name}
 target_link_libraries(${a_lib_name}
   PUBLIC ${DD4hep_required_libraries} fmt::fmt
   )
-if(EPIC_ECCE_LEGACY_COMPAT)
-  target_compile_definitions(${a_lib_name} PUBLIC EPIC_ECCE_LEGACY_COMPAT)
-endif()
 
 #-----------------------------------------------------------------------------------
 # Parse jinja templates: once by default, and once for all yml files
@@ -131,16 +126,6 @@ install(DIRECTORY compact/
 install(DIRECTORY calibrations/
     DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/calibrations
     )
-
-# Handle ECCE compatibility mode
-if(EPIC_ECCE_LEGACY_COMPAT)
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ./${PROJECT_NAME} ${CMAKE_INSTALL_PREFIX}/share/ecce)")
-  set(EPIC_ECCE_ORIGINAL_CONFIGURATIONS 18x275 calorimeters central dirc_only drich_only full imaging inner_detector ip6 pfrich_only pid_only sciglass tof_only tracking_only vertex_only)
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ./${PROJECT_NAME}.xml ${CMAKE_INSTALL_PREFIX}/share/ecce/ecce.xml)")
-  foreach(ecce_configuration ${EPIC_ECCE_ORIGINAL_CONFIGURATIONS})
-    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ./${PROJECT_NAME}_${ecce_configuration}.xml ${CMAKE_INSTALL_PREFIX}/share/ecce/ecce_${ecce_configuration}.xml)")
-  endforeach()
-endif()
 
 #-----------------------------------------------------------------------------------
 # Configure and install detector setup script

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -95,53 +95,54 @@ The unused IDs below are saved for future use.
     <constant name="TrackerSubAssembly_3_ID"      value="43"/>
     <constant name="TrackerSubAssembly_4_ID"      value="44"/>
     <constant name="TrackerSubAssembly_5_ID"      value="45"/>
+    <constant name="TrackerSubAssembly_6_ID"      value="46"/>
 
-    <constant name="TrackerCompositeBarrel_0_ID"  value="46"/>
-    <constant name="TrackerCompositeBarrel_1_ID"  value="47"/>
-    <constant name="TrackerCompositeBarrel_2_ID"  value="48"/>
-    <constant name="TrackerCompositeBarrel_3_ID"  value="49"/>
-    <constant name="TrackerCompositeEndcapN_0_ID" value="50"/>
-    <constant name="TrackerCompositeEndcapN_1_ID" value="51"/>
-    <constant name="TrackerCompositeEndcapN_2_ID" value="52"/>
-    <constant name="TrackerCompositeEndcapN_3_ID" value="53"/>
-    <constant name="TrackerCompositeEndcapP_0_ID" value="54"/>
-    <constant name="TrackerCompositeEndcapP_1_ID" value="55"/>
-    <constant name="TrackerCompositeEndcapP_2_ID" value="56"/>
-    <constant name="TrackerCompositeEndcapP_3_ID" value="57"/>
+    <constant name="TrackerCompositeBarrel_0_ID"  value="47"/>
+    <constant name="TrackerCompositeBarrel_1_ID"  value="48"/>
+    <constant name="TrackerCompositeBarrel_2_ID"  value="49"/>
+    <constant name="TrackerCompositeBarrel_3_ID"  value="50"/>
+    <constant name="TrackerCompositeEndcapN_0_ID" value="51"/>
+    <constant name="TrackerCompositeEndcapN_1_ID" value="52"/>
+    <constant name="TrackerCompositeEndcapN_2_ID" value="53"/>
+    <constant name="TrackerCompositeEndcapN_3_ID" value="54"/>
+    <constant name="TrackerCompositeEndcapP_0_ID" value="55"/>
+    <constant name="TrackerCompositeEndcapP_1_ID" value="56"/>
+    <constant name="TrackerCompositeEndcapP_2_ID" value="57"/>
+    <constant name="TrackerCompositeEndcapP_3_ID" value="58"/>
 
-    <constant name="TrackerBarrel_0_ID"           value="58"/>
-    <constant name="TrackerBarrel_1_ID"           value="59"/>
-    <constant name="TrackerBarrel_2_ID"           value="60"/>
-    <constant name="TrackerBarrel_3_ID"           value="61"/>
-    <constant name="TrackerBarrel_4_ID"           value="62"/>
-    <constant name="TrackerBarrel_5_ID"           value="63"/>
-    <constant name="TrackerBarrel_6_ID"           value="64"/>
-    <constant name="TrackerBarrel_7_ID"           value="65"/>
-    <constant name="TrackerBarrel_8_ID"           value="66"/>
-    <constant name="TrackerEndcapN_0_ID"          value="67"/>
-    <constant name="TrackerEndcapN_1_ID"          value="68"/>
-    <constant name="TrackerEndcapN_2_ID"          value="69"/>
-    <constant name="TrackerEndcapN_3_ID"          value="70"/>
-    <constant name="TrackerEndcapN_4_ID"          value="71"/>
-    <constant name="TrackerEndcapN_5_ID"          value="72"/>
-    <constant name="TrackerEndcapN_6_ID"          value="73"/>
-    <constant name="TrackerEndcapN_7_ID"          value="74"/>
-    <constant name="TrackerEndcapN_8_ID"          value="75"/>
-    <constant name="TrackerEndcapP_0_ID"          value="76"/>
-    <constant name="TrackerEndcapP_1_ID"          value="77"/>
-    <constant name="TrackerEndcapP_2_ID"          value="78"/>
-    <constant name="TrackerEndcapP_3_ID"          value="79"/>
-    <constant name="TrackerEndcapP_4_ID"          value="80"/>
-    <constant name="TrackerEndcapP_5_ID"          value="81"/>
-    <constant name="TrackerEndcapP_6_ID"          value="82"/>
-    <constant name="TrackerEndcapP_7_ID"          value="83"/>
-    <constant name="TrackerEndcapP_8_ID"          value="84"/>
-    <constant name="MPGDDIRC_0_ID"                value="85"/>
+    <constant name="TrackerBarrel_0_ID"           value="59"/>
+    <constant name="TrackerBarrel_1_ID"           value="60"/>
+    <constant name="TrackerBarrel_2_ID"           value="61"/>
+    <constant name="TrackerBarrel_3_ID"           value="62"/>
+    <constant name="TrackerBarrel_4_ID"           value="63"/>
+    <constant name="TrackerBarrel_5_ID"           value="64"/>
+    <constant name="TrackerBarrel_6_ID"           value="65"/>
+    <constant name="TrackerBarrel_7_ID"           value="66"/>
+    <constant name="TrackerBarrel_8_ID"           value="67"/>
+    <constant name="TrackerEndcapN_0_ID"          value="68"/>
+    <constant name="TrackerEndcapN_1_ID"          value="69"/>
+    <constant name="TrackerEndcapN_2_ID"          value="70"/>
+    <constant name="TrackerEndcapN_3_ID"          value="71"/>
+    <constant name="TrackerEndcapN_4_ID"          value="72"/>
+    <constant name="TrackerEndcapN_5_ID"          value="73"/>
+    <constant name="TrackerEndcapN_6_ID"          value="74"/>
+    <constant name="TrackerEndcapN_7_ID"          value="75"/>
+    <constant name="TrackerEndcapN_8_ID"          value="76"/>
+    <constant name="TrackerEndcapP_0_ID"          value="77"/>
+    <constant name="TrackerEndcapP_1_ID"          value="78"/>
+    <constant name="TrackerEndcapP_2_ID"          value="79"/>
+    <constant name="TrackerEndcapP_3_ID"          value="80"/>
+    <constant name="TrackerEndcapP_4_ID"          value="81"/>
+    <constant name="TrackerEndcapP_5_ID"          value="82"/>
+    <constant name="TrackerEndcapP_6_ID"          value="83"/>
+    <constant name="TrackerEndcapP_7_ID"          value="84"/>
+    <constant name="TrackerEndcapP_8_ID"          value="85"/>
+    <constant name="MPGDDIRC_0_ID"                value="86"/>
 
     <documentation>
-    #### (86-99) Reserved IDs
+    #### (87-99) Reserved IDs
 
-    - Unused IDs: 85-89
+    - Unused IDs: 87-89
     TBD
     </documentation>
     <documentation>

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -136,9 +136,10 @@ The unused IDs below are saved for future use.
     <constant name="TrackerEndcapP_6_ID"          value="82"/>
     <constant name="TrackerEndcapP_7_ID"          value="83"/>
     <constant name="TrackerEndcapP_8_ID"          value="84"/>
+    <constant name="MPGDDIRC_0_ID"                value="85"/>
 
     <documentation>
-    #### (85-99) Reserved IDs
+    #### (86-99) Reserved IDs
 
     - Unused IDs: 85-89
     TBD
@@ -260,7 +261,7 @@ The unused IDs below are saved for future use.
     <constant name="ZDC_PbSci_ID"                value="167"/>
     <constant name="VacuumMagnetElement_1_ID"        value="168"/>
     <constant name="B0ECal_ID" value="169"/>
-    
+
     <documentation>
       #### (170-189) Far Forward Beamline Magnets
     </documentation>
@@ -403,7 +404,6 @@ Examples:
 
     <documentation>
       ## Tracking Detector Parameters
-
     </documentation>
 
     <documentation>
@@ -424,7 +424,7 @@ Examples:
 
     </documentation>
 
-    <constant name="CentralTrackingRegion_rmax"   value="715.0*mm" />
+    <constant name="CentralTrackingRegion_rmax"   value="700.0*mm" />
     <constant name="CentralTrackingRegionP_zmax"  value="1730.0*mm" />
     <constant name="CentralTrackingRegionN_zmax"  value="1474.7*mm" />
     <constant name="CentralTrackingRegion_length" value="CentralTrackingRegionP_zmax + CentralTrackingRegionN_zmax" />
@@ -475,7 +475,7 @@ Examples:
 
     <comment> Note: PID has space for DIRC, ExtraSpace sits past the PID</comment>
     <constant name="BarrelPIDRegion_thickness"    value="7.0 * cm" />
-    <constant name="BarrelExtraSpace_thickness"   value="1.0 * cm" />
+    <constant name="BarrelExtraSpace_thickness"   value="2.5 * cm" />
 
     <documentation>
     ## Forward/backward tracking region behind the PID detectors
@@ -565,12 +565,13 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
   </documentation>
     <constant name="DIRCReadout_length"         value="30*cm"/>
     <constant name="DIRCForward_length"         value="0*cm"/>
-    <constant name="DIRCForward_zmax"           value="CentralTrackingRegionP_zmax"/>
+    <constant name="DIRCForward_zmax"           value="CentralTrackingRegionP_zmax + 5*cm"/>
     <constant name="DIRCBackward_zmax"          value="287*cm"/>
     <constant name="DIRC_length"                value="DIRCForward_zmax + DIRCBackward_zmax"/>
     <constant name="DIRC_offset"                value="(DIRCForward_zmax - DIRCBackward_zmax)/2"/>
+    <constant name="DIRC_thickness"             value="3*cm"/> <!-- DIRC bar box thickness, not readout -->
     <constant name="DIRC_rmin"                  value="CentralTrackingRegion_rmax"/>
-    <constant name="DIRC_rmax"                  value="DIRC_rmin + BarrelPIDRegion_thickness"/>
+    <constant name="DIRC_rmax"                  value="DIRC_rmin + DIRC_thickness"/>
 
     <documentation>
       ## Hadronic Calorimeter Parameters

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -375,10 +375,10 @@ Examples:
     </documentation>
 
     <comment>Solenoid option (BaBar magnet)</comment>
-    <constant name="Solenoid_length"           value="3790.0*mm"/>
+    <constant name="Solenoid_length"           value="3840.0*mm"/>
     <constant name="Solenoid_rmin"             value="1420.0*mm"/>
     <constant name="Solenoid_thickness"        value="350*mm"/>
-    <constant name="Solenoid_offset"           value="0*mm"/>
+    <constant name="Solenoid_offset"           value="-100*mm"/>
 
     <comment>Solenoid option (ATHENA design)</comment>
     <comment>

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -510,6 +510,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="BackwardServiceGap_zmin"      value="320.0 * cm"/> <!-- FIXME hardcoded -->
     <constant name="BackwardServiceGap_zmax"      value="BackwardServiceGap_zmin + BackwardServiceGap_length"/>
 
+
   <documentation level="3">
 ## Calorimeter Parameters
   </documentation>
@@ -534,8 +535,9 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="EcalEndcapPInsert_hole_xposition" value="-7.29*cm"/>
     <constant name="EcalEndcapPInsert_hole_yposition" value="0.0*cm"/>
 
-    <constant name="EcalEndcapN_zmin"               value="BackwardPIDRegion_zmin + BackwardInnerEndcapRegion_length"/>
-    <constant name="EcalEndcapN_length"             value="60*cm" />
+    <!-- <constant name="EcalEndcapN_zmin"               value="BackwardPIDRegion_zmin + BackwardInnerEndcapRegion_length"/> -->
+    <constant name="EcalEndcapN_zmin"               value="174*cm"/>   <!-- Currently fix value hardcoded -->
+    <constant name="EcalEndcapN_length"             value="60*cm" />   <!-- Currently fix value hardcoded -->
     <constant name="EcalEndcapN_zmax"               value="EcalEndcapN_zmin + EcalEndcapN_length"/>
 
     <comment>
@@ -544,8 +546,8 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     </comment>
     <constant name="EcalEndcapN_rmin1"              value="Eta4_6_tan * EcalEndcapN_zmin"/>
     <constant name="EcalEndcapN_rmin2"              value="Eta3_9_tan * EcalEndcapN_zmin"/>
-    <constant name="EcalEndcapN_rmin"               value="max(EcalEndcapN_rmin1, EcalEndcapN_rmin2)"/>
-    <constant name="EcalEndcapN_rmax"               value="63*cm"/> <!-- FIXME hardcoded -->
+    <constant name="EcalEndcapN_rmin"               value="9.*cm"/>    <!-- Currently fix value hardcoded -->
+    <constant name="EcalEndcapN_rmax"               value="63.*cm"/>   <!-- Currently fix value hardcoded -->
 
     <constant name="EcalBarrelRegion_thickness"     value="54.0*cm"/>
     <constant name="EcalBarrel_rmin"                value="CentralTrackingRegion_rmax + BarrelPIDRegion_thickness + BarrelExtraSpace_thickness"/>
@@ -557,6 +559,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="EcalBarrel_offset"              value="(EcalBarrelForward_zmax - EcalBarrelBackward_zmax)/2.0"/>
     <constant name="EcalBarrelReadout_length"       value="20*cm"/>
 
+    
   <documentation level="3">
     ## Special DIRC parameters (depend on the ECAL setup)
   </documentation>

--- a/compact/dirc.xml
+++ b/compact/dirc.xml
@@ -1,19 +1,18 @@
 <lccdd>
 
   <comment>
-    DIRC consists of 16 (default) identical modules making a barrel.
+    DIRC consists of 12 (default) identical modules making a barrel.
     Each DIRC module consists of:
-    _______
-    [  |   \
-    [  |    \
-    [FD|Prizm|Lens|--------bars+glue-----|mirror]
+    ________
+    [   |   \
+    [   |    \
+    [MCP|Prism|Lens|--------bars+glue-----|mirror]
 
     Main constants to control DIRC global geometry:
       - DIRC_length
       - DIRC_offset
       - DIRC_rmin
-      - DIRCBox_count  (16 full dirc, 1 - a single module)
-      - DIRC_rotation  (allows to flip the DIRC)
+      - DIRCBox_count  (12 full dirc, 1 - a single module)
 
     When DIRC_length is set, it affects bars length (all other lengths are fixed)
     The width of each DIRC module is derived from DIRCPrism_width
@@ -21,27 +20,16 @@
   </comment>
 
   <define>
-    <constant name="DIRCFake_rmin"             value="BarrelTracking_rmax-11*cm"/>
-    <constant name="DIRC_rotation"         value="pi" comment="Allows DIRC flip"/>
-    <!-- <constant name="cb_DIRC_length"    value="DIRCLength"/> -->
-    <!-- CLEANUP THIS if not sure. This is from the initial implementation
-    <constant name="DIRC_length"            value="285.500*cm"/>
-    <constant name="DIRCFake_rmin"              value="82.00*cm"/>-->
-
     <!-- Prism -->
-    <constant name="DIRCPrism_width"        value="360*mm"/>
+    <constant name="DIRCPrism_width"        value="350*mm"/>
     <constant name="DIRCPrism_length"       value="300*mm"/>
     <constant name="DIRCPrism_short_edge"   value="50*mm"/>
     <constant name="DIRCPrism_angle"        value="32*deg"/>
     <constant name="DIRCPrism_long_edge"    value="DIRCPrism_short_edge + DIRCPrism_length * tan(DIRCPrism_angle)"/>
     <constant name="DIRCPrism_height"       value="DIRCPrism_long_edge"/>
 
-    <!-- DIRC length -->
-    <constant name="DIRCMain_length"           value="DIRC_length"/>
-    <constant name="DIRCFake_offset"           value="DIRC_offset+15*cm"/>
-
     <!-- Box - main DIRC modules -->
-    <constant name="DIRCBox_count"          value="16"  comment="Number of DIRC boxes per... DIRC. 16 - default"/>
+    <constant name="DIRCBox_count"          value="12"  comment="Number of DIRC boxes per... DIRC. 12 - default"/>
     <constant name="DIRCBox_width"          value="DIRCPrism_width"/>
 
     <!-- Mirror -->
@@ -50,34 +38,29 @@
     <constant name="DIRCMirror_thickness"   value="1 * mm"/>
 
     <!-- Lens -->
-    <constant name="DIRCLens_height"        value="DIRCPrism_long_edge"/>
-    <constant name="DIRCLens_width"         value="DIRCPrism_width"/>
     <constant name="DIRCLens_thickness"     value="12 * mm"/>
-    <constant name="DIRCLens_r1"            value="33 * mm"/>
-    <constant name="DIRCLens_r2"            value="24 * mm"/>
-    <constant name="DIRCLens_shight"        value="25 * mm" comment="Is 'shight' from UK urban dictionary???"/>
+    <constant name="DIRCLens_r1"            value="62 * mm"/>
+    <constant name="DIRCLens_r2"            value="36 * mm"/>
+    <constant name="DIRCLens_height"        value="50 * mm"/>
+    <constant name="DIRCLens_shift"         value="10 * mm" comment="Shift of optical axis compared to bar center"/>
+    <constant name="DIRCLens_width"         value="DIRCPrism_width"/>
 
-    <!-- FD (Foto detectors?) -->
-    <constant name="DIRCFd_height"          value="DIRCPrism_height"/>
-    <constant name="DIRCFd_width"           value="DIRCPrism_width"/>
-    <constant name="DIRCFd_thickness"       value="1*mm"/>
+    <!-- MCP -->
+    <constant name="DIRCMCP_height"          value="DIRCPrism_height"/>
+    <constant name="DIRCMCP_width"           value="DIRCPrism_width"/>
+    <constant name="DIRCMCP_thickness"       value="1*mm"/>
 
     <!-- Bar - Each DIRC box consists of N "bars" -->
     <!-- BarAssembly - Bars + Glue -->
-    <constant name="DIRCBarAssm_length"     value="DIRCMain_length - DIRCPrism_length - DIRCMirror_thickness - DIRCLens_thickness - DIRCFd_thickness" comment="Length of bars+glue assembly"/>
-    <constant name="DIRCBar_count"          value="11" comment="Number of bars per box"/>
+    <constant name="DIRCBarAssm_length"     value="DIRC_length - DIRCPrism_length - DIRCMirror_thickness - DIRCLens_thickness - DIRCMCP_thickness" comment="Length of bars+glue assembly"/>
+    <constant name="DIRCBar_count_y"        value="10" comment="Number of bars per box in y direction"/>
+    <constant name="DIRCBar_count_z"        value="4" comment="Number of bars per box in z direction"/>
     <constant name="DIRCBar_gap"            value="0.15 * mm"/>
     <constant name="DIRCBar_height"         value="17 * mm"/>
-    <constant name="DIRCBar_width"          value="(DIRCPrism_width - (DIRCBar_count - 1) * DIRCBar_gap) / DIRCBar_count"/>
+    <constant name="DIRCBar_width"          value="(DIRCPrism_width - (DIRCBar_count_y - 1) * DIRCBar_gap) / DIRCBar_count_y"/>
     <constant name="DIRCGlue_thickness"     value="0.05 * mm"/>
-    <constant name="DIRCBar_length"         value="(DIRCBarAssm_length-4*DIRCGlue_thickness)/4"/>
+    <constant name="DIRCBar_length"         value="(DIRCBarAssm_length - 4 * DIRCGlue_thickness)/4"/>
 
-    <!-- dirc outer volume -->
-    <comment>
-      RMax is calculated according to "rectangle inside ring" problem solution
-      https://math.stackexchange.com/questions/4222684/calculate-rectangle-inside-ring-parameters/4222691#4222691
-    </comment>
-    <constant name="DIRCFake_rmax"              value="sqrt( (DIRCFake_rmin+DIRCPrism_height)^2 + 0.25*(DIRCPrism_height)^2 )"/>
   </define>
 
   <materials>
@@ -86,7 +69,6 @@
       See optical_materials.xml for optical ones
       -
     </comment>
-
     <material name="Epotek">
       <D type="density" value="1.2" unit="g/cm3"/>
       <composite n="5" ref="H"/>
@@ -116,15 +98,14 @@
     <vis name="DIRCGlue"   ref="AnlViolet" visible="true"  showDaughters="false"  lineStyle="solid" drawingStyle="solid" />
     <vis name="DIRCMirror" ref="AnlGray" visible="true"  showDaughters="false"  lineStyle="solid" drawingStyle="solid" />
     <vis name="DIRCPrism"  ref="AnlTeal" visible="true"  showDaughters="false"  lineStyle="solid" drawingStyle="solid" />
-    <vis name="DIRCFd"     ref="AnlRed" visible="true"  showDaughters="false" />
+    <vis name="DIRCMCP"    ref="AnlRed" visible="true"  showDaughters="false" />
   </display>
 
   <detectors>
-    <detector id="BarrelDIRC_ID" name="cb_DIRC" type="epic_cb_DIRC" readout="DIRCBarHits" vis="DIRCTube">
-      <dimensions rmin="DIRCFake_rmin" rmax="DIRCFake_rmax" length="DIRCMain_length" radius="DIRCRadius" dx="DIRCBars_DX" dy="DIRCBars_DY" number="DIRCNum" deltaphi="DIRCDPhi"/>
-      <position x="0" y="0" z="DIRCFake_offset"/>
-      <rotation theta="DIRC_rotation"/>
-      <module name="DircBox" R="DIRCRadius" repeat="DIRCBox_count" width="DIRCPrism_width + 1*mm" height="DIRCPrism_height*2" length="DIRCBarAssm_length + 550*mm" vis="DIRCBox">
+    <detector id="BarrelDIRC_ID" name="cb_DIRC" type="epic_DIRC" readout="DIRCBarHits" vis="DIRCTube">
+      <dimensions rmin="DIRC_rmin" rmax="DIRC_rmin + DIRCBar_height" length="DIRC_length"/>
+      <position x="0" y="0" z="DIRC_offset"/>
+      <module name="DIRCBox" repeat="DIRCBox_count" width="DIRCPrism_width + 1*mm" height="DIRCPrism_height*2" length="DIRCBarAssm_length + 550*mm" vis="DIRCBox">
         <!-- Mirror (at the end of the module) -->
         <mirror
           height="DIRCMirror_height"
@@ -140,7 +121,8 @@
           height="DIRCBar_height"
           width="DIRCBar_width"
           length="DIRCBar_length"
-          repeat="DIRCBar_count"
+          repeat_y="DIRCBar_count_y"
+          repeat_z="DIRCBar_count_z"
           gap="DIRCBar_gap"
           material="Quartz"
           vis="DIRCBar"
@@ -152,19 +134,34 @@
         <lens
           height="DIRCLens_height"
           width="DIRCLens_width"
+          shift="DIRCLens_shift"
           thickness="DIRCLens_thickness"
           r1="DIRCLens_r1"
           r2="DIRCLens_r2"
+          material1="Quartz"
+          material2="Nlak33a"
+          material3="Quartz"
+          vis1="DIRCLens1"
+          vis2="DIRCLens2"
+          vis3="DIRCLens3"
         />
 
-        <prism/> <!-- TODO parametrize here -->
-
-        <fd
-          height="DIRCFd_height"
-          width="DIRCFd_width"
-          thickness="DIRCFd_thickness"
-          vis="DIRCFd"
+        <prism
+          width="DIRCPrism_width"
+          length="DIRCPrism_length"
+          angle="DIRCPrism_angle"
+          long_edge="DIRCPrism_long_edge"
+          short_edge="DIRCPrism_short_edge"
           material="Quartz"
+          vis="DIRCPrism"
+        />
+
+        <mcp
+          height="DIRCMCP_height"
+          width="DIRCMCP_width"
+          thickness="DIRCMCP_thickness"
+          material="Quartz"
+          vis="DIRCMCP"
         />
       </module>
     </detector>

--- a/compact/ecal_backward_PbWO4.xml
+++ b/compact/ecal_backward_PbWO4.xml
@@ -2,8 +2,15 @@
   <define>
     <constant name="EcalEndcapN_CrystalModule_width" value="20.00*mm"/>
     <constant name="EcalEndcapN_CrystalModule_length" value="200.00*mm"/>
-    <constant name="EcalEndcapN_CrystalModule_wrap" value="0.50*mm"/>
+    <constant name="EcalEndcapN_CrystalModule_carbon_thickness" value="0.20*mm"/>
+    <constant name="EcalEndcapN_CrystalModule_wrap_thickness" value="0.05*mm"/>
+    <constant name="EcalEndcapN_CrystalModule_carbon_length" value="20.00*mm"/>
 
+    <comment>The size of outer frame</comment>
+    <constant name="EcalEndcapN_structure_ring_length" value="EcalEndcapN_length"/>
+    <constant name="EcalEndcapN_structure_ring_max" value="65.00*cm"/>
+    <constant name="EcalEndcapN_structure_ring_min" value="EcalEndcapN_structure_ring_max - 0.9*cm"/>
+    
     <comment>FIXME currently unused</comment>
     <constant name="EcalEndcapN_IonCutout_dphi" value="30*degree"/>
 
@@ -19,25 +26,45 @@
         name="EcalEndcapN"
         type="epic_HomogeneousCalorimeter"
         readout="EcalEndcapNHits">
-      <position x="0" y="0" z="-(EcalEndcapN_zmin + EcalEndcapN_length/2.)"/>
-      <rotation x="0" y="180.*degree" z="0"/>
+      <position x="0" y="0" z="-(EcalEndcapN_zmin + EcalEndcapN_CrystalModule_length/2.)"/>
+      <rotation x="0" y="0." z="0"/>
       <placements>
-        <disk
+        <disk_12surface
             rmin="EcalEndcapN_rmin"
-            rmax="EcalEndcapN_rmax"
+            rmax="EcalEndcapN_structure_ring_min"
+            r12min="EcalEndcapN_structure_ring_min"
+            r12max="EcalEndcapN_structure_ring_max"
+            SFlength="EcalEndcapN_structure_ring_length"
+            CMlength="EcalEndcapN_CrystalModule_length + 2.*EcalEndcapN_CrystalModule_wrap_thickness" 
             envelope="true"
+            vis_struc="RPVis"
+            vis_steel_gap="AnlGray"
+            ring_material="StainlessSteel"
             sector="1">
           <module
+            gx="EcalEndcapN_CrystalModule_width + 2.*EcalEndcapN_CrystalModule_carbon_thickness + 2.*EcalEndcapN_CrystalModule_wrap_thickness"
+            gy="EcalEndcapN_CrystalModule_width + 2.*EcalEndcapN_CrystalModule_carbon_thickness + 2.*EcalEndcapN_CrystalModule_wrap_thickness"
+            gz="EcalEndcapN_CrystalModule_length"
+            gdz="EcalEndcapN_CrystalModule_wrap_thickness"
+            gmaterial="Vacuum"
+            vis="BlueVis"/>              
+          <crystal
             sizex="EcalEndcapN_CrystalModule_width"
             sizey="EcalEndcapN_CrystalModule_width"
             sizez="EcalEndcapN_CrystalModule_length"
-            vis="EcalEndcapNModuleVis"
-            material="PbWO4"/>
+            material="leadtungsten_optical"
+            cryvis="GreenVis"/>
           <wrapper
-            thickness="EcalEndcapN_CrystalModule_wrap"
-            material="Epoxy"
-            vis="WhiteVis"/>
-        </disk>
+            carbon_thickness="EcalEndcapN_CrystalModule_carbon_thickness"
+            wrap_thickness="EcalEndcapN_CrystalModule_wrap_thickness"
+            length="EcalEndcapN_CrystalModule_carbon_length"  
+            material_carbon="CarbonFiber"
+            material_wrap="VM2000"
+            material_gap="Air"
+            vis_carbon="PurpleVis"
+            vis_wrap="RPVis"
+            vis_gap="AnlGray"/>
+        </disk_12surface>
       </placements>
 
     </detector>

--- a/compact/ecal_barrel_sciglass.xml
+++ b/compact/ecal_barrel_sciglass.xml
@@ -17,7 +17,7 @@
 
   <display>
     <vis name="det_vis" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="false" />
-    <vis name="becal_wedge" alpha="1.1" r="0.82" g="0.84" b="0.86" showDaughters="true" visible="true" />
+    <vis name="becal_wedge" alpha="1.0" r="0.82" g="0.84" b="0.86" showDaughters="true" visible="true" />
     <vis name="carbon_fiber" alpha="0.9" r="0.1" g="0.1" b="0.1" showDaughters="true" visible="true" />
     <vis name="family1" alpha="1.0" r="0.22" g="0.54" b="0.71" showDaughters="true" visible="true" />
     <vis name="family2" alpha="1.0" r="0.90" g="0.48" b="0.47" showDaughters="true" visible="true" />

--- a/compact/ecal_barrel_sciglass.xml
+++ b/compact/ecal_barrel_sciglass.xml
@@ -7,7 +7,11 @@
     <documentation>
       The EcalBarrel eta limits cut into the barrel shape.
     </documentation>
-    <constant name="EcalBarrel_etamin" value="-3.5"/>
+    <comment>
+      The current numbers are not based on any design in particular, but
+      provide some extra space for other detectors.
+    </comment>
+    <constant name="EcalBarrel_etamin" value="-1.9"/>
     <constant name="EcalBarrel_etamax" value="+1.4"/>
   </define>
 
@@ -21,6 +25,7 @@
     <vis name="family4" alpha="1.0" r="0.94" g="0.48" b="0.73" showDaughters="true" visible="true" />
     <vis name="family5" alpha="1.0" r="0.44" g="0.63" b="0.44" showDaughters="true" visible="true" />
     <vis name="family6" alpha="1.0" r="0.50" g="0.35" b="0.76" showDaughters="true" visible="true" />
+    <vis name="family7" alpha="1.0" r="0.76" g="0.35" b="0.50" showDaughters="true" visible="true" />
   </display>
 
   <detectors>
@@ -66,10 +71,18 @@
           <family dir_sign="-1" x1="2 * cm" y1="2 * cm" z_length="45.5 * cm" number="5"  flare_angle_polar="0.82 * degree"  flare_angle_at_face="1.0258 * degree" vis="family4" />
           <family dir_sign="-1" x1="2 * cm" y1="2 * cm" z_length="45.5 * cm" number="5"  flare_angle_polar="0.70 * degree"  flare_angle_at_face="1.126 * degree"  vis="family5" />
           <family dir_sign="-1" x1="2 * cm" y1="2 * cm" z_length="45.5 * cm" number="6"  flare_angle_polar="0.586 * degree" flare_angle_at_face="1.1914 * degree" vis="family6" />
+          <comment>
+            Family 7 is not based on any design in particular. The polar
+            flaring angle was adjusted according to the trend to avoid overlaps
+            and provide gaps needed to place the supports.
+          </comment>
+          <family dir_sign="-1" x1="2 * cm" y1="2 * cm" z_length="45.5 * cm" number="2"  flare_angle_polar="0.46 * degree" flare_angle_at_face="1.1914 * degree" vis="family7" />
         </rows>
 
+        <documentation>
+          This describes the carbon fiber supports that are placed in the gaps between the towers.
+        </documentation>
         <comment>
-          The gaps between towers contain fiber support.
           In current geometry, the supports are represented by double-thickness layers shared between towers.
           As Air-gapped towers are preferred, cut outs are implemented with margins that were roughly estimated from a preliminary CAD drawing.
         </comment>

--- a/compact/optical_materials.xml
+++ b/compact/optical_materials.xml
@@ -258,6 +258,10 @@
       4.75035*eV   1.85713
       4.93961*eV   1.87039
       "/>
+    <matrix name="RINDEX__VM2000" coldim="2" values="
+      1.37760*eV   1.42
+      4.13281*eV   1.42
+      "/>
     <matrix name="ABSLENGTH__DIRCNlak33a" coldim="2" values="
       1.0*eV       371813*mm
       1.2511*eV    352095*mm
@@ -802,6 +806,31 @@
         Nlak33aMaterial->AddElement(O, natoms = 2);
       -->
     </material>
+    <material name="VM2000">
+      <D type="density" value="1.43" unit="g / cm3"/>
+      <composite n="2" ref="C"/>
+      <composite n="2" ref="H"/>
+      <composite n="2" ref="F"/>
+      <property name="RINDEX" ref="RINDEX__VM2000"/>
+      <property name="REFLECTIVITY" coldim="2"
+                values="1.776*eV  0.95
+                        4.143*eV  0.95"/>
+    </material>
+    <material name="leadtungsten_optical">
+      <D type="density" value="8.3" unit="g / cm3"/>
+      <composite n="1" ref="Pb"/>
+      <composite n="1" ref="W"/>
+      <composite n="4" ref="O"/>
+      <property name="RINDEX" coldim="2"
+                values="1.551*eV  2.4
+                        3.545*eV  2.40"/>
+      <property name="ABSLENGTH" coldim="2"
+                values="1.551*eV  200.0*cm
+                        3.545*eV  200.0*cm"/>
+      <property name="SCINTILLATIONYIELD1"  value="200.0/MeV"/>
+      <property name="SCINTILLATIONTIMECONSTANT1"    value="6.0*ns"/>
+      <property name="RESOLUTIONSCALE"     value="1.0"/>
+    </material>        
   </materials>
   <surfaces>
     <opticalsurface finish="polished" model="glisur" name="MirrorOpticalSurface" type="dielectric_metal" value="0">

--- a/compact/tof_barrel.xml
+++ b/compact/tof_barrel.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd>
+<info name="tof_barrel.xml"
+      title="AC-LGAD Detectors"
+      author="yezhenyu2003"
+      url="https://github.com/yezhenyu2003"
+      status="development"
+      version="1.0"
+><comment/>
+</info>
 
   <define>
     <comment>
@@ -14,9 +22,10 @@
     <constant name="BarrelTOF_CHoneycomb_thickness"   value="2*0.29*cm"/>
     <constant name="BarrelTOF_CoolingTube_thickness"  value="0.08*cm"/>
     <constant name="BarrelTOF_Coolant_thickness"      value="0.08*cm"/>
-    <constant name="BarrelTOF_Module_thickness"    value="BarrelTOF_Sensor_thickness+2*BarrelTOF_Hybrid_thickness+2*BarrelTOF_CFSkin_thickness+BarrelTOF_CFoam_thickness+BarrelTOF_CoolingTube_thickness+BarrelTOF_Coolant_thickness"/>
+    <constant name="BarrelTOF_Module_thickness"       value="BarrelTOF_Sensor_thickness+2*BarrelTOF_Hybrid_thickness+2*BarrelTOF_CFSkin_thickness+BarrelTOF_CFoam_thickness+BarrelTOF_CoolingTube_thickness+BarrelTOF_Coolant_thickness"/>
 
-    <constant name="BarrelTOF_radius_design"           value="61.5*cm"/>
+    <constant name="BarrelTOF_zOffset"                 value="0*cm"/>
+    <constant name="BarrelTOF_radius_design"           value="64.6*cm"/>
     <constant name="BarrelTOF_Module_width_design"     value="56.0*mm"/>
     <constant name="BarrelTOF_Sensor_width_design"     value="32.0*mm"/>
     <constant name="BarrelTOF_CFoam_width_design"      value="BarrelTOF_Sensor_width_design-5.0*mm"/>
@@ -31,7 +40,7 @@
     <constant name="BarrelTOF_Coolant_position_design" value="BarrelTOF_CHoneycomb_position_design"/>
     <constant name="BarrelTOF_Service_position_design" value="0.0*mm"/>
 
-    <constant name="BarrelTOF_scale"               value="1.05"/>
+    <constant name="BarrelTOF_scale"               value="1.0"/>
     <constant name="BarrelTOF_radius"              value="BarrelTOF_scale * BarrelTOF_radius_design"/>
     <constant name="BarrelTOF_Sensor_width"        value="BarrelTOF_scale * BarrelTOF_Sensor_width_design"/>
     <constant name="BarrelTOF_CFoam_width"         value="BarrelTOF_scale * BarrelTOF_CFoam_width_design"/>
@@ -45,15 +54,15 @@
     <constant name="BarrelTOF_Coolant_position"    value="BarrelTOF_scale * BarrelTOF_Coolant_position_design"/>
     <constant name="BarrelTOF_Service_position"    value="BarrelTOF_scale * BarrelTOF_Service_position_design"/>
     <constant name="BarrelTOF_Module_width"        value="BarrelTOF_scale*BarrelTOF_Module_width_design"/>
-    <constant name="BarrelTOF_Module_tiltangle"    value="18.0*degree"/>
+    <constant name="BarrelTOF_Module_tiltangle"    value="20*degree"/>
     <constant name="BarrelTOF_Module_nphi"         value="144"/>
     <constant name="BarrelTOF_Module_nz"           value="1"/>
 
-    <constant name="BarrelTOF_rmin"                value="BarrelTOF_radius"/>
-    <constant name="BarrelTOF_rmax"                value="BarrelTOF_rmin+BarrelTOF_Module_width*tan(BarrelTOF_Module_tiltangle)"/>
-    <constant name="BarrelTOF_thickness"           value="BarrelTOF_rmax-BarrelTOF_rmin"/>
-    <constant name="BarrelTOF_rOffset"             value="16.0*mm"/>
-    <constant name="BarrelTOF_length1"             value="2 * 135 * cm"/>
+    <constant name="BarrelTOF_rOffset1"            value="1.6*cm"/>
+    <constant name="BarrelTOF_rOffset2"            value="1.4*cm"/>
+    <constant name="BarrelTOF_rmin"                value="BarrelTOF_radius-BarrelTOF_rOffset1"/>
+    <constant name="BarrelTOF_rmax"                value="BarrelTOF_radius+BarrelTOF_rOffset2"/>
+    <constant name="BarrelTOF_length1"             value="2 * 120 * cm"/>
     <constant name="BarrelTOF_length2"             value="BarrelTOF_length1"/>
     <constant name="BarrelTOF_length"              value="BarrelTOF_length2"/>
 
@@ -70,8 +79,8 @@
       readout="TOFBarrelHits"
       insideTrackingVolume="true">
       <dimensions
-        rmin="BarrelTOF_rmin-BarrelTOF_rOffset"
-        rmax="BarrelTOF_rmax+BarrelTOF_rOffset"
+        rmin="BarrelTOF_rmin"
+        rmax="BarrelTOF_rmax"
         length="BarrelTOF_length"/>
       <comment>
         Tracker Barrel Modules
@@ -107,18 +116,18 @@
       </module>
       <layer module="BarrelTOF_Module1" id="1" vis="TOFLayerVis">
         <barrel_envelope
-          inner_r="BarrelTOF_rmin-BarrelTOF_rOffset"
-          outer_r="BarrelTOF_rmax+BarrelTOF_rOffset"
-          z_length="BarrelTOF_length"/>
-        <rphi_layout phi_tilt="BarrelTOF_Module_tiltangle" nphi="BarrelTOF_Module_nphi" phi0="0.0" rc="BarrelTOF_rmin" dr="0.0*mm"/>
-        <z_layout dr="0.0*mm" z0="15.0*cm" nz="BarrelTOF_Module_nz"/>
+          inner_r="BarrelTOF_rmin"
+          outer_r="BarrelTOF_rmax"
+          z_length="BarrelTOF_length+2*BarrelTOF_zOffset"/>
+        <rphi_layout phi_tilt="BarrelTOF_Module_tiltangle" nphi="BarrelTOF_Module_nphi" phi0="0.0" rc="BarrelTOF_radius" dr="0.0*mm"/>
+        <z_layout dr="0.0*mm" z0="BarrelTOF_zOffset" nz="BarrelTOF_Module_nz"/>
       </layer>
     </detector>
   </detectors>
 
   <readouts>
     <readout name="TOFBarrelHits">
-      <segmentation type="CartesianGridXY" grid_size_x="0.05*mm" grid_size_y="1*cm" />
+      <segmentation type="CartesianGridXY" grid_size_x="0.1*mm" grid_size_y="1*cm" />
       <id>system:8,layer:4,module:12,sensor:2,x:32:-16,y:-16</id>
     </readout>
   </readouts>

--- a/compact/tof_endcap.xml
+++ b/compact/tof_endcap.xml
@@ -112,7 +112,7 @@
     <comment> 1 um padding to not have layer and module touch (ACTS requirement) </comment>
     <constant name="TOFEndcapLayer_thickness"   value="TOFEndcapMod_thickness + 2 * TOFEndcapMod_dz + 1 * um" />
 
-    <constant name="ForwardTOFMod_rmin"         value="ForwardTOFRegion_minR" />
+    <constant name="ForwardTOFMod_rmin"         value="ForwardTOFRegion_minR+5.0*mm" />
     <constant name="ForwardTOFMod_rmax"         value="ForwardTOFRegion_maxR" />
     <constant name="ForwardTOFMod1_zmin"        value="ForwardTOF_zmin" />
     <constant name="ForwardTOFMod2_zmin"        value="ForwardTOF_zmin + ForwardTOFMod_offset" />
@@ -130,6 +130,9 @@
     <constant name="BackwardTOFLayer1_zmin"     value="BackwardTOFMod1_zmin - TOFEndcapLayer_thickness / 2" />
     <constant name="BackwardTOFLayer2_zmin"     value="BackwardTOFMod2_zmin - TOFEndcapLayer_thickness / 2" />
 
+    <constant name="ForwardTOFMod_x1"           value="2 * ForwardTOFMod_rmin * tan(TOFEndcapMod_angle/2)" />
+    <constant name="ForwardTOFMod_x2"           value="2 * ForwardTOFMod_rmax * sin(TOFEndcapMod_angle/2)" />
+    <constant name="ForwardTOFMod_y"            value="ForwardTOFMod_rmax * cos(TOFEndcapMod_angle/2) - ForwardTOFMod_rmin" />
     <constant name="BackwardTOF_xOffset"        value="0.0*cm" />
     <constant name="BackwardTOF_det_height"     value="2.0*cm" />
   </define>
@@ -138,26 +141,15 @@
       <detector
         id="ForwardTOF_ID"
         name="ForwardTOF"
-        type="epic_TOFEndcap"
+        type="epic_TrapEndcapTracker"
         readout="TOFEndcapHits"
         vis="TOFVis"
         reflect="false">
         <module name="ForwardModule" vis="TOFModuleVis">
-          <dimensions
-            rMin="ForwardTOFMod_rmin"
-            rMax="ForwardTOFMod_rmax"
-            xOffset="ForwardTOF_xOffset"
-            det_height="ForwardTOF_det_height"
-            zPos="ForwardTOF_zmin"
-            cooling_plate_height="TOFEndcap_cooling_plate_height"
-            wallthickness_coolingtube="TOFEndcap_wallthickness_coolingtube"
-            diameter_coolingtube="TOFEndcap_diameter_coolingtube"
-            material="Aluminum"/>
-          <sensorparameters
-            width="TOFEndcap_sensor_width"
-            length="TOFEndcap_sensor_length"
-            baseplate_length="TOFEndcap_baseplate_length"
-            baseplate_width="TOFEndcap_baseplate_width"/>
+          <trd x1="ForwardTOFMod_x1/2.0" x2="ForwardTOFMod_x2/2.0" z="ForwardTOFMod_y/2"/>
+          <comment> TRDs are built back-to-front </comment>
+          <module_component thickness="TOFEndcapService_thickness" material="Silicon" vis="TOFVis"/>
+          <module_component thickness="TOFEndcapSensor_thickness" material="Silicon" sensitive="true" vis="TOFSensorVis"/>
         </module>
         <layer id="1">
           <envelope  vis="TOFLayerVis"
@@ -165,29 +157,26 @@
             rmax="ForwardTOFLayer_rmax"
             length="TOFEndcapLayer_thickness"
             zstart="ForwardTOFLayer1_zmin" />
+          <ring
+            r="ForwardTOFMod_rmin + ForwardTOFMod_y/2.0"
+            zstart="0"
+            nmodules="TOFEndcapMod_count"
+            dz="TOFEndcapMod_dz"
+            module="ForwardModule" />
         </layer>
-        <layer id="2" name="SensorStack" thickness="SS_thickness" numslices="8">
-            <slice name="ThermalPad"  material="Graphite"         thickness="SS_TP_thickness" width="SS_TP_width" length="SS_TP_length" offset="SS_TP_offset" sensitive="no"/>
-            <slice name="ALNBtm"      material="AluminumNitrate"  thickness="SS_ALNBtm_thickness"     width="SS_ALNBtm_width"     length="SS_ALNBtm_length"     offset="SS_ALNBtm_offset"     sensitive="no"/>
-            <slice name="LairdFilm"   material="Graphite"         thickness="SS_LairdFilm_thickness"  width="SS_LairdFilm_width"  length="SS_LairdFilm_length"  offset="SS_LairdFilm_offset"  sensitive="no"/>
-            <slice name="ROC"         material="Plexiglass"       thickness="SS_ROC_thickness"        width="SS_ROC_width"        length="SS_ROC_length"        offset="SS_ROC_offset"        sensitive="no"/>
-            <slice name="Solder"      material="Tin"              thickness="SS_Solder_thickness"     width="SS_Solder_width"     length="SS_Solder_length"     offset="SS_Solder_offset"     sensitive="no"/>
-            <slice name="Sensor"      material="Silicon"          thickness="SS_Sensor_thickness"     width="SS_Sensor_width"     length="SS_Sensor_length"     offset="SS_Sensor_offset"     sensitive="yes"/>
-            <slice name="Epoxy"       material="Epoxy"            thickness="SS_Epoxy_thickness"      width="SS_Epoxy_width"      length="SS_Epoxy_length"      offset="SS_Epoxy_offset"      sensitive="no"/>
-            <slice name="ALNTop"      material="AluminumNitrate"  thickness="SS_ALNTop_thickness"     width="SS_ALNTop_width"     length="SS_ALNTop_length"     offset="SS_ALNTop_offset"     sensitive="no"/>
-          </layer>
-        <layer id="3" name="ServiceHybridStack" thickness="SH_thickness" numslices="4">
-            <slice name="ThermalPad"      material="Graphite"     thickness="SH_TP_thickness"     width="SH_TP_width"         length="SH_TP_length"         offset="SH_TP_offset"         sensitive="no"/>
-            <slice name="HighSpeedBoard"  material="Polystyrene"  thickness="SH_HSB_thickness"    width="SH_HSB_width"        length="SH_HSB_length"        offset="SH_HSB_offset"        sensitive="no"/>
-            <slice name="ConnectorSpace"  material="Air"          thickness="SH_ConnSp_thickness" width="SH_ConnSp_width"     length="SH_ConnSp_length"     offset="SH_ConnSp_offset"     sensitive="no"/>
-            <slice name="Powerboard"      material="Polystyrene"  thickness="SH_PB_thickness"     width="SH_PB_width"         length="SH_PB_length"         offset="SH_PB_offset"         sensitive="no"/>
-          </layer>
+      </detector>
+      <detector id="BackwardTOF_ID"
+        name="BackwardTOF"
+        type="epic_CompositeTracker"
+        actsType="endcap"
+        vis="TrackerSubAssemblyVis">
+        <position x="0*cm" y="0*cm" z="-1*um" />
       </detector>
   </detectors>
 
   <readouts>
     <readout name="TOFEndcapHits">
-      <segmentation type="CartesianGridXZ" grid_size_x="50*um" grid_size_z="50*um" />
+      <segmentation type="CartesianGridXZ" grid_size_x="100*um" grid_size_z="100*um" />
       <id>system:8,layer:2,module:6,sensor:16,x:32:-16,z:-16</id>
     </readout>
   </readouts>

--- a/compact/tracker.xml
+++ b/compact/tracker.xml
@@ -28,7 +28,7 @@
     <comment> barrel length: 2R/tan(angle) - dz </comment>
 
     <comment> Position in center of space behind DIRC </comment>
-    <constant name="OuterMPGDBarrel_rmin"            value="CentralTrackingRegion_rmax"/>
+    <constant name="MPGDDIRC_rmin"            value="DIRC_rmin + DIRC_thickness"/>
     <comment> barrel asymmetryc between forward and backward lengths </comment>
 
     <comment> Service/Support setup </comment>
@@ -119,12 +119,15 @@
       vis="TrackerSubAssemblyVis">
       <composite name="InnerMPGDBarrel"/>
     </detector>
-    <detector id="TrackerSubAssembly_5_ID"
-      name="OuterMPGDSubSubAssembly"
-      type="DD4hep_SubdetectorAssembly"
-      vis="TrackerSubAssemblyVis">
-      <composite name="OuterMPGDBarrel"/>
-    </detector>
+    <comment>
+      <comment>FIXME update the OuterMPGDBarrel to use the MPGDDIRC detector</comment>
+      <detector id="TrackerSubAssembly_5_ID"
+        name="OuterMPGDSubSubAssembly"
+        type="DD4hep_SubdetectorAssembly"
+        vis="TrackerSubAssemblyVis">
+        <composite name="OuterMPGDBarrel"/>
+      </detector>
+    </comment>
   </detectors>
 
   <documentation>
@@ -142,6 +145,7 @@
   <include ref="tracker/vertex_barrel.xml"/>
   <include ref="tracker/silicon_barrel.xml"/>
   <include ref="tracker/mpgd_barrel.xml"/>
+  <include ref="tracker/mpgd_dirc.xml"/>
   <include ref="tracker/silicon_disks.xml"/>
   <include ref="tracker/support_service_assembly.xml"/>
 

--- a/compact/tracker.xml
+++ b/compact/tracker.xml
@@ -119,6 +119,12 @@
       vis="TrackerSubAssemblyVis">
       <composite name="InnerMPGDBarrel"/>
     </detector>
+    <detector id="TrackerSubAssembly_4_ID"
+      name="BarrelTOFSubAssembly"
+      type="DD4hep_SubdetectorAssembly"
+      vis="TrackerSubAssemblyVis">
+      <composite name="BarrelTOF"/>
+    </detector>
     <comment>
       <comment>FIXME update the OuterMPGDBarrel to use the MPGDDIRC detector</comment>
       <detector id="TrackerSubAssembly_5_ID"
@@ -128,6 +134,13 @@
         <composite name="OuterMPGDBarrel"/>
       </detector>
     </comment>
+    <detector id="TrackerSubAssembly_6_ID"
+      name="EndcapTOFSubSubAssembly"
+      type="DD4hep_SubdetectorAssembly"
+      vis="TrackerSubAssemblyVis">
+      <composite name="ForwardTOF"/>
+      <composite name="BackwardTOF"/>
+    </detector>
   </detectors>
 
   <documentation>
@@ -148,5 +161,7 @@
   <include ref="tracker/mpgd_dirc.xml"/>
   <include ref="tracker/silicon_disks.xml"/>
   <include ref="tracker/support_service_assembly.xml"/>
+  <include ref="tof_barrel.xml"/>
+  <include ref="tof_endcap.xml"/>
 
 </lccdd>

--- a/compact/tracker/mpgd_barrel.xml
+++ b/compact/tracker/mpgd_barrel.xml
@@ -11,8 +11,7 @@
 
   <define>
     <comment>
-      Main parameters - Geo based on the original ECCE design, while for now
-                        using the ATHENA MMGAS design for the layers (FIXME)
+      Inner MPGD tracking layer(s)
 
       Note: the inner and outer layers are implemented as separate detectors, as they
       belong to different ACTS tracking volumes. If this restriction goes away
@@ -22,30 +21,12 @@
     <constant name="InnerMPGDBarrelMod_rmin"                value="InnerMPGDBarrel_rmin"/>
     <constant name="InnerMPGDBarrelMod_dz"                  value="InnerMPGDBarrel_dz"/>
 
-    <constant name="OuterMPGDBarrelMod_rmin"                value="OuterMPGDBarrel_rmin"/>
-
-    <comment> Gem disk setup.
-      Note: some GEM disk z-positions are moved slightly (below in the parametrization)
-            to avoid vertical overlaps with the silicon disks (which is not allowed by ACTS).
-            @FIXME
-    </comment>
-
     <constant name="InnerMPGDBarrelMod_length"              value="2 * InnerMPGDBarrelMod_rmin / tan(TrackerBackwardAngle) - InnerMPGDBarrel_dz" />
     <constant name="InnerMPGDBarrelLayer_length"            value="InnerMPGDBarrelMod_length + 1*um" />
     <constant name="InnerMPGDBarrelLayer_thickness"         value="2*cm" />
     <constant name="InnerMPGDBarrelLayer_rmin"              value="InnerMPGDBarrelMod_rmin - InnerMPGDBarrelLayer_thickness / 2.0"/>
     <constant name="InnerMPGDBarrelLayer_rmax"              value="InnerMPGDBarrelLayer_rmin + InnerMPGDBarrelLayer_thickness"/>
 
-    <constant name="OuterMPGDBarrelMod_zmin1"               value="CentralTrackingRegionP_zmax" />
-    <constant name="OuterMPGDBarrelMod_zmin2"               value="OuterMPGDBarrelMod_rmin / tan(TrackerBackwardAngle)" />
-    <constant name="OuterMPGDBarrelMod_length"              value="OuterMPGDBarrelMod_zmin1 + OuterMPGDBarrelMod_zmin2" />
-    <constant name="OuterMPGDBarrelMod_zoffset"             value="(OuterMPGDBarrelMod_zmin1 - OuterMPGDBarrelMod_zmin2)/2" />
-    <constant name="OuterMPGDBarrelLayer_length"            value="OuterMPGDBarrelMod_length + 1*um" />
-    <constant name="OuterMPGDBarrelLayer_thickness"         value="2*cm" />
-    <constant name="OuterMPGDBarrelLayer_rmin"              value="OuterMPGDBarrelMod_rmin - OuterMPGDBarrelLayer_thickness / 2.0"/>
-    <constant name="OuterMPGDBarrelLayer_rmax"              value="OuterMPGDBarrelLayer_rmin + OuterMPGDBarrelLayer_thickness"/>
-
-    <comment> MMGAS tracker parameters </comment>
     <constant name="MMKaptonOverlay_thickness"              value="50*um"/>
     <constant name="MMCuGround_thickness"                   value="1.58*um"/>
     <constant name="MMPCB_thickness"                        value="100*um"/>
@@ -62,8 +43,6 @@
     <comment> FIXME: No support material is here, so fudge factor used to bring material budget to ~0.5% for barrel </comment>
     <constant name="MMFudgeInnerMPGDBarrel_thickness"                      value="570*um"/>
 
-    <comment> FIXME: No support material is here, so fudge factor used to bring material budget to ~1% for barrel </comment>
-    <constant name="MMFudgeOuterMPGDBarrel_thickness"                      value="115*um"/>
 
     <comment>
       Extra parameters to approximate a cylinder as a set of skinny staves
@@ -72,7 +51,6 @@
     </comment>
     <constant name="MPGDBarrelStave_count"            value="128"/>
     <constant name="InnerMPGDBarrelStave_width"       value="2*InnerMPGDBarrelLayer_rmin * tan(180*degree/MPGDBarrelStave_count)"/>
-    <constant name="OuterMPGDBarrelStave_width"       value="2*OuterMPGDBarrelLayer_rmin * tan(180*degree/MPGDBarrelStave_count)"/>
   </define>
 
   <detectors>
@@ -112,43 +90,7 @@
         <z_layout dr="0.0 * mm" z0="0.0 * mm" nz="1"/>
       </layer>
     </detector>
-    <detector
-      id="TrackerBarrel_4_ID"
-      name="OuterMPGDBarrel"
-      type="epic_TrackerBarrel"
-      readout="MPGDBarrelHits"
-      insideTrackingVolume="true">
-      <dimensions
-        rmin="OuterMPGDBarrelLayer_rmin"
-        rmax="OuterMPGDBarrelLayer_rmax"
-        length="OuterMPGDBarrelLayer_length"/>
-      <module name="OuterMPGDBarrel_Mod1" vis="TrackerMPGDVis">
-        <comment> Going from the inside (sensitive) side to the readout side </comment>
-        <module_component name="DriftCuGround" thickness="MMDriftCuGround_thickness" material="Copper" vis="TrackerMPGDVis" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-        <module_component name="DriftKapton" thickness="MMDriftKapton_thickness" material="Kapton" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-        <module_component name="DriftCuElectrode" thickness="MMDriftCuElectrode_thickness" material="Copper" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-        <module_component name="GasGap" thickness="MMGasGap_thickness" material="Ar90IsoButane" sensitive="True" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-        <module_component name="Mesh" thickness="MMMesh_thickness" material="MMGAS_InoxForMesh" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-	<module_component name="Fudge" thickness="MMFudgeOuterMPGDBarrel_thickness" material="Copper" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-        <module_component name="Gas" thickness="MMGas_thickness" material="Ar90IsoButane" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-        <module_component name="ResistiveStrips" thickness="MMResistiveStrip_thickness" material="MMGAS_ResistivePaste" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-        <module_component name="KaptonStrips" thickness="MMKaptonStrip_thickness" material="Kapton" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-        <module_component name="CuStrips" thickness="MMCuStrip_thickness" material="Copper" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-        <module_component name="PCB" thickness="MMPCB_thickness" material="Fr4" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-        <module_component name="CuGround" thickness="MMCuGround_thickness" material="Copper" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-        <module_component name="KaptonOverlay" thickness="MMKaptonOverlay_thickness" material="Kapton" vis="TrackerSupportVis" width="OuterMPGDBarrelStave_width" length="OuterMPGDBarrelMod_length"/>
-      </module>
-      <layer module="OuterMPGDBarrel_Mod1" id="1" vis="TrackerMMGASLayerVis">
-        <barrel_envelope
-          inner_r="OuterMPGDBarrelLayer_rmin"
-          outer_r="OuterMPGDBarrelLayer_rmax"
-          z_length="OuterMPGDBarrelLayer_length"
-          z0="OuterMPGDBarrelMod_zoffset"/>
-        <layer_material surface="inner" binning="binPhi,binZ" bins0="MPGDBarrelStave_count" bins1="100" />
-        <rphi_layout phi_tilt="0" nphi="MPGDBarrelStave_count" phi0="0.0" rc="OuterMPGDBarrelMod_rmin" dr="0.0 * mm"/>
-        <z_layout dr="0.0 * mm" z0="0.0 * mm" nz="1"/>
-      </layer>
-    </detector>
+
   </detectors>
 
 

--- a/compact/tracker/mpgd_dirc.xml
+++ b/compact/tracker/mpgd_dirc.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd>
+<info name="mrwell_dirc.xml"
+      title="Micro-Pattern Gas Detector for aiding DIRC PID"
+      author="mposik1983"
+      url="https://github.com/mposik1983"
+      status="development"
+      version="1.0"
+><comment/>
+</info>
+
+<define>
+    <comment> frames </comment>   
+    <constant name="MPGDDIRCFrame_width"            value="20*mm"/>
+    <constant name="MPGDDIRCFrame_thickness"        value="7*mm"/>
+
+    <comment> module constants </comment>   
+    <constant name="MPGDDIRCModule_count"                   value="12" />
+    <constant name="MPGDDIRCModule_allowed_space"           value="2*cm"/>
+    <constant name="MPGDDIRCModule_rmin"                    value="MPGDDIRC_rmin"/>
+    <constant name="MPGDDIRCModule_rmax"                    value="MPGDDIRCModule_rmin + MPGDDIRCModule_allowed_space" />
+    <constant name="MPGDDIRCModule_zmin1"                   value="145.0*cm"/>
+    <constant name="MPGDDIRCModule_zmin2"                   value="197.0*cm"/>
+    <constant name="MPGDDIRCModule_width"                   value="36.2*cm"/>
+    <constant name="MPGDDIRCModule_length"                  value="0.5*(MPGDDIRCModule_zmin1 + MPGDDIRCModule_zmin2)"/>
+    <constant name="MPGDDIRCModule_offset"                  value="(MPGDDIRCModule_zmin1 - MPGDDIRCModule_zmin2)/2.0"/>
+
+
+
+    <comment> layer parameters </comment>   
+    <constant name="MPGDDIRCWindow_thickness"             value="50*um"/>
+    <constant name="MPGDDIRCWindowGap_thickness"          value="2*mm"/>
+    <constant name="MPGDDIRCDriftGap_thickness"           value="3*mm"/>
+    <constant name="MPGDDIRCFoilCu_thickness"             value="5*um"/>
+    <constant name="MPGDDIRCReadOutElectrode_thickness"   value="10*um"/>
+    <constant name="MPGDDIRCFoilKapton_thickness"         value="50*um"/>
+    <constant name="MPGDDIRCReadOutNomex_thickness"       value="50*um"/>
+    <constant name="MPGDDIRCReadOutKapton_thickness"      value="50*um"/>
+    <constant name="MPGDDIRCPCB_thickness"                value="3*mm"/>
+
+    <comment> Thickness values </comment>   
+    <constant name="MPGDDIRCCathode_thickness"          value="MPGDDIRCFoilKapton_thickness + MPGDDIRCFoilCu_thickness"/>
+    <constant name="MPGDDIRCFoil_thickness"             value="MPGDDIRCFoilKapton_thickness + MPGDDIRCFoilCu_thickness"/>
+    <constant name="MPGDDIRCReadOut_thickness"          value="MPGDDIRCReadOutNomex_thickness + MPGDDIRCReadOutElectrode_thickness + MPGDDIRCReadOutKapton_thickness"/> 
+    <constant name="MPGDDIRCModule_thickness"           value="MPGDDIRCWindow_thickness + MPGDDIRCCathode_thickness + 
+                                                            MPGDDIRCFoil_thickness + MPGDDIRCReadOut_thickness + 
+                                                            MPGDDIRCPCB_thickness + MPGDDIRCFrame_thickness" />
+  </define>
+
+
+  <materials>
+  </materials>
+
+  <limits>
+  </limits>
+
+  <regions>
+  </regions>
+
+  <display>
+  </display>
+
+   <detectors>
+   <detector id="MPGDDIRC_0_ID" name="MPGDDIRC_0" type="epic_MPGDDIRC" readout="MPGDDIRCHits" vis="TrackerVis">
+     <dimensions width="MPGDDIRCModule_width" length="MPGDDIRCModule_length" height="MPGDDIRCModule_allowed_space" />
+     <position x="0" y="0" z="MPGDDIRCModule_offset" />
+
+    <comment> MPGD DIRC module components</comment>
+    <module name="MPGDDIRCModule" vis="TrackerVis">
+
+        <module_component name="DriftGap"
+               material="Ar"
+               sensitive="true"
+               width="MPGDDIRCModule_width"
+               thickness="MPGDDIRCDriftGap_thickness"
+               vis="TrackerMPGDGasVis"
+               length="MPGDDIRCModule_length"/>
+   
+        <module_component name="WindowGasGap"
+               material="Ar"
+               sensitive="false"
+               width="MPGDDIRCModule_width"
+               thickness="MPGDDIRCWindowGap_thickness"
+               vis="TrackerMPGDGasVis"
+               length="MPGDDIRCModule_length" />
+   
+        <module_component name="Window"
+               material="Kapton"
+               sensitive="false"
+               width="MPGDDIRCModule_width"
+               thickness="MPGDDIRCWindow_thickness"
+               vis="TrackerVis"
+               length="MPGDDIRCModule_length" />
+        <module_component name="Cathode_Kapton"
+               material="Kapton"
+               sensitive="false"
+               width="MPGDDIRCModule_width"
+               thickness="MPGDDIRCFoilKapton_thickness"
+               vis="TrackerVis"
+               length="MPGDDIRCModule_length" />
+        <module_component name="Cathode_Cu"
+               material="Copper"
+               sensitive="false"
+               width="MPGDDIRCModule_width"
+               thickness="MPGDDIRCFoilCu_thickness"
+               vis="TrackerVis"
+               length="MPGDDIRCModule_length" />
+        <module_component name="RWELL_Cu"
+               material="Copper"
+               sensitive="false"
+               width="MPGDDIRCModule_width"
+               thickness="MPGDDIRCFoilCu_thickness"
+               vis="TrackerVis"
+               length="MPGDDIRCModule_length" />
+        <module_component name="RWELL_Kapton"
+               material="Kapton"
+               sensitive="false"
+               width="MPGDDIRCModule_width"
+               thickness="MPGDDIRCFoilKapton_thickness"
+               vis="TrackerVis"
+               length="MPGDDIRCModule_length" />
+        <module_component name="Nomex"
+               material="Nomex"
+               sensitive="false"
+               width="MPGDDIRCModule_width"
+               thickness="MPGDDIRCReadOutNomex_thickness"
+               vis="TrackerVis"
+               length="MPGDDIRCModule_length" />
+        <module_component name="ReadOutElectrodes"
+               material="Copper"
+               sensitive="false"
+               width="MPGDDIRCModule_width"
+               thickness="MPGDDIRCReadOutElectrode_thickness" 
+               vis="TrackerVis"
+               length="MPGDDIRCModule_length" />
+        <module_component name="ReadOutKapton"
+               material="Kapton"
+               sensitive="false"
+               width="MPGDDIRCModule_width"
+               thickness="MPGDDIRCReadOutKapton_thickness" 
+               vis="TrackerVis"
+               length="MPGDDIRCModule_length" />
+        <module_component name="PCB"
+               material="Fr4"
+               sensitive="false"
+               width="MPGDDIRCModule_width"
+               thickness="MPGDDIRCPCB_thickness" 
+               vis="TrackerVis"
+               length="MPGDDIRCModule_length" />
+   
+   <comment> Frame width gets subtracted from the gas module volumes
+      see src/MPGDDIRC_geo.cpp 
+        </comment>
+      
+        <frame material="Fr4"
+               width="MPGDDIRCFrame_width"
+               vis="TrackerSupportVis"
+               thickness="MPGDDIRCFrame_thickness"/>
+   
+</module>
+<comment> MPGD DIRC layers </comment>
+      <layer module="MPGDDIRCModule" id="0" vis="TrackerSupportVis">
+   <rphi_layout
+          phi_tilt="0"
+          nphi="MPGDDIRCModule_count"
+          phi0="0"
+          rc="MPGDDIRCModule_rmin"
+          dr="0" />
+   </layer>
+</detector>
+</detectors>
+
+  <readouts>
+    <readout name="MPGDDIRCHits">
+      <segmentation type="CartesianGridXY" grid_size_x="0.150*mm*sqrt(12)" grid_size_y="0.150*mm*sqrt(12)" />
+      <id>system:8,layer:4,module:8,section:4,x:32:-16,y:-16</id>
+    </readout>
+  </readouts>
+
+  <plugins>
+  </plugins>
+
+  <fields>
+  </fields>
+</lccdd>

--- a/configurations/calorimeters.yml
+++ b/configurations/calorimeters.yml
@@ -1,10 +1,10 @@
 features:
-- beampipe
-- solenoid
-- ecal:
-  - forward_scifi
-  - forward_homogeneous
-  - forward_insert
-  - barrel_sciglass
-  - backward_PbWO4
-- hcal
+  beampipe:
+  solenoid:
+  ecal:
+    forward_scifi
+    forward_homogeneous
+    forward_insert
+    barrel_sciglass
+    backward_PbWO4
+  hcal:

--- a/configurations/dirc_only.yml
+++ b/configurations/dirc_only.yml
@@ -1,4 +1,3 @@
 features:
-  beampipe:
   pid:
     dirc:

--- a/configurations/dirc_only.yml
+++ b/configurations/dirc_only.yml
@@ -1,4 +1,4 @@
 features:
-- beampipe
-- pid:
-    - dirc
+  beampipe:
+  pid:
+    dirc:

--- a/configurations/drich_only.yml
+++ b/configurations/drich_only.yml
@@ -1,4 +1,3 @@
 features:
-  # beampipe:
   pid:
     drich:

--- a/configurations/full.yml
+++ b/configurations/full.yml
@@ -7,8 +7,6 @@ features:
     tof_barrel:
     mrich:
     drich:
-      #SJJ: disabled as it needs re-integrating with the tracker
-      #    tof_barrel:
   ecal:
     forward_scifi:
     forward_homogeneous:

--- a/configurations/full.yml
+++ b/configurations/full.yml
@@ -2,6 +2,7 @@ features:
   beampipe:
   tracking:
   pid:
+    dirc:
     tof_endcap:
     tof_barrel:
     mrich:

--- a/configurations/full.yml
+++ b/configurations/full.yml
@@ -3,8 +3,6 @@ features:
   tracking:
   pid:
     dirc:
-    tof_endcap:
-    tof_barrel:
     mrich:
     drich:
   ecal:

--- a/configurations/imaging.yml
+++ b/configurations/imaging.yml
@@ -2,6 +2,7 @@ features:
   beampipe:
   tracking:
   pid:
+    dirc:
     mrich:
     drich:
       #SJJ: disabled as it needs re-integrating with the tracker

--- a/configurations/imaging.yml
+++ b/configurations/imaging.yml
@@ -5,8 +5,6 @@ features:
     dirc:
     mrich:
     drich:
-      #SJJ: disabled as it needs re-integrating with the tracker
-      #    tof_barrel:
   ecal:
     forward_scifi:
     forward_homogeneous:

--- a/configurations/inner_detector.yml
+++ b/configurations/inner_detector.yml
@@ -2,6 +2,6 @@ features:
   beampipe:
   tracking:
   ecal:
-  - barrel_sciglass
-  - backward_PbWO4
+    barrel_sciglass
+    backward_PbWO4
   pid:

--- a/configurations/ip6.yml
+++ b/configurations/ip6.yml
@@ -1,4 +1,4 @@
 features:
-- beampipe
-- farforward
-- farbackward
+  beampipe:
+  farforward:
+  farbackward:

--- a/configurations/pfrich_only.yml
+++ b/configurations/pfrich_only.yml
@@ -1,4 +1,3 @@
 features:
-- beampipe
-- pid:
-    - pfrich
+  pid:
+    pfrich

--- a/configurations/pid_only.yml
+++ b/configurations/pid_only.yml
@@ -1,3 +1,2 @@
 features:
-  beampipe:
   pid:

--- a/configurations/sciglass.yml
+++ b/configurations/sciglass.yml
@@ -2,6 +2,7 @@ features:
   beampipe:
   tracking:
   pid:
+    dirc:
     mrich:
     drich:
       #SJJ: disabled as it needs re-integrating with the tracker

--- a/configurations/tof_endcap_only.yml
+++ b/configurations/tof_endcap_only.yml
@@ -1,4 +1,3 @@
 features:
-  beampipe:
   pid:
     tof_endcap:

--- a/configurations/tof_only.yml
+++ b/configurations/tof_only.yml
@@ -1,5 +1,4 @@
 features:
-  beampipe:
   pid:
     tof_endcap:
     tof_barrel:

--- a/configurations/tracking_only.yml
+++ b/configurations/tracking_only.yml
@@ -1,3 +1,2 @@
 features:
-- beampipe
-- tracking
+  tracking:

--- a/configurations/vertex_only.yml
+++ b/configurations/vertex_only.yml
@@ -1,3 +1,2 @@
 features:
-- beampipe
-- vertex
+  vertex:

--- a/src/BarrelBarDetectorWithSideFrame_geo.cpp
+++ b/src/BarrelBarDetectorWithSideFrame_geo.cpp
@@ -246,11 +246,5 @@ static Ref_t create_BarrelBarDetectorWithSideFrame(Detector& description, xml_h 
 
 //@}
 // clang-format off
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_BarrelBarDetectorWithSideFrame, create_BarrelBarDetectorWithSideFrame)
-#endif
 DECLARE_DETELEMENT(epic_BarrelBarDetectorWithSideFrame, create_BarrelBarDetectorWithSideFrame)
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_FakeDIRC, create_BarrelBarDetectorWithSideFrame)
-#endif
 DECLARE_DETELEMENT(epic_FakeDIRC, create_BarrelBarDetectorWithSideFrame)

--- a/src/BarrelCalorimeterInterlayers_geo.cpp
+++ b/src/BarrelCalorimeterInterlayers_geo.cpp
@@ -449,7 +449,4 @@ vector<tuple<int, Point, Point, Point, Point>> gridPoints(int div_x, int div_z, 
   return points;
 }
 
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_EcalBarrelInterlayers, create_detector)
-#endif
 DECLARE_DETELEMENT(epic_EcalBarrelInterlayers, create_detector)

--- a/src/BarrelCalorimeter_geo.cpp
+++ b/src/BarrelCalorimeter_geo.cpp
@@ -227,11 +227,5 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   return sdet;
 }
 
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_EcalBarrel, create_detector)
-#endif
 DECLARE_DETELEMENT(epic_EcalBarrel, create_detector)
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_HcalBarrel, create_detector)
-#endif
 DECLARE_DETELEMENT(epic_HcalBarrel, create_detector)

--- a/src/BarrelTrackerWithFrame_geo.cpp
+++ b/src/BarrelTrackerWithFrame_geo.cpp
@@ -348,19 +348,7 @@ static Ref_t create_BarrelTrackerWithFrame(Detector& description, xml_h e, Sensi
 
 //@}
 // clang-format off
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_BarrelTrackerWithFrame, create_BarrelTrackerWithFrame)
-#endif
 DECLARE_DETELEMENT(epic_BarrelTrackerWithFrame, create_BarrelTrackerWithFrame)
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_TrackerBarrel,   create_BarrelTrackerWithFrame)
-#endif
 DECLARE_DETELEMENT(epic_TrackerBarrel,   create_BarrelTrackerWithFrame)
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_VertexBarrel,    create_BarrelTrackerWithFrame)
-#endif
 DECLARE_DETELEMENT(epic_VertexBarrel,    create_BarrelTrackerWithFrame)
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_TOFBarrel,       create_BarrelTrackerWithFrame)
-#endif
 DECLARE_DETELEMENT(epic_TOFBarrel,       create_BarrelTrackerWithFrame)

--- a/src/CompositeTracker_geo.cpp
+++ b/src/CompositeTracker_geo.cpp
@@ -66,7 +66,4 @@ static Ref_t create_element(Detector& description, xml_h e, Ref_t)
   return sdet;
 }
 
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_CompositeTracker, create_element)
-#endif
 DECLARE_DETELEMENT(epic_CompositeTracker, create_element)

--- a/src/CylinderTrackerBarrel_geo.cpp
+++ b/src/CylinderTrackerBarrel_geo.cpp
@@ -202,19 +202,7 @@ static Ref_t CylinderTrackerBarrel_create_detector(Detector& description, xml_h 
 }
 
 // clang-format off
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_CylinderTrackerBarrel, CylinderTrackerBarrel_create_detector)
-#endif
 DECLARE_DETELEMENT(epic_CylinderTrackerBarrel, CylinderTrackerBarrel_create_detector)
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_MMTrackerBarrel,       CylinderTrackerBarrel_create_detector)
-#endif
 DECLARE_DETELEMENT(epic_MMTrackerBarrel,       CylinderTrackerBarrel_create_detector)
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_RWellTrackerBarrel,    CylinderTrackerBarrel_create_detector)
-#endif
 DECLARE_DETELEMENT(epic_RWellTrackerBarrel,    CylinderTrackerBarrel_create_detector)
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_CylinderVertexBarrel,  CylinderTrackerBarrel_create_detector)
-#endif
 DECLARE_DETELEMENT(epic_CylinderVertexBarrel,  CylinderTrackerBarrel_create_detector)

--- a/src/DIRC_geo.cpp
+++ b/src/DIRC_geo.cpp
@@ -337,9 +337,6 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens)
   return det;
 }
 
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_cb_DIRC, createDetector)
-#endif
 DECLARE_DETELEMENT(epic_cb_DIRC, createDetector)
 
 dd4hep::Trap MakeTrap(const std::string& pName, double pZ, double pY, double pX, double pLTX)

--- a/src/DIRC_geo.cpp
+++ b/src/DIRC_geo.cpp
@@ -12,334 +12,201 @@
 using namespace std;
 using namespace dd4hep;
 
-// Fixed Trap constructor. This function is a workaround of this bug:
-// https://github.com/AIDASoft/DD4hep/issues/850
-// Should be used instead of dd4hep::Trap(pName, pZ, pY, pX, pLTX) constructor
-dd4hep::Trap MakeTrap(const std::string& pName, double pZ, double pY, double pX, double pLTX);
+static dd4hep::Trap MakeTrap(const std::string& pName, double pZ, double pY, double pX, double pLTX);
 
 static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens)
 {
-  xml_det_t xml_det  = e;
-  string    det_name = xml_det.nameStr();
-  int       det_id   = xml_det.id();
+  xml_det_t xml_det = e;
 
-  // Main detector xml element
+  // Detector element
+  string     det_name = xml_det.nameStr();
+  int        det_id   = xml_det.id();
+  DetElement det(det_name, det_id);
+
+  // Detector dimension, position, rotation
   xml_dim_t dirc_dim = xml_det.dimensions();
   xml_dim_t dirc_pos = xml_det.position();
-  xml_dim_t dirc_rot = xml_det.rotation();
-  double    det_rin  = dirc_dim.rmin();
-  double    det_rout = dirc_dim.rmax();
-  double    SizeZ    = dirc_dim.length();
+  double    det_rmin = dirc_dim.rmin();
+  double    det_rmax = dirc_dim.rmax();
+  double    det_ravg = (det_rmin + det_rmax) / 2;
 
-  // DEBUG
-  // double mirror_r1 = x_det.attr<double>(_Unicode(r1));
+  // Detector type
+  sens.setType("tracker");
 
-  // DIRC box:
-  xml_comp_t xml_box_module = xml_det.child(_U(module));
-
-  Material quartz       = desc.material("Quartz");
-  Material nlak33a      = desc.material("Nlak33a");
-  auto&    bar_material = quartz;
-
-  Tube det_geo(det_rin, det_rout, SizeZ / 2., 0., 360.0 * deg);
-  // Volume   det_volume("DIRC", det_geo, Vacuum);
+  // Entire DIRC assembly
   Assembly det_volume("DIRC");
   det_volume.setVisAttributes(desc.visAttributes(xml_det.visStr()));
+  Transform3D det_tr(RotationY(0), Position(0.0, 0.0, dirc_pos.z()));
+  det.setPlacement(desc.pickMotherVolume(det).placeVolume(det_volume, det_tr).addPhysVolID("system", det_id));
 
-  DetElement det(det_name, det_id);
-  Volume     mother_vol = desc.pickMotherVolume(det);
+  // Construct module
+  xml_comp_t xml_module = xml_det.child(_U(module));
 
-  Transform3D  tr_global(RotationZYX(0, dirc_rot.theta(), 0.0), Position(0.0, 0.0, dirc_pos.z()));
-  PlacedVolume det_plvol = mother_vol.placeVolume(det_volume, tr_global);
-
-  det_plvol.addPhysVolID("system", det_id);
-  det.setPlacement(det_plvol);
-
-  // Parts Dimentions
-
-  // focusing system:
-  //   0    no lens
-  //   1    spherical lens
-  //   3    3-layer spherical lens
-  //   6    3-layer cylindrical lens
-  //   10   ideal lens (thickness = 0, ideal focusing)
-  // FIXME unused
-  // int fLensId = 6;
-
-  // geometry type:
-  //   0    full DIRC
-  //   1    only one plate
-  // FIXME unused
-  // int fGeomType = 0;
-
-  // run type:
-  //   0, 10 - simulation, 1, 5 - lookup table, 2,3,4 - reconstruction
-  // FIXME unused
-  // int fRunType  = 0;
-
-  // prism
-  double fPrizm[4];
-  fPrizm[0] = 360 * mm;
-  fPrizm[1] = 300 * mm;
-  fPrizm[3] = 50 * mm;
-  fPrizm[2] = fPrizm[3] + 300 * tan(32 * deg) * mm;
-  std::cout << "DIRC: fPrizm[2] " << fPrizm[2] << std::endl;
-
-  // gap between bars
-  // FIXME unused
-  // double fBarsGap = 0.15 * mm;
-
-  // double fdTilt = 80 * deg;
-
-  // double fPrizmT[6];
-  // fPrizmT[0] = 390 * mm;
-  // fPrizmT[1] = (400 - 290 * cos(fdTilt)) * mm; //
-  // fPrizmT[2] = 290 * sin(fdTilt) * mm;         // hight
-  // fPrizmT[3] = 50 * mm;                        // face
-  // fPrizmT[4] = 290 * mm;
-  // fPrizmT[5] = 290 * cos(fdTilt) * mm;
-
-  // double fMirror[3];
-  // fMirror[0] = 20 * mm;
-  // fMirror[1] = fPrizm[0];
-  // fMirror[2] = 1 * mm;
-  //   fPrizm[0] = 170; fPrizm[1] = 300; fPrizm[2] = 50+300*tan(45*deg); fPrizm[3] = 50;
-
-  //  double fBar[3];
-  //  fBar[0] = 17 * mm;
-  //  fBar[1] = (fPrizm[0] - (fNBar - 1) * fBarsGap) / fNBar;
-  //  fBar[2] = 1050 * mm; // 4200; //4200
-
-  double fMcpTotal[3];
-  double fMcpActive[3];
-  fMcpTotal[0] = fMcpTotal[1] = 53 + 4;
-  fMcpTotal[2]                = 1 * mm;
-  fMcpActive[0] = fMcpActive[1] = 53;
-  fMcpActive[2]                 = 1 * mm;
-
-  double fLens[4];
-  fLens[0] = fLens[1] = 40 * mm;
-  fLens[2]            = 10 * mm;
-  double fRadius      = (det_rin + det_rout) / 2;
-
-  double fBoxWidth = fPrizm[0];
-
-  double fFd[3];
-  fFd[0] = fBoxWidth;
-  fFd[1] = fPrizm[2];
-  fFd[2] = 1 * mm;
-
-  fLens[0] = fPrizm[3];
-  fLens[1] = fPrizm[0];
-  fLens[2] = 12 * mm;
-
-  // Getting box XML
-  const int    fNBoxes   = xml_box_module.repeat();
-  const double box_width = xml_box_module.width();
-  // FIXME unused box height and length
-  // const double box_height = xml_box_module.height();
-  // const double box_length = xml_box_module.length() + 550 * mm;
-
-  // The DIRC
   Assembly dirc_module("DIRCModule");
+  dirc_module.setVisAttributes(desc.visAttributes(xml_module.visStr()));
 
-  // Volume lDirc("lDirc", gDirc, air);
-  dirc_module.setVisAttributes(desc.visAttributes(xml_box_module.visStr()));
-
-  // FD... whatever F and D is
-  xml_comp_t xml_fd = xml_box_module.child(_Unicode(fd));
-  Box        gFd("gFd", xml_fd.height() / 2, xml_fd.width() / 2, xml_fd.thickness() / 2);
-  Volume     lFd("lFd", gFd, desc.material(xml_fd.materialStr()));
-  lFd.setVisAttributes(desc.visAttributes(xml_fd.visStr()));
-  // lFd.setSensitiveDetector(sens);
-
-  // The Bar
-  xml_comp_t xml_bar    = xml_box_module.child(_Unicode(bar));
+  // Bar
+  xml_comp_t xml_bar    = xml_module.child(_Unicode(bar));
   double     bar_height = xml_bar.height();
   double     bar_width  = xml_bar.width();
   double     bar_length = xml_bar.length();
-  Box        gBar("gBar", bar_height / 2, bar_width / 2, bar_length / 2);
-  Volume     lBar("lBar", gBar, desc.material(xml_bar.materialStr()));
-  lBar.setVisAttributes(desc.visAttributes(xml_bar.visStr()));
+  Box        bar_box("bar_box", bar_height / 2, bar_width / 2, bar_length / 2);
+  Volume     bar_vol("bar_vol", bar_box, desc.material(xml_bar.materialStr()));
+  bar_vol.setVisAttributes(desc.visAttributes(xml_bar.visStr()));
 
   // Glue
-  xml_comp_t xml_glue       = xml_box_module.child(_Unicode(glue));
-  double     glue_thickness = xml_glue.thickness(); // 0.05 * mm;
-  Box        gGlue("gGlue", bar_height / 2, bar_width / 2, glue_thickness / 2);
-  Volume     lGlue("lGlue", gGlue, desc.material(xml_glue.materialStr()));
-  lGlue.setVisAttributes(desc.visAttributes(xml_glue.visStr()));
+  xml_comp_t xml_glue       = xml_module.child(_Unicode(glue));
+  double     glue_thickness = xml_glue.thickness();
+  Box        glue_box("glue_box", bar_height / 2, bar_width / 2, glue_thickness / 2);
+  Volume     glue_vol("glue_vol", glue_box, desc.material(xml_glue.materialStr()));
+  glue_vol.setVisAttributes(desc.visAttributes(xml_glue.visStr()));
 
-  sens.setType("tracker");
-  lBar.setSensitiveDetector(sens);
-
-  int    bars_repeat_z   = 4; // TODO parametrize!
-  double bar_assm_length = (bar_length + glue_thickness) * bars_repeat_z;
-  int    fNBar           = xml_bar.repeat();
-  double bar_gap         = xml_bar.gap();
-  for (int y_index = 0; y_index < fNBar; y_index++) {
-    double shift_y = y_index * (bar_width + bar_gap) - 0.5 * box_width + 0.5 * bar_width;
-    for (int z_index = 0; z_index < bars_repeat_z; z_index++) {
-      double z          = -0.5 * bar_assm_length + 0.5 * bar_length + (bar_length + glue_thickness) * z_index;
-      auto   placed_bar = dirc_module.placeVolume(lBar, Position(0, shift_y, z));
-      dirc_module.placeVolume(lGlue, Position(0, shift_y, z + 0.5 * (bar_length + glue_thickness)));
-      placed_bar.addPhysVolID("section", z_index);
-      placed_bar.addPhysVolID("bar", y_index);
+  // Place bars + glue into module assembly
+  // FIXME place bars + glue into separate box volume
+  auto bar_repeat_y    = xml_bar.attr<int>(_Unicode(repeat_y));
+  auto bar_repeat_z    = xml_bar.attr<int>(_Unicode(repeat_z));
+  auto bar_gap         = xml_bar.gap();
+  auto bar_assm_width  = (bar_width + bar_gap) * bar_repeat_y - bar_gap;
+  auto bar_assm_length = (bar_length + glue_thickness) * bar_repeat_z;
+  for (int y_index = 0; y_index < bar_repeat_y; y_index++) {
+    double y = 0.5 * bar_assm_width - 0.5 * bar_width - (bar_width + bar_gap) * y_index;
+    for (int z_index = 0; z_index < bar_repeat_z; z_index++) {
+      double z = 0.5 * bar_assm_length - 0.5 * bar_length - (bar_length + glue_thickness) * z_index;
+      dirc_module.placeVolume(glue_vol, Position(0, y, z - 0.5 * (bar_length + glue_thickness)));
+      dirc_module.placeVolume(bar_vol, Position(0, y, z)).addPhysVolID("section", z_index).addPhysVolID("bar", y_index);
     }
   }
 
-  // The Mirror
-  xml_comp_t xml_mirror = xml_box_module.child(_Unicode(mirror));
-  Box        gMirror("gMirror", xml_mirror.height() / 2, xml_mirror.width() / 2, xml_mirror.thickness() / 2);
-  Volume     lMirror("lMirror", gMirror, desc.material(xml_mirror.materialStr()));
-  dirc_module.placeVolume(lMirror, Position(0, 0, -0.5 * (bar_assm_length - xml_mirror.thickness())));
-  lMirror.setVisAttributes(desc.visAttributes(xml_mirror.visStr()));
+  // Mirror construction
+  xml_comp_t xml_mirror       = xml_module.child(_Unicode(mirror));
+  auto       mirror_width     = xml_mirror.width();
+  auto       mirror_height    = xml_mirror.height();
+  auto       mirror_thickness = xml_mirror.thickness();
+  Box        mirror_box("mirror_box", mirror_height / 2, mirror_width / 2, mirror_thickness / 2);
+  Volume     mirror_vol("mirror_vol", mirror_box, desc.material(xml_mirror.materialStr()));
+  mirror_vol.setVisAttributes(desc.visAttributes(xml_mirror.visStr()));
 
-  // The mirror optical surface
-  OpticalSurfaceManager surfMgr = desc.surfaceManager();
-  auto                  surf    = surfMgr.opticalSurface("MirrorOpticalSurface");
-  SkinSurface           skin(desc, det, Form("dirc_mirror_optical_surface"), surf, lMirror);
+  // Mirror optical surface
+  auto        surfMgr = desc.surfaceManager();
+  auto        surf    = surfMgr.opticalSurface("MirrorOpticalSurface");
+  SkinSurface skin(desc, det, Form("dirc_mirror_optical_surface"), surf, mirror_vol);
   skin.isValid();
 
-  // LENS
-  // Lens volumes
-  Volume lLens1;
-  Volume lLens2;
-  Volume lLens3;
+  // Place mirror
+  dirc_module.placeVolume(mirror_vol, Position(0, 0, 0.5 * (bar_assm_length + mirror_thickness)));
 
-  double lensMinThikness = 2.0 * mm;
-  double layer12         = lensMinThikness * 2;
+  // Prism variables
+  xml_comp_t xml_prism        = xml_module.child(_Unicode(prism));
+  double     prism_angle      = xml_prism.angle();
+  double     prism_width      = xml_prism.width();
+  double     prism_length     = xml_prism.length();
+  double     prism_short_edge = getAttrOrDefault(xml_prism, _Unicode(short_edge), 50 * mm);
+  double     prism_long_edge  = prism_short_edge + prism_length * tan(prism_angle);
 
-  // r1 = (r1==0)? 27.45: r1;
-  // r2 = (r2==0)? 20.02: r2;
+  // Lens variables
+  xml_comp_t xml_lens    = xml_module.child(_Unicode(lens));
+  double     lens_height = getAttrOrDefault(xml_lens, _Unicode(height), 50 * mm);
+  double     lens_shift  = getAttrOrDefault(xml_lens, _Unicode(shift), 0 * mm);
+  // double lens_width = getAttrOrDefault(xml_lens, _Unicode(width), 25 * mm);
+  double lens_thickness = getAttrOrDefault(xml_lens, _Unicode(thickness), 12 * mm);
+  double lens_r1        = getAttrOrDefault(xml_lens, _Unicode(r1), 62 * mm);
+  double lens_r2        = getAttrOrDefault(xml_lens, _Unicode(r2), 36 * mm);
 
-  double r1     = 33 * mm;
-  double r2     = 24 * mm;
-  double shight = 25 * mm;
+  // Lens construction
+  // FIXME avoid negative impact of booleans by putting lens inside box
 
-  Position zTrans1(0, 0, -r1 - fLens[2] / 2. + r1 - sqrt(r1 * r1 - shight / 2. * shight / 2.) + lensMinThikness);
-  Position zTrans2(0, 0, -r2 - fLens[2] / 2. + r2 - sqrt(r2 * r2 - shight / 2. * shight / 2.) + layer12);
+  // lens_min_thickness is distance from face to r1, and from r1 to r2 at lens top edge
+  double lens_min_thickness = 0.5 * mm;
+  double layer01            = 1.0 * lens_min_thickness;
+  double layer12            = 2.0 * lens_min_thickness;
 
-  Box gfbox("fbox", 0.5 * fLens[0], 0.5 * fLens[1], 0.5 * fLens[2]);
-  Box gcbox("cbox", 0.5 * fLens[0], 0.5 * fLens[1] + 1 * mm, 0.5 * fLens[2]);
+  // ztrans1 and ztrans2 are the z shifts of the lens center for r1 and r2
+  double ztrans1 = lens_thickness / 2. + sqrt(lens_r1 * lens_r1 - lens_height / 2. * lens_height / 2.) - layer01;
+  double ztrans2 = lens_thickness / 2. + sqrt(lens_r2 * lens_r2 - lens_height / 2. * lens_height / 2.) - layer12;
 
-  //  Volume gfbox_volume("gfbox_volume", gfbox, bar_material);
-  //  lDirc.placeVolume(gfbox_volume, Position(0, 0, 0));
-  //
-  //  Volume gcbox_volume("gcbox_volume", gcbox, bar_material);
-  //  lDirc.placeVolume(gcbox_volume, Position(0, 0, 50));
+  Box gfbox("fbox", 0.5 * prism_short_edge, 0.5 * prism_width, 0.5 * lens_thickness);
+  Box gcbox("cbox", 0.5 * prism_short_edge, 0.5 * prism_width + 1 * mm, 0.5 * lens_thickness);
 
-  Position         tTrans1(0.5 * (fLens[0] + shight), 0, -fLens[2] + layer12);
-  Position         tTrans0(-0.5 * (fLens[0] + shight), 0, -fLens[2] + layer12);
+  Position         tTrans1(0.5 * (prism_short_edge + lens_height), 0, lens_thickness - layer12);
+  Position         tTrans0(-0.5 * (prism_short_edge + lens_height), 0, lens_thickness - layer12);
   SubtractionSolid tubox("tubox", gfbox, gcbox, tTrans1);
   SubtractionSolid gubox("gubox", tubox, gcbox, tTrans0);
 
-  //  Volume tubox_volume("tubox_volume", tubox, bar_material);
-  //  lDirc.placeVolume(tubox_volume, Position(0, 0, 100));
-  //
-  //  Volume gubox_volume("gubox_volume", gubox, bar_material);
-  //  lDirc.placeVolume(gubox_volume, Position(0, 0, 150));
+  Tube gcylinder1("Cylinder1", 0, lens_r1, 0.5 * prism_width, 0 * deg, 360 * deg);
+  Tube gcylinder2("Cylinder2", 0, lens_r2, 0.5 * prism_width - 0.5 * mm, 0 * deg, 360 * deg);
+  Tube gcylinder1c("Cylinder1c", 0, lens_r1, 0.5 * prism_width + 0.5 * mm, 0 * deg, 360 * deg);
+  Tube gcylinder2c("Cylinder2c", 0, lens_r2, 0.5 * prism_width + 0.5 * mm, 0 * deg, 360 * deg);
 
-  Tube      gcylinder1("Cylinder1", 0, r1, 0.5 * fLens[1], 0 * deg, 360 * deg);
-  Tube      gcylinder2("Cylinder2", 0, r2, 0.5 * fLens[1] - 0.5 * mm, 0 * deg, 360 * deg);
-  Tube      gcylinder1c("Cylinder1c", 0, r1, 0.5 * fLens[1] + 0.5 * mm, 0 * deg, 360 * deg);
-  Tube      gcylinder2c("Cylinder2c", 0, r2, 0.5 * fLens[1] + 0.5 * mm, 0 * deg, 360 * deg);
-  RotationX xRot(-M_PI / 2.);
+  IntersectionSolid lens_layer1_solid("lens_layer1_solid", gubox, gcylinder1,
+                                      Transform3D(RotationX(M_PI / 2.), Position(0, 0, ztrans1)));
+  SubtractionSolid  gLenst("temp", gubox, gcylinder1c, Transform3D(RotationX(M_PI / 2.), Position(0, 0, ztrans1)));
 
-  IntersectionSolid gLens1("Lens1", gubox, gcylinder1, Transform3D(xRot, zTrans1));
-  SubtractionSolid  gLenst("temp", gubox, gcylinder1c, Transform3D(xRot, zTrans1));
+  IntersectionSolid lens_layer2_solid("lens_layer2_solid", gLenst, gcylinder2,
+                                      Transform3D(RotationX(M_PI / 2.), Position(0, 0, ztrans2)));
+  SubtractionSolid  lens_layer3_solid("lens_layer3_solid", gLenst, gcylinder2c,
+                                      Transform3D(RotationX(M_PI / 2.), Position(0, 0, ztrans2)));
 
-  //  Volume gLens1_volume("gLens1_volume", gLens1, bar_material);
-  //  lDirc.placeVolume(gLens1_volume, Position(0, 0, 200));
-  //
-  //  Volume gLenst_volume("gLenst_volume", gLenst, bar_material);
-  //  lDirc.placeVolume(gLenst_volume, Position(0, 0, 250));
+  Volume lens_layer1_vol("lens_layer1_vol", lens_layer1_solid,
+                         desc.material(xml_lens.attr<std::string>(_Unicode(material1))));
+  Volume lens_layer2_vol("lens_layer2_vol", lens_layer2_solid,
+                         desc.material(xml_lens.attr<std::string>(_Unicode(material2))));
+  Volume lens_layer3_vol("lens_layer3_vol", lens_layer3_solid,
+                         desc.material(xml_lens.attr<std::string>(_Unicode(material3))));
 
-  IntersectionSolid gLens2("Lens2", gLenst, gcylinder2, Transform3D(xRot, zTrans2));
-  SubtractionSolid  gLens3("Lens3", gLenst, gcylinder2c, Transform3D(xRot, zTrans2));
+  lens_layer1_vol.setVisAttributes(desc.visAttributes(xml_lens.attr<std::string>(_Unicode(vis1))));
+  lens_layer2_vol.setVisAttributes(desc.visAttributes(xml_lens.attr<std::string>(_Unicode(vis2))));
+  lens_layer3_vol.setVisAttributes(desc.visAttributes(xml_lens.attr<std::string>(_Unicode(vis3))));
 
-  lLens1 = Volume("lLens1", gLens1, bar_material);
-  lLens2 = Volume("lLens2", gLens2, nlak33a);
-  lLens3 = Volume("lLens3", gLens3, bar_material);
+  double   lens_position_x = lens_shift;
+  double   lens_position_z = -0.5 * (bar_assm_length + lens_thickness);
+  Position lens_position(lens_position_x, 0, lens_position_z);
+  dirc_module.placeVolume(lens_layer1_vol, lens_position);
+  dirc_module.placeVolume(lens_layer2_vol, lens_position);
+  dirc_module.placeVolume(lens_layer3_vol, lens_position);
 
-  lLens1.setVisAttributes(desc.visAttributes("DIRCLens1"));
-  lLens2.setVisAttributes(desc.visAttributes("DIRCLens2"));
-  lLens3.setVisAttributes(desc.visAttributes("DIRCLens3"));
+  // Prism construction
+  Trap   prism_trap = MakeTrap("prism_trap", prism_width, prism_length, prism_long_edge, prism_short_edge);
+  Volume prism_vol("prism_vol", prism_trap, desc.material(xml_prism.materialStr()));
+  prism_vol.setVisAttributes(desc.visAttributes(xml_prism.visStr()));
 
-  double shifth = 0.5 * (bar_assm_length + fLens[2]);
-  // fmt::print("LENS HERE shifth={}\n", shifth);
+  double    prism_position_x = (prism_long_edge + prism_short_edge) / 4. - 0.5 * prism_short_edge + lens_shift;
+  double    prism_position_z = -0.5 * (bar_assm_length + prism_length) - lens_thickness;
+  RotationX prism_rotation(M_PI / 2.);
+  Position  prism_position(prism_position_x, 0, prism_position_z);
+  dirc_module.placeVolume(prism_vol, Transform3D(prism_rotation, prism_position));
 
-  lLens1.setVisAttributes(desc.visAttributes("AnlTeal"));
-  dirc_module.placeVolume(lLens1, Position(0, 0, shifth));
-  dirc_module.placeVolume(lLens2, Position(0, 0, shifth));
-  dirc_module.placeVolume(lLens3, Position(0, 0, shifth));
+  // MCP variables
+  xml_comp_t xml_mcp       = xml_module.child(_Unicode(mcp));
+  double     mcp_thickness = xml_mcp.thickness();
+  double     mcp_height    = xml_mcp.height();
+  double     mcp_width     = xml_mcp.width();
 
-  // The Prizm
-  Trap   gPrizm = MakeTrap("gPrizm", fPrizm[0], fPrizm[1], fPrizm[2], fPrizm[3]);
-  Volume lPrizm("lPrizm", gPrizm, bar_material);
-  lPrizm.setVisAttributes(desc.visAttributes("DIRCPrism"));
+  // MCP construction
+  Box    mcp_box("mcp_box", mcp_height / 2, mcp_width / 2, mcp_thickness / 2);
+  Volume mcp_vol("mcp_vol", mcp_box, desc.material(xml_mcp.materialStr()));
+  mcp_vol.setVisAttributes(desc.visAttributes(xml_mcp.visStr())).setSensitiveDetector(sens);
 
-  // G4RotationMatrix *fdRot = new G4RotationMatrix();
-  // G4RotationMatrix *fdrot = new G4RotationMatrix();
-  double evshiftz = 0.5 * bar_assm_length + fPrizm[1] + fMcpActive[2] / 2. + fLens[2];
-  double evshiftx = -3 * mm;
+  double   mcp_position_x = 0.5 * prism_long_edge - 0.5 * prism_short_edge + lens_shift;
+  double   mcp_position_z = -0.5 * bar_assm_length - lens_thickness - prism_length - 0.5 * mcp_thickness;
+  Position mcp_position(mcp_position_x, 0, mcp_position_z);
+  dirc_module.placeVolume(mcp_vol, mcp_position);
 
-  double prism_shift_x = (fPrizm[2] + fPrizm[3]) / 4. - 0.5 * fPrizm[3] + 1.5 * mm;
-  double prism_shift_z = 0.5 * (bar_assm_length + fPrizm[1]) + fLens[2];
-
-  Position fPrismShift(prism_shift_x, 0, prism_shift_z);
-  dirc_module.placeVolume(lPrizm, Transform3D(xRot, fPrismShift));
-  dirc_module.placeVolume(lFd, Position(0.5 * fFd[1] - 0.5 * fPrizm[3] - evshiftx, 0, evshiftz));
-
-  double dphi = 2 * M_PI / (double)fNBoxes;
-  for (int i = 0; i < fNBoxes; i++) {
+  // Place modules
+  const int    module_repeat = xml_module.repeat();
+  const double dphi          = 2. * M_PI / module_repeat;
+  for (int i = 0; i < module_repeat; i++) {
     double phi = dphi * i;
-    double dx  = -fRadius * cos(phi);
-    double dy  = -fRadius * sin(phi);
+    double x   = det_ravg * cos(phi);
+    double y   = det_ravg * sin(phi);
 
-    // G4RotationMatrix *tRot = new G4RotationMatrix();
-
-    Transform3D  tr(RotationZ(phi + M_PI), Position(dx, dy, 0));
-    PlacedVolume box_placement = det_volume.placeVolume(dirc_module, tr);
-    box_placement.addPhysVolID("module", i);
-
-    // fmt::print("placing dircbox # {} -tphi={:.0f} dx={:.0f}, dy={:.0f}\n", i, phi/deg, dx/cm, dy/cm);
-
-    // new G4PVPlacement(tRot, G4ThreeVector(dx, dy, 0), lDirc, "wDirc", lExpHall, false, i);
+    Transform3D tr(RotationZ(phi), Position(x, y, 0));
+    det_volume.placeVolume(dirc_module, tr).addPhysVolID("module", i);
   }
 
-  //////////////////
-  // DIRC Bars
-  //////////////////
-
-  // double bar_radius   = 83.65 * cm;
-  // double bar_length   = SizeZ;
-  // double bar_width    = 42. * cm;
-  // double bar_thicknes = 1.7 * cm;
-  // int    bar_count    = 2 * M_PI * bar_radius / bar_width;
-  // double bar_dphi     = 2 * 3.1415926 / bar_count;
-  // Material bar_material = desc.material("Quartz");
-
-  // Box    bar_geo(bar_thicknes / 2., bar_width / 2., bar_length / 2.);
-  // Volume bar_volume("cb_DIRC_bars_Logix", bar_geo, bar_material);
-  // bar_volume.setVisAttributes(desc.visAttributes(xml_det.visStr()));
-  // sens.setType("tracker");
-  // bar_volume.setSensitiveDetector(sens);
-
-  // for (int ia = 0; ia < bar_count; ia++) {
-  //   double phi = (ia * (bar_dphi));
-  //   double x   = -bar_radius * cos(phi);
-  //   double y   = -bar_radius * sin(phi);
-
-  //   Transform3D  tr(RotationZ(bar_dphi * ia), Position(x, y, 0));
-  //   PlacedVolume barPV = det_volume.placeVolume(bar_volume, tr);
-  //   barPV.addPhysVolID("module", ia);
-  // }
   return det;
 }
 
-DECLARE_DETELEMENT(epic_cb_DIRC, createDetector)
-
-dd4hep::Trap MakeTrap(const std::string& pName, double pZ, double pY, double pX, double pLTX)
+static dd4hep::Trap MakeTrap(const std::string& pName, double pZ, double pY, double pX, double pLTX)
 {
   // Fixed Trap constructor. This function is a workaround of this bug:
   // https://github.com/AIDASoft/DD4hep/issues/850
@@ -351,7 +218,7 @@ dd4hep::Trap MakeTrap(const std::string& pName, double pZ, double pY, double pX,
   double fDy1        = 0.5 * pY;
   double fDx1        = 0.5 * pX;
   double fDx2        = 0.5 * pLTX;
-  double fTalpha1    = 0.5 * (pLTX - pX) / pY;
+  double fTalpha1    = atan(0.5 * (pLTX - pX) / pY);
   double fDy2        = fDy1;
   double fDx3        = fDx1;
   double fDx4        = fDx2;
@@ -359,3 +226,5 @@ dd4hep::Trap MakeTrap(const std::string& pName, double pZ, double pY, double pX,
 
   return Trap(pName, fDz, fTthetaCphi, fTthetaSphi, fDy1, fDx1, fDx2, fTalpha1, fDy2, fDx3, fDx4, fTalpha2);
 }
+
+DECLARE_DETELEMENT(epic_DIRC, createDetector)

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -574,7 +574,4 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
 }
 
 // clang-format off
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_DRICH, createDetector)
-#endif
 DECLARE_DETELEMENT(epic_DRICH, createDetector)

--- a/src/FieldMapBrBz.cpp
+++ b/src/FieldMapBrBz.cpp
@@ -221,7 +221,4 @@ static Ref_t create_field_map_brbz(Detector& /*lcdd*/, xml::Handle_t handle)
   return field;
 }
 
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_XMLELEMENT(ecce_FieldMapBrBz, create_field_map_brbz)
-#endif
 DECLARE_XMLELEMENT(epic_FieldMapBrBz, create_field_map_brbz)

--- a/src/FileLoader.cpp
+++ b/src/FileLoader.cpp
@@ -64,7 +64,4 @@ long load_file(Detector& /* desc */, int argc, char** argv)
   return 1;
 }
 
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_APPLY(ecce_FileLoader, load_file)
-#endif
 DECLARE_APPLY(epic_FileLoader, load_file)

--- a/src/GaseousRICH_geo.cpp
+++ b/src/GaseousRICH_geo.cpp
@@ -211,7 +211,4 @@ void build_sensors(Detector& desc, Volume& env, xml::Component plm, const Positi
 //@}
 
 // clang-format off
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_GaseousRICH, createDetector)
-#endif
 DECLARE_DETELEMENT(epic_GaseousRICH, createDetector)

--- a/src/HomogeneousCalorimeter_geo.cpp
+++ b/src/HomogeneousCalorimeter_geo.cpp
@@ -10,6 +10,14 @@
 //  Author: Chao Peng (ANL)
 //  Date: 06/09/2021
 //==========================================================================
+//==========================================================================
+//  Add the new geometry and the supporting structue
+//  Adapted the single module with additional wrraper and supporting structure
+//--------------------------------------------------------------------------
+//  Author: WANG Pu-Kai, ZHU Yuwei (IJClab)
+//  Date: 03/10/2022
+//==========================================================================
+
 
 #include "DD4hep/DetFactoryHelper.h"
 #include "GeometryHelpers.h"
@@ -118,8 +126,8 @@ static std::tuple<int, int> add_individuals(Detector& desc, Assembly& env, xml::
                                             SensitiveDetector& sens, int id);
 static std::tuple<int, int> add_array(Detector& desc, Assembly& env, xml::Collection_t& plm, SensitiveDetector& sens,
                                       int id);
-static std::tuple<int, int> add_disk(Detector& desc, Assembly& env, xml::Collection_t& plm, SensitiveDetector& sens,
-                                     int id);
+static std::tuple<int, int> add_disk(Detector& desc, Assembly& env, xml::Collection_t& plm, SensitiveDetector& sens, int id);
+static std::tuple<int, int> add_12surface_disk(Detector& desc, Assembly& env, xml::Collection_t& plm, SensitiveDetector& sens, int id);
 static std::tuple<int, int> add_lines(Detector& desc, Assembly& env, xml::Collection_t& plm, SensitiveDetector& sens,
                                       int id);
 
@@ -173,6 +181,10 @@ static Ref_t create_detector(Detector& desc, xml::Handle_t handle, SensitiveDete
     auto [sector, nmod] = add_disk(desc, assembly, disk, sens, sector_id++);
     addModuleNumbers(sector, nmod);
   }
+  for (xml::Collection_t disk_12surface(plm, _Unicode(disk_12surface)); disk_12surface; ++disk_12surface) {
+    auto [sector, nmod] = add_12surface_disk(desc, assembly, disk_12surface, sens, sector_id++);
+    addModuleNumbers(sector, nmod);
+  }
   for (xml::Collection_t lines(plm, _Unicode(lines)); lines; ++lines) {
     auto [sector, nmod] = add_lines(desc, assembly, lines, sens, sector_id++);
     addModuleNumbers(sector, nmod);
@@ -180,7 +192,7 @@ static Ref_t create_detector(Detector& desc, xml::Handle_t handle, SensitiveDete
 
   for (auto [sector, nmods] : sectorModuleNumbers) {
     desc.add(Constant(Form((detName + "_NModules_Sector%d").c_str(), sector), std::to_string(nmods)));
-  }
+ }
 
   // detector position and rotation
   auto         pos       = get_xml_xyz(detElem, _Unicode(position));
@@ -196,33 +208,81 @@ static Ref_t create_detector(Detector& desc, xml::Handle_t handle, SensitiveDete
 // helper function to build module with or w/o wrapper
 std::tuple<Volume, Position> build_module(Detector& desc, xml::Collection_t& plm, SensitiveDetector& sens)
 {
-  auto   mod = plm.child(_Unicode(module));
-  auto   sx  = mod.attr<double>(_Unicode(sizex));
-  auto   sy  = mod.attr<double>(_Unicode(sizey));
-  auto   sz  = mod.attr<double>(_Unicode(sizez));
-  Box    modShape(sx / 2., sy / 2., sz / 2.);
-  auto   modMat = desc.material(mod.attr<std::string>(_Unicode(material)));
-  Volume modVol("module_vol", modShape, modMat);
-  modVol.setSensitiveDetector(sens);
+  auto mod = plm.child(_Unicode(module));
+  auto sx  = mod.attr<double>(_Unicode(gx));
+  auto sy  = mod.attr<double>(_Unicode(gy));
+  auto sz  = mod.attr<double>(_Unicode(gz));
+  auto sdz  = mod.attr<double>(_Unicode(gdz));
+  Box modshape(sx / 2., sy / 2., (sz + sdz) / 2.);
+  auto modMat = desc.material(mod.attr<std::string>(_Unicode(gmaterial)));
+  Volume modVol("module_vol", modshape, modMat);
   modVol.setVisAttributes(desc.visAttributes(mod.attr<std::string>(_Unicode(vis))));
+  
+  auto cry = plm.child(_Unicode(crystal));
+  auto cryx  = cry.attr<double>(_Unicode(sizex));
+  auto cryy  = cry.attr<double>(_Unicode(sizey));
+  auto cryz  = cry.attr<double>(_Unicode(sizez));
+  Box crystalshape(cryx / 2., cryy / 2., cryz / 2.);
+  auto crystalMat = desc.material(cry.attr<std::string>(_Unicode(material)));
+  Volume crystalVol("crystal_vol", crystalshape, crystalMat);
+  modVol.placeVolume(crystalVol, Position(0., 0., -sdz / 2.));
+  crystalVol.setVisAttributes(desc.visAttributes(cry.attr<std::string>(_Unicode(cryvis))));
+  crystalVol.setSensitiveDetector(sens);
 
-  // no wrapper
-  if (!plm.hasChild(_Unicode(wrapper))) {
-    return std::make_tuple(modVol, Position{sx, sy, sz});
-    // build wrapper
-  } else {
-    auto wrp       = plm.child(_Unicode(wrapper));
-    auto thickness = wrp.attr<double>(_Unicode(thickness));
-    if (thickness < 1e-12 * mm) {
+
+  std::cout << "build...." << std::endl;
+  std::cout << !plm.hasChild(_Unicode(wrapper)) << std::endl;
+  
+
+  if (!plm.hasChild(_Unicode(wrapper)))    // no wrapper
+    {
+      std::cout << "without wrapper" << std::endl;
+      
+      return std::make_tuple(modVol, Position{sx, sy, sz});
+
+    }
+  else // build wrapper
+    {
+      auto wrp       = plm.child(_Unicode(wrapper)); //Read all the content in the wrapper block
+      auto carbon_thickness = wrp.attr<double>(_Unicode(carbon_thickness));
+      auto wrap_thickness = wrp.attr<double>(_Unicode(wrap_thickness));
+      auto length_wrapper = wrp.attr<double>(_Unicode(length));
+      auto carbonMat = desc.material(wrp.attr<std::string>(_Unicode(material_carbon)));
+      auto wrpMat = desc.material(wrp.attr<std::string>(_Unicode(material_wrap)));
+      auto gapMat = desc.material(wrp.attr<std::string>(_Unicode(material_gap)));
+
+      if (carbon_thickness < 1e-12 * mm)
+        return std::make_tuple(modVol, Position{sx, sy, sz});
+      
+      Box carbonShape(sx / 2., sy / 2., length_wrapper / 2.);
+      Box carbonShape_sub((sx - 2.*carbon_thickness) / 2., (sy - 2.*carbon_thickness) / 2., length_wrapper / 2.);
+      SubtractionSolid carbon_subtract(carbonShape, carbonShape_sub, Position(0., 0., 0.));
+
+      Box wrpShape((sx - 2.*carbon_thickness) / 2., (sy - 2.*carbon_thickness) / 2., (sz + wrap_thickness) / 2.);
+      Box wrpShape_sub((sx - 2.*carbon_thickness - 2.*wrap_thickness) / 2., (sy - 2.*carbon_thickness - 2.*wrap_thickness) / 2., sz / 2.);
+      SubtractionSolid wrp_subtract(wrpShape, wrpShape_sub, Position(0., 0., -wrap_thickness));
+      
+      Box gapShape(sx / 2., sy / 2., (sz - 2. * length_wrapper) / 2.);
+      Box gapShape_sub((sx - 2.*carbon_thickness) / 2., (sy - 2.*carbon_thickness) / 2., (sz - 2. * length_wrapper) / 2.);
+      SubtractionSolid gap_subtract(gapShape, gapShape_sub, Position(0., 0., 0.));
+
+      Volume carbonVol("carbon_vol", carbon_subtract, carbonMat);
+      Volume wrpVol("wrapper_vol", wrp_subtract, wrpMat);
+      Volume gapVol("gap_vol", gap_subtract, gapMat);
+      
+      modVol.placeVolume(carbonVol, Position(0., 0., (sz - length_wrapper - wrap_thickness) / 2.)); //put the wrap in the both ends of crystal
+      modVol.placeVolume(carbonVol, Position(0., 0., (length_wrapper - sz - wrap_thickness) / 2.));
+      modVol.placeVolume(wrpVol, Position(0., 0., wrap_thickness / 2.));
+      modVol.placeVolume(gapVol, Position(0., 0., -wrap_thickness / 2.)); //put the gap in the middle of crystal 
+
+      carbonVol.setVisAttributes(desc.visAttributes(wrp.attr<std::string>(_Unicode(vis_carbon))));
+      wrpVol.setVisAttributes(desc.visAttributes(wrp.attr<std::string>(_Unicode(vis_wrap))));
+      gapVol.setVisAttributes(desc.visAttributes(wrp.attr<std::string>(_Unicode(vis_gap))));
+
+      std::cout << "with wrapper" << std::endl;
+
       return std::make_tuple(modVol, Position{sx, sy, sz});
     }
-    auto   wrpMat = desc.material(wrp.attr<std::string>(_Unicode(material)));
-    Box    wrpShape((sx + thickness) / 2., (sy + thickness) / 2., sz / 2.);
-    Volume wrpVol("wrapper_vol", wrpShape, wrpMat);
-    wrpVol.placeVolume(modVol, Position(0., 0., 0.));
-    wrpVol.setVisAttributes(desc.visAttributes(wrp.attr<std::string>(_Unicode(vis))));
-    return std::make_tuple(wrpVol, Position{sx + thickness, sy + thickness, sz});
-  }
 }
 
 // place modules, id must be provided
@@ -324,18 +384,149 @@ static std::tuple<int, int> add_disk(Detector& desc, Assembly& env, xml::Collect
   Tube        solid(rmin, rmax, modSize.z() / 2.0, phimin, phimax);
   Volume      env_vol(std::string(env.name()) + "_envelope", solid, material);
   Transform3D tr_global = RotationZYX(rot.z(), rot.y(), rot.x()) * Translation3D(pos.x(), pos.y(), pos.z());
-  if (has_envelope) {
+  if (has_envelope) 
     env.placeVolume(env_vol, tr_global);
-  }
+ 
 
   // local placement of modules
-  int  mid    = 0;
+  int mid = 0;
   auto points = epic::geo::fillRectangles({0., 0.}, modSize.x(), modSize.y(), rmin, rmax, phimin, phimax);
-  for (auto& p : points) {
-    Transform3D tr_local = RotationZYX(0.0, 0.0, 0.0) * Translation3D(p.x(), p.y(), 0.0);
-    auto modPV = (has_envelope ? env_vol.placeVolume(modVol, tr_local) : env.placeVolume(modVol, tr_global * tr_local));
-    modPV.addPhysVolID("sector", sector_id).addPhysVolID("module", id_begin + mid++);
-  }
+  for (auto& p : points)
+    {      
+      Transform3D tr_local = RotationZYX(0.0, 0.0, 0.0) * Translation3D(p.x(), p.y(), 0.0);
+      auto modPV = (has_envelope ? env_vol.placeVolume(modVol, tr_local) : env.placeVolume(modVol, tr_global * tr_local));
+      modPV.addPhysVolID("sector", sector_id).addPhysVolID("module", id_begin + mid++);
+    }
+
+  
+  return {sector_id, mid};
+}
+
+// place 12 surface disk of modules
+static std::tuple<int, int> add_12surface_disk(Detector& desc, Assembly& env, xml::Collection_t& plm, SensitiveDetector& sens, int sid)
+{
+  auto [modVol, modSize] = build_module(desc, plm, sens);
+  int    sector_id       = dd4hep::getAttrOrDefault<int>(plm, _Unicode(sector), sid);
+  int    id_begin        = dd4hep::getAttrOrDefault<int>(plm, _Unicode(id_begin), 1);
+  double rmin            = plm.attr<double>(_Unicode(rmin));
+  double rmax            = plm.attr<double>(_Unicode(rmax));
+  double r12min          = plm.attr<double>(_Unicode(r12min));
+  double r12max          = plm.attr<double>(_Unicode(r12max));
+  double structure_frame_length = plm.attr<double>(_Unicode(SFlength));
+  double calo_module_length = plm.attr<double>(_Unicode(CMlength));
+  double phimin          = dd4hep::getAttrOrDefault<double>(plm, _Unicode(phimin), 0.);
+  double phimax          = dd4hep::getAttrOrDefault<double>(plm, _Unicode(phimax), 2. * M_PI);
+
+  
+  // placement inside mother
+  //
+  // auto pos = get_xml_xyz(plm, _Unicode(position));
+  // auto rot = get_xml_xyz(plm, _Unicode(rotation));
+
+
+  
+  //=========================================================
+  // optional envelope volume and the supporting frame
+  //=========================================================
+  // The mother volume of modules
+  //
+  bool has_envelope = dd4hep::getAttrOrDefault<bool>(plm, _Unicode(envelope), false);
+  Material ring_material     = desc.material(getAttrOrDefault<std::string>(plm, _U(material), "StainlessSteel"));
+  // Material hole_material     = desc.material(getAttrOrDefault<std::string>(plm, _U(material), "Air"));
+  PolyhedraRegular solid_world(12, 0., r12min, calo_module_length);
+  Tube solid_sub(0., rmin, calo_module_length/2., phimin, phimax);
+  SubtractionSolid calo_subtract(solid_world, solid_sub, Position(0., 0., 0.)); 
+  Volume      env_vol(std::string(env.name()) + "_envelope", calo_subtract, ring_material);
+  Transform3D tr_global = RotationZYX(15.*degree, 0., 0.) * Translation3D(0., 0., 0.);
+  env_vol.setVisAttributes(desc.visAttributes(plm.attr<std::string>(_Unicode(vis_steel_gap))));
+
+  
+  // Outer supporting frame
+  //
+  PolyhedraRegular solid_ring12(12, r12min, r12max, structure_frame_length);
+  Volume ring12_vol("ring12", solid_ring12, ring_material);
+  Transform3D tr_global_Oring = RotationZYX(15.*degree, 0., 0.) * Translation3D(0., 0., -20.*cm);
+  ring12_vol.setVisAttributes(desc.visAttributes(plm.attr<std::string>(_Unicode(vis_struc))));
+
+  
+  // Inner supporting frame
+  //
+  Tube        Ssolid_ring12(8.5*cm, rmin, calo_module_length/2., phimin, phimax);
+  Volume      Sring12_vol("Sring12", Ssolid_ring12, ring_material);
+  Sring12_vol.setVisAttributes(desc.visAttributes(plm.attr<std::string>(_Unicode(vis_struc))));
+  Transform3D tr_global_Iring = RotationZYX(0., 0., 0.) * Translation3D(0., 0., 0.);
+
+  
+  // Supporting frame for the cabling
+  // Having overlapped with tracker barrelendcapsupporting structure, comment here until the size and position determined
+  //
+  // PolyhedraRegular cabling_support12(12, r12max, 70.*cm, 2.54*cm);
+  // Volume cabling_support12_V("cabling_support12_V", cabling_support12, ring_material);
+  // Transform3D tr_global_csfront = RotationZYX(15.*degree, 0., 0.) * Translation3D(0., 0., 9.*cm);
+  // Transform3D tr_global_csback = RotationZYX(15.*degree, 0., 0.) * Translation3D(0., 0., -49.*cm);
+  
+  // Box hole(13.5/2.*cm, 2.54/2.*cm, 2.54/2.*cm);
+  // Volume hole_V("hole_V", hole, hole_material);
+  // Transform3D hole_pos = RotationZYX(0., 0., 0.) * Translation3D(0., 0., 0.);
+
+
+  // Place frames and mother volume of modules into the world volume
+  //
+  if (has_envelope) 
+    {
+      env.placeVolume(env_vol, tr_global);                      // Place the mother volume for all modules
+      env.placeVolume(ring12_vol, tr_global_Oring);             // Place the outer supporting frame
+      env.placeVolume(Sring12_vol, tr_global_Iring);            // Place the inner supporting frame
+
+      // env.placeVolume(cabling_support12_V, tr_global_csfront);  // Place the front cabling frame(Only the holes are visible)
+      // env.placeVolume(cabling_support12_V, tr_global_csback);   // Place the back cabling frame(Only the holes are visible)
+
+      // for(int i = 0 ; i < 12 ; i++)
+      //   {
+      //     hole_pos = RotationZYX((15. + i * 30.)*degree, 0., 0.) * Translation3D(82.5*mm, 675.*mm, 0.);
+      //     cabling_support12_V.placeVolume(hole_V, hole_pos);
+      //     hole_pos = RotationZYX((15. + i * 30.)*degree, 0., 0.) * Translation3D(-82.5*mm, 675.*mm, 0.);
+      //     cabling_support12_V.placeVolume(hole_V, hole_pos);
+      //   }
+    }
+
+    
+
+  
+  // local placement of modules
+  //
+  int mid = 0, total_id = 0;  
+  auto points = epic::geo::fillRectangles({0., 0.}, modSize.x(), modSize.y(), rmin, rmax, phimin, phimax);
+
+  Transform3D add_local = RotationZYX(-15.*degree, 0.0, 0.0) * Translation3D(-14.35*cm, 61.5*cm, 0.0);
+  auto modPV = env_vol.placeVolume(modVol, add_local);
+  modPV.addPhysVolID("sector", sector_id).addPhysVolID("module", total_id);
+
+  // Place the modules in the circle
+  for (auto& p : points)
+    {            
+      Transform3D tr_local = RotationZYX(-15.*degree, 0.0, 0.0) * Translation3D(p.x(), p.y(), 0.0);
+      modPV = (has_envelope ? env_vol.placeVolume(modVol, tr_local) : env.placeVolume(modVol, tr_global * tr_local));
+      total_id = id_begin + mid++;
+      modPV.addPhysVolID("sector", sector_id).addPhysVolID("module", total_id);      
+    }
+
+  
+  // Add the modules manually in the gap
+  //
+  const int add_N_mod = 51;  
+  double addX[add_N_mod] = {-16.4,-18.45,-20.5,-38.95,-43.05,-45.1,-47.15,-49.2,-59.45,-61.5,-61.5,-61.5,16.4,18.45,20.5,38.95,43.05,45.1,47.15,49.2,59.45,61.5,61.5,61.5,-16.4,-18.45,-20.5,-38.95,-43.05,-45.1,-47.15,-49.2,-59.45,-61.5,-61.5,-61.5,16.4,18.45,20.5,38.95,43.05,45.1,47.15,49.2,59.45,61.5,61.5,61.5,14.35,14.35,-14.35};
+  double addY[add_N_mod] = {61.5,61.5,59.45,49.2,47.15,45.1,43.05,38.95,20.5,14.35,16.4,18.45,61.5,61.5,59.45,49.2,47.15,45.1,43.05,38.95,20.5,14.35,16.4,18.45,-61.5,-61.5,-59.45,-49.2,-47.15,-45.1,-43.05,-38.95,-20.5,-14.35,-16.4,-18.45,-61.5,-61.5,-59.45,-49.2,-47.15,-45.1,-43.05,-38.95,-20.5,-14.35,-16.4,-18.45,-61.5,61.5,-61.5};
+  for(int im = 0 ; im < add_N_mod ; im++)
+    {
+      total_id++;
+      add_local = RotationZYX(-15.*degree, 0.0, 0.0) * Translation3D(addX[im]*cm, addY[im]*cm, 0.0);
+      modPV = env_vol.placeVolume(modVol, add_local);
+      modPV.addPhysVolID("sector", sector_id).addPhysVolID("module", total_id);
+    }
+
+  
+    
   return {sector_id, mid};
 }
 

--- a/src/HomogeneousCalorimeter_geo.cpp
+++ b/src/HomogeneousCalorimeter_geo.cpp
@@ -409,7 +409,4 @@ static std::tuple<int, int> add_lines(Detector& desc, Assembly& env, xml::Collec
   return {sector_id, mid};
 }
 //@}
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_HomogeneousCalorimeter, create_detector)
-#endif
 DECLARE_DETELEMENT(epic_HomogeneousCalorimeter, create_detector)

--- a/src/HybridCalorimeter_geo.cpp
+++ b/src/HybridCalorimeter_geo.cpp
@@ -181,7 +181,4 @@ static Ref_t create_detector(Detector& desc, xml::Handle_t handle, SensitiveDete
 }
 
 //@}
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_HybridCalorimeter, create_detector)
-#endif
 DECLARE_DETELEMENT(epic_HybridCalorimeter, create_detector)

--- a/src/MPGDDIRC_geo.cpp
+++ b/src/MPGDDIRC_geo.cpp
@@ -1,0 +1,246 @@
+/** \addtogroup PID
+ * \brief Type: **Barrel bar detector (rectangular geom.) with frames surrounding the perimeter.
+ * \author S. Joosten
+ * Modified by M. Posik
+ *
+ * \ingroup PID
+ * \ingroup Tracking
+ *
+ *
+ * \code
+ * \endcode
+ *
+ * @{
+ */
+
+#include "DD4hep/DetFactoryHelper.h"
+#include "DD4hep/Printout.h"
+#include "DD4hep/Shapes.h"
+#include "DDRec/DetectorData.h"
+#include "DDRec/Surface.h"
+#include "XML/Layering.h"
+#include <array>
+
+using namespace std;
+using namespace dd4hep;
+
+/** Barrel Bar detector with optional frame
+ *
+ * - Optional "frame" tag within the module element (frame eats part of the module width and length
+ *   and surrounds the rectangular perimeter)
+ * - Detector is setup as a "tracker" so we can use the hits
+ *
+ */
+static Ref_t create_MPGDDIRC_geo(Detector& description, xml_h e, SensitiveDetector sens)
+{
+  typedef vector<PlacedVolume> Placements;
+  xml_det_t                    x_det = e;
+  //  Material                                air      = description.air();
+  int                                     det_id   = x_det.id();
+  string                                  det_name = x_det.nameStr();
+  DetElement                              sdet(det_name, det_id);
+  map<string, Volume>                     volumes;
+  map<string, Placements>                 sensitives;
+  map<string, std::vector<rec::VolPlane>> volplane_surfaces;
+  PlacedVolume                            pv;
+  dd4hep::xml::Dimension                  dimensions(x_det.dimensions());
+  xml_dim_t                               mpgd_dirc_pos = x_det.position();
+  Assembly                                assembly(det_name);
+
+  map<string, std::array<double, 2>> module_thicknesses;
+  sens.setType("tracker");
+
+  // loop over the modules
+  for (xml_coll_t mi(x_det, _U(module)); mi; ++mi) {
+    xml_comp_t x_mod = mi;
+    string     m_nam = x_mod.nameStr();
+
+    if (volumes.find(m_nam) != volumes.end()) {
+      printout(ERROR, "MPGDDIRC_geo",
+               string((string("Module with named ") + m_nam + string(" already exists."))).c_str());
+      throw runtime_error("Logics error in building modules.");
+    }
+
+    int    ncomponents     = 0;
+    double total_thickness = 0;
+
+    // Compute module total thickness from components
+    xml_coll_t ci(x_mod, _U(module_component));
+    for (ci.reset(), total_thickness = 0.0; ci; ++ci) {
+      total_thickness += xml_comp_t(ci).thickness();
+    }
+    // the module assembly volume
+    Assembly m_vol(m_nam);
+    volumes[m_nam] = m_vol;
+    m_vol.setVisAttributes(description, x_mod.visStr());
+
+    // Optional module frame.
+    // frame is 4  bars around the perimeter of the rectangular module. The frame will eat the
+    // overlapping module area
+    //
+    //  ___
+    // |___| <-- example module cross section (x-y plane), frame is flush with the
+    //           bottom of the module and protrudes on the top if needed
+
+    // Get frame width, as it impacts the main module for being built. We
+    // construct the actual frame structure later (once we know the module width)
+    double frame_width = 0;
+    if (x_mod.hasChild(_U(frame))) {
+      xml_comp_t m_frame = x_mod.child(_U(frame));
+      frame_width        = m_frame.width();
+    }
+
+    double thickness_so_far     = 0.0;
+    double thickness_sum        = -total_thickness / 2.0;
+    double max_component_width  = 0;
+    double max_component_length = 0;
+    double gas_thickness        = 0.0;
+    for (xml_coll_t mci(x_mod, _U(module_component)); mci; ++mci, ++ncomponents) {
+      xml_comp_t x_comp    = mci;
+      string     c_nam     = _toString(ncomponents, "component%d");
+      string     comp_name = x_comp.nameStr();
+
+      double box_width  = x_comp.width();
+      double box_length = x_comp.length();
+      Box    c_box;
+      // Since MPGD frames are layed over the MPGD foils, the foil material is pressent under the frame as well.
+      // The gas volumes are not present under the frames, so our frames must eat only the gas module areas
+      //
+      //   ------------------- MPGD foil
+      //   --               -- Frame
+      //   --  gas volume   -- Frame
+      //   --               -- Frame
+      //   ------------------- MPGD foil
+
+      // Look for gas modules to subtract frame thickness from
+      // FIXME: these module names are hard coded for now. Should find
+      // a way to set a arribut via the moduel tag to flag what components
+      // need to have frame thickness subtracted.
+      if ((comp_name == "DriftGap" || comp_name == "WindowGasGap")) {
+        box_width            = x_comp.width() - 2.0 * frame_width;
+        box_length           = x_comp.length() - 2.0 * frame_width;
+        max_component_width  = box_width;
+        max_component_length = box_length;
+        gas_thickness += x_comp.thickness();
+        c_box = {box_width / 2, box_length / 2, x_comp.thickness() / 2};
+        printout(DEBUG, "MPGDDIRC_geo", "gas: %f", comp_name);
+        printout(DEBUG, "MPGDDIRC_geo", "box_width: %f", box_width);
+        printout(DEBUG, "MPGDDIRC_geo", "box_length: %%f", box_length);
+        printout(DEBUG, "MPGDDIRC_geo", "box_thickness: %f", x_comp.thickness());
+      } else {
+        c_box = {x_comp.width() / 2, x_comp.length() / 2, x_comp.thickness() / 2};
+        printout(DEBUG, "MPGDDIRC_geo", "Not gas: %f", comp_name);
+        printout(DEBUG, "MPGDDIRC_geo", "box_comp_width: %f", x_comp.width());
+        printout(DEBUG, "MPGDDIRC_geo", "box_comp_length: %f", x_comp.length());
+        printout(DEBUG, "MPGDDIRC_geo", "box_comp_thickness: %f", x_comp.thickness());
+      }
+      Volume c_vol{c_nam, c_box, description.material(x_comp.materialStr())};
+      pv = m_vol.placeVolume(c_vol, Position(0, 0, thickness_sum + x_comp.thickness() / 2.0));
+
+      c_vol.setRegion(description, x_comp.regionStr());
+      c_vol.setLimitSet(description, x_comp.limitsStr());
+      c_vol.setVisAttributes(description, x_comp.visStr());
+      if (x_comp.isSensitive()) {
+        c_vol.setSensitiveDetector(sens);
+        sensitives[m_nam].push_back(pv);
+        module_thicknesses[m_nam] = {thickness_so_far + x_comp.thickness() / 2.0,
+                                     total_thickness - thickness_so_far - x_comp.thickness() / 2.0};
+        // -------- create a measurement plane for the tracking surface attched to the sensitive volume -----
+        rec::Vector3D u(0., 1., 0.);
+        rec::Vector3D v(0., 0., 1.);
+        rec::Vector3D n(1., 0., 0.);
+
+        // compute the inner and outer thicknesses that need to be assigned to the tracking surface
+        // depending on wether the support is above or below the sensor
+        double inner_thickness = module_thicknesses[m_nam][0];
+        double outer_thickness = module_thicknesses[m_nam][1];
+
+        rec::SurfaceType type(rec::SurfaceType::Sensitive);
+
+        rec::VolPlane surf(c_vol, type, inner_thickness, outer_thickness, u, v, n); //,o ) ;
+        volplane_surfaces[m_nam].push_back(surf);
+      }
+      thickness_sum += x_comp.thickness();
+      thickness_so_far += x_comp.thickness();
+    }
+    // Now add-on the frame
+    if (x_mod.hasChild(_U(frame))) {
+      xml_comp_t m_frame         = x_mod.child(_U(frame));
+      double     frame_thickness = getAttrOrDefault<double>(m_frame, _U(thickness), total_thickness);
+
+      Box lframe_box{m_frame.width() / 2.0, (max_component_length + 2.0 * m_frame.width()) / 2.0,
+                     frame_thickness / 2.0};
+      Box rframe_box{m_frame.width() / 2.0, (max_component_length + 2.0 * m_frame.width()) / 2.0,
+                     frame_thickness / 2.0};
+      Box tframe_box{max_component_width / 2.0, m_frame.width() / 2.0, frame_thickness / 2.0};
+      Box bframe_box{max_component_width / 2.0, m_frame.width() / 2.0, frame_thickness / 2.0};
+
+      // Keep track of frame with so we can adjust the module bars appropriately
+
+      Volume lframe_vol{"left_frame", lframe_box, description.material(m_frame.materialStr())};
+      Volume rframe_vol{"right_frame", rframe_box, description.material(m_frame.materialStr())};
+      Volume tframe_vol{"top_frame", tframe_box, description.material(m_frame.materialStr())};
+      Volume bframe_vol{"bottom_frame", bframe_box, description.material(m_frame.materialStr())};
+
+      lframe_vol.setVisAttributes(description, m_frame.visStr());
+      rframe_vol.setVisAttributes(description, m_frame.visStr());
+      tframe_vol.setVisAttributes(description, m_frame.visStr());
+      bframe_vol.setVisAttributes(description, m_frame.visStr());
+
+      printout(DEBUG, "MPGDDIRC_geo", "frame_thickness: %f", frame_thickness);
+      printout(DEBUG, "MPGDDIRC_geo", "total_thickness: %f", total_thickness);
+      printout(DEBUG, "MPGDDIRC_geo", "frame_thickness + total_thickness: %f", frame_thickness + total_thickness);
+
+      m_vol.placeVolume(lframe_vol, Position(frame_width / 2.0 + max_component_width / 2, 0.0,
+                                             frame_thickness / 2.0 - total_thickness / 2.0 - gas_thickness / 2.0));
+      m_vol.placeVolume(rframe_vol, Position(-frame_width / 2.0 - max_component_width / 2.0, 0.0,
+                                             frame_thickness / 2.0 - total_thickness / 2.0 - gas_thickness / 2.0));
+      m_vol.placeVolume(tframe_vol, Position(0.0, frame_width / 2.0 + max_component_length / 2,
+                                             frame_thickness / 2.0 - total_thickness / 2.0 - gas_thickness / 2.0));
+      m_vol.placeVolume(bframe_vol, Position(0.0, -frame_width / 2.0 - max_component_length / 2.0,
+                                             frame_thickness / 2.0 - total_thickness / 2.0 - gas_thickness / 2.0));
+    }
+    pv = assembly.placeVolume(m_vol);
+  }
+
+  // build layers
+  for (xml_coll_t li(x_det, _U(layer)); li; ++li) {
+    xml_comp_t x_layer  = li;
+    xml_comp_t x_layout = x_layer.child(_U(rphi_layout));
+
+    double phi0     = x_layout.phi0();     // starting phi of first module
+    double phi_tilt = x_layout.phi_tilt(); // Phi tilit of module
+    double rc       = x_layout.rc();       // Radius of the module
+    int    nphi     = x_layout.nphi();     // Number of modules in phi
+    double rphi_dr  = x_layout.dr();       // The delta radius of every other module
+    double phi_incr = (2 * M_PI) / nphi;   // Phi increment for one module
+    double phic     = phi0;                // Phi of the module
+
+    // loop over phi modules
+    for (int ii = 0; ii < nphi; ii++) {
+      double xc = rc * std::cos(phic);
+      double yc = rc * std::sin(phic);
+      // place P-side moduels
+      Transform3D tr(RotationZYX(0.0, ((M_PI / 2) - phic - phi_tilt), -M_PI / 2),
+                     Position(xc, yc, mpgd_dirc_pos.z() + 0.5 * dimensions.length())); // in x-y plane,
+      sdet.setAttributes(description, assembly, x_det.regionStr(), x_det.limitsStr(), x_det.visStr());
+      // assembly.setVisAttributes(description.invisible());
+      pv = description.pickMotherVolume(sdet).placeVolume(assembly, tr);
+      pv.addPhysVolID("system", det_id); // Set the subdetector system ID.
+      // place N-side modules
+      Transform3D tr2(RotationZYX(0.0, ((M_PI / 2) - phic - phi_tilt), -M_PI / 2),
+                      Position(xc, yc, mpgd_dirc_pos.z() - 0.5 * dimensions.length()));
+      pv = description.pickMotherVolume(sdet).placeVolume(assembly, tr2);
+      pv.addPhysVolID("system", det_id); // Set the subdetector system ID.
+      // increment counters
+      phic += phi_incr;
+      rc += rphi_dr;
+    }
+  }
+  sdet.setPlacement(pv);
+  return sdet;
+}
+
+//@}
+// clang-format off
+DECLARE_DETELEMENT(epic_MPGDDIRC, create_MPGDDIRC_geo)

--- a/src/MRich_geo.cpp
+++ b/src/MRich_geo.cpp
@@ -459,7 +459,4 @@ static Ref_t createDetector(Detector& description, xml::Handle_t e, SensitiveDet
 // }
 
 // clang-format off
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_MRICH, createDetector)
-#endif
 DECLARE_DETELEMENT(epic_MRICH, createDetector)

--- a/src/PFRICH_geo.cpp
+++ b/src/PFRICH_geo.cpp
@@ -308,7 +308,4 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
 }
 
 // clang-format off
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_PFRICH, createDetector)
-#endif
 DECLARE_DETELEMENT(epic_PFRICH, createDetector)

--- a/src/PolyhedraEndcapCalorimeter2_geo.cpp
+++ b/src/PolyhedraEndcapCalorimeter2_geo.cpp
@@ -128,11 +128,5 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 }
 
 // clang-format off
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_PolyhedraEndcapCalorimeter2, create_detector)
-#endif
 DECLARE_DETELEMENT(epic_PolyhedraEndcapCalorimeter2, create_detector)
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_PolyhedraEndcapCalorimeter, create_detector)
-#endif
 DECLARE_DETELEMENT(epic_PolyhedraEndcapCalorimeter, create_detector)

--- a/src/ScFiCalorimeter_geo.cpp
+++ b/src/ScFiCalorimeter_geo.cpp
@@ -181,7 +181,4 @@ std::tuple<Volume, Position> build_module(const Detector& desc, const xml::Compo
   return std::make_tuple(modVol, Position{sx, sy, sz});
 }
 
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_ScFiCalorimeter, create_detector)
-#endif
 DECLARE_DETELEMENT(epic_ScFiCalorimeter, create_detector)

--- a/src/SciGlassCalorimeter_geo.cpp
+++ b/src/SciGlassCalorimeter_geo.cpp
@@ -359,10 +359,10 @@ static Ref_t create_detector(Detector &lcdd, xml_h handle,
                     Transform3D{Position{0, dir_sign * carbon_fiber_support_handle.thickness() / 2, z + (overhang_top + non_overlap_long - overhang_bottom) / 2}})
                 .volume()
                 .setVisAttributes(lcdd.visAttributes(carbon_fiber_support_handle.visStr()));
-
-            beta_prev = beta;
-            flare_angle_polar_prev = flare_angle_polar;
           }
+
+          beta_prev = beta;
+          flare_angle_polar_prev = flare_angle_polar;
         }
       }
     }

--- a/src/ShashlikCalorimeter_geo.cpp
+++ b/src/ShashlikCalorimeter_geo.cpp
@@ -182,7 +182,4 @@ static void add_disk_shashlik(Detector& desc, Assembly& env, xml::Collection_t& 
   }
 }
 
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_ShashlikCalorimeter, create_detector)
-#endif
 DECLARE_DETELEMENT(epic_ShashlikCalorimeter, create_detector)

--- a/src/SimpleDiskDetector_geo.cpp
+++ b/src/SimpleDiskDetector_geo.cpp
@@ -118,11 +118,5 @@ static Ref_t SimpleDiskDetector_create_detector(Detector& description, xml_h e, 
   return sdet;
 }
 
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_ref_SolenoidEndcap, SimpleDiskDetector_create_detector)
-#endif
 DECLARE_DETELEMENT(epic_ref_SolenoidEndcap, SimpleDiskDetector_create_detector)
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_SolenoidEndcap, SimpleDiskDetector_create_detector)
-#endif
 DECLARE_DETELEMENT(epic_SolenoidEndcap, SimpleDiskDetector_create_detector)

--- a/src/Solenoid_geo.cpp
+++ b/src/Solenoid_geo.cpp
@@ -86,7 +86,4 @@ static Ref_t create_detector(Detector& description, xml_h e, [[maybe_unused]] Se
   return sdet;
 }
 
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_Solenoid, create_detector)
-#endif
 DECLARE_DETELEMENT(epic_Solenoid, create_detector)

--- a/src/SupportServiceMaterial_geo.cpp
+++ b/src/SupportServiceMaterial_geo.cpp
@@ -132,7 +132,4 @@ static Ref_t create_SupportServiceMaterial(Detector& description, xml_h e, [[may
 }
 
 // clang-format off
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_SupportServiceMaterial, create_SupportServiceMaterial)
-#endif
 DECLARE_DETELEMENT(epic_SupportServiceMaterial, create_SupportServiceMaterial)

--- a/src/TrapEndcapTracker_geo.cpp
+++ b/src/TrapEndcapTracker_geo.cpp
@@ -326,11 +326,5 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
 //@}
 // clang-format off
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_TrapEndcapTracker, create_detector)
-#endif
 DECLARE_DETELEMENT(epic_TrapEndcapTracker, create_detector)
-#ifdef EPIC_ECCE_LEGACY_COMPAT
-DECLARE_DETELEMENT(ecce_GEMTrackerEndcap, create_detector)
-#endif
 DECLARE_DETELEMENT(epic_GEMTrackerEndcap, create_detector)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Update backward silicon disk position according to Ernst's re-optimization at https://indico.bnl.gov/event/17418/contributions/69075/attachments/43717/73653/20221010%20-%20EIC%20silicon%20consortium%20geometry.pdf

Also reduce the disks inner radii to: 
 r_beampipe (31.8mm) + 5mm (for bake out) + beampipe offset + whatever buffer to pass overlap check.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x ] New feature (issue #_177_)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Nope
### Does this PR change default behavior?
This change will create temporarily inconsistence between the tracking geometry and material map, until the new material map is produced
