### PR TITLE
feat(dRICH): add readout for charged particles

### DIFF
--- a/compact/drich.xml
+++ b/compact/drich.xml
@@ -224,12 +224,13 @@
 
 <documentation level="10">
 #### Readout
-- segmentation: square matrix of pixels
+- sensor segmentation: square matrix of pixels
   - `grid_size_x,y`: size of each sensor pixel
   - `offset_x,y`: specified such that the `x` and `y` values are unsigned
     (except for very rare hits on the sensor sides)
 </documentation>
 <readouts>
+  <!-- sensor pixels (Cartesian matrix): for photon hits -->
   <readout name="DRICHHits">
     <segmentation
       type="CartesianGridXY"
@@ -240,6 +241,25 @@
       />
     <id>system:8,sector:3,module:12,x:32:-16,y:-16</id>
   </readout>
+  <!-- radiator z-slices: for charged particle trajectories -->
+  <readout name="DRICHTracks">
+    <segmentation
+      type="CartesianStripZ"
+      strip_size_x="DRICH_aerogel_thickness / 5.0"
+      offset_x="0.0"
+      identifier_x="slice"
+      />
+    <id>system:8,sector:3,module:12,slice:32:-32</id>
+  </readout>
+  <!-- <readout name="DRICHGasTracks"> -->
+  <!--   <segmentation -->
+  <!--     type="CartesianStripZ" -->
+  <!--     strip_size_x="(DRICH_Length - DRICH_aerogel_thickness) / 10.0" -->
+  <!--     offset_x="0.0" -->
+  <!--     identifier_x="slice" -->
+  <!--     /> -->
+  <!--   <id>system:8,radiator:3,slice:32:-32</id> -->
+  <!-- </readout> -->
 </readouts>
 
 

--- a/compact/drich.xml
+++ b/compact/drich.xml
@@ -230,36 +230,27 @@
     (except for very rare hits on the sensor sides)
 </documentation>
 <readouts>
-  <!-- sensor pixels (Cartesian matrix): for photon hits -->
   <readout name="DRICHHits">
-    <segmentation
-      type="CartesianGridXY"
-      grid_size_x="DRICH_pixel_pitch"
-      grid_size_y="DRICH_pixel_pitch"
-      offset_x="-0.5*(DRICH_num_px-1)*DRICH_pixel_pitch"
-      offset_y="-0.5*(DRICH_num_px-1)*DRICH_pixel_pitch"
-      />
-    <id>system:8,sector:3,module:12,x:32:-16,y:-16</id>
+    <segmentation type="MultiSegmentation" key="radiator">
+      <segmentation name="AerogelZslices" key_value="0" type="CartesianStripZ"
+        strip_size_x="DRICH_aerogel_thickness / 5.0"
+        offset_x="0.0"
+        identifier_x="x"
+        />
+      <segmentation name="GasZslices" key_value="1" type="CartesianStripZ"
+        strip_size_x="(DRICH_Length - DRICH_aerogel_thickness) / 10.0"
+        offset_x="0.0"
+        identifier_x="x"
+        />
+      <segmentation name="SensorPixels" key_value="7" type="CartesianGridXY"
+        grid_size_x="DRICH_pixel_pitch"
+        grid_size_y="DRICH_pixel_pitch"
+        offset_x="-0.5*(DRICH_num_px-1)*DRICH_pixel_pitch"
+        offset_y="-0.5*(DRICH_num_px-1)*DRICH_pixel_pitch"
+        />
+    </segmentation>
+    <id>system:8,radiator:3,sector:3,module:12,x:32:-16,y:-16</id>
   </readout>
-  <!-- radiator z-slices: for charged particle trajectories -->
-  <readout name="DRICHTracks">
-    <segmentation
-      type="CartesianStripZ"
-      strip_size_x="DRICH_aerogel_thickness / 5.0"
-      offset_x="0.0"
-      identifier_x="slice"
-      />
-    <id>system:8,sector:3,module:12,slice:32:-32</id>
-  </readout>
-  <!-- <readout name="DRICHGasTracks"> -->
-  <!--   <segmentation -->
-  <!--     type="CartesianStripZ" -->
-  <!--     strip_size_x="(DRICH_Length - DRICH_aerogel_thickness) / 10.0" -->
-  <!--     offset_x="0.0" -->
-  <!--     identifier_x="slice" -->
-  <!--     /> -->
-  <!--   <id>system:8,radiator:3,slice:32:-32</id> -->
-  <!-- </readout> -->
 </readouts>
 
 

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -293,10 +293,10 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   };
 
   // make the radiators sensitive, to get actual charged particle tracks
-  // aerogelPV.addPhysVolID("radiator",0);
-  // gasvolPV.addPhysVolID("radiator",1);
-  aerogelPV.addPhysVolID("sector",7).addPhysVolID("module",0);
-  gasvolPV.addPhysVolID("sector",7).addPhysVolID("module",1);
+  aerogelPV.addPhysVolID("radiator",0);
+  gasvolPV.addPhysVolID("radiator",1);
+  aerogelPV.addPhysVolID("sector",0).addPhysVolID("module",0);
+  gasvolPV.addPhysVolID("sector",0).addPhysVolID("module",0);
   aerogelVol.setSensitiveDetector(sens);
   gasvolVol.setSensitiveDetector(sens);
 
@@ -550,7 +550,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
           // if(isec==0) printf("%d %f %f\n",imod,sensorPV.position().x(),sensorPV.position().y());
 
           // properties
-          sensorPV.addPhysVolID("sector", isec).addPhysVolID("module", imod); // NOTE: must be consistent with `sensorIDfields`
+          sensorPV.addPhysVolID("radiator",7).addPhysVolID("sector", isec).addPhysVolID("module", imod); // NOTE: must be consistent with `sensorIDfields`
           auto imodsec = encodeSensorID(sensorPV.volIDs());
           std::string modsecName = secName + "_" + std::to_string(imod);
           DetElement sensorDE(det, "sensor_de_" + modsecName, imodsec);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
For reconstruction development, it is useful to have the charged particle steps. To emulate them, this PR aims to segment the aerogel and gas radiators into 1D z-slices. Hits on each slice could then be used as potential photon emission vertices. 

In real reconstruction, we will only have the track reconstruction; this PR serves to (1) help us integrate the IRT part of the reconstruction without worrying about the tracking information yet and (2) provide debugging assistance in the future. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Hopefully not

### Does this PR change default behavior?
Hopefully not