### PR TITLE
fix: `farforward` should not be allowed in `*_only` configs

### DIFF
--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -184,7 +184,7 @@
 {% endif -%}
 
 {% if features is not defined or 'farforward' in features %}
-{% if features is not defined or features['farforward'] is none %}
+{%- if features is not defined or features['farforward'] is none %}
   <documentation level="11">
     ## Far foward detectors
   </documentation>
@@ -199,7 +199,7 @@
     ## Far foward detectors
   </documentation>
   <include ref="${BEAMLINE_PATH}/ip6/far_forward_brycecanyon.xml"/>
-{% endif %}
+{% endif -%}
 {% endif -%}
 
 {% if features is not defined or 'farbackward' in features %}

--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -183,7 +183,8 @@
   <include ref="${BEAMLINE_PATH}/ip6/central_beampipe.xml"/>
 {% endif -%}
 
-{% if features is not defined or 'farforward' not in features or features['farforward'] is none %}
+{% if features is not defined or 'farforward' in features %}
+{% if features is not defined or features['farforward'] is none %}
   <documentation level="11">
     ## Far foward detectors
   </documentation>
@@ -198,6 +199,7 @@
     ## Far foward detectors
   </documentation>
   <include ref="${BEAMLINE_PATH}/ip6/far_forward_brycecanyon.xml"/>
+{% endif %}
 {% endif -%}
 
 {% if features is not defined or 'farbackward' in features %}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Disallows `farforward` from being included in XML files rendered from `configurations/*_only.yml`

This PR does not affect any of
```
epic.xml
epic_full.xml
epic_arches.xml
epic_brycecanyon.xml
epic_imaging.xml
epic_sciglass.xml
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No