### PR TITLE
Updated ZDC ids to point to older ZDC ATHENA geometry for this campaign.

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -255,11 +255,15 @@ The unused IDs below are saved for future use.
     <constant name="ForwardOffMTracker_station_2_ID" value="160"/>
     <constant name="ForwardOffMTracker_station_3_ID" value="161"/>
     <constant name="ForwardOffMTracker_station_4_ID" value="162"/>
+    <!--
     <constant name="ZDC_1stSilicon_ID"           value="163"/>
     <constant name="ZDC_Crystal_ID"              value="164"/>
     <constant name="ZDC_WSi_ID"                  value="165"/>
     <constant name="ZDC_PbSi_ID"                 value="166"/>
     <constant name="ZDC_PbSci_ID"                value="167"/>
+    -->
+    <constant name="ZDCEcal_ID"              value="163"/>
+    <constant name="ZDCHcal_ID"              value="164"/>
     <constant name="VacuumMagnetElement_1_ID"        value="168"/>
     <constant name="B0ECal_ID" value="169"/>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The PR switches the 5 hit IDs (163 - 167) used the FoCal ZDC back to the 2 IDs used (163-164) for the old ATHENA ZDC. This is because the digitization is problematic for the FoCal design at the moment.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Documentation update
- [x] Other: Revert to older geometry to match existing digitization.

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
It should not - it should AVOID a breaking issue at digitization.

### Does this PR change default behavior?
It should make the default behavior work properly.