### PR TITLE
epic.xml.jinja2: fix logic for farforward

### DIFF
--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -183,21 +183,17 @@
   <include ref="${BEAMLINE_PATH}/ip6/central_beampipe.xml"/>
 {% endif -%}
 
-{% if features is not defined or 'farforward' not in features or features['farforward'] is none %}
+{% if features is not defined or 'farforward' in features %}
   <documentation level="11">
     ## Far foward detectors
   </documentation>
+  {% if features is not defined or features['farforward'] is none %}
   <include ref="${BEAMLINE_PATH}/ip6/far_forward.xml"/>
-{% elif 'arches' in features['farforward'] %}
-  <documentation level="11">
-    ## Far foward detectors
-  </documentation>
+  {% elif 'arches' in features['farforward'] %}
   <include ref="${BEAMLINE_PATH}/ip6/far_forward_arches.xml"/>
-{% elif 'brycecanyon' in features['farforward'] %}
-  <documentation level="11">
-    ## Far foward detectors
-  </documentation>
+  {% elif 'brycecanyon' in features['farforward'] %}
   <include ref="${BEAMLINE_PATH}/ip6/far_forward_brycecanyon.xml"/>
+  {% endif -%}
 {% endif -%}
 
 {% if features is not defined or 'farbackward' in features %}


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/eic/epic/pull/186

The current logic enables farforward whenever `'farforward' not in features` which makes it harder to disable farforward.