### PR TITLE
fix: remove spurious debugging output

### DIFF
--- a/src/HomogeneousCalorimeter_geo.cpp
+++ b/src/HomogeneousCalorimeter_geo.cpp
@@ -20,6 +20,7 @@
 
 
 #include "DD4hep/DetFactoryHelper.h"
+#include "DD4hep/Printout.h"
 #include "GeometryHelpers.h"
 #include <XML/Helper.h>
 #include <algorithm>
@@ -229,14 +230,9 @@ std::tuple<Volume, Position> build_module(Detector& desc, xml::Collection_t& plm
   crystalVol.setVisAttributes(desc.visAttributes(cry.attr<std::string>(_Unicode(cryvis))));
   crystalVol.setSensitiveDetector(sens);
 
-
-  std::cout << "build...." << std::endl;
-  std::cout << !plm.hasChild(_Unicode(wrapper)) << std::endl;
-  
-
   if (!plm.hasChild(_Unicode(wrapper)))    // no wrapper
     {
-      std::cout << "without wrapper" << std::endl;
+      printout(DEBUG, "HomogeneousCalorimeter", "without wrapper");
       
       return std::make_tuple(modVol, Position{sx, sy, sz});
 
@@ -279,7 +275,7 @@ std::tuple<Volume, Position> build_module(Detector& desc, xml::Collection_t& plm
       wrpVol.setVisAttributes(desc.visAttributes(wrp.attr<std::string>(_Unicode(vis_wrap))));
       gapVol.setVisAttributes(desc.visAttributes(wrp.attr<std::string>(_Unicode(vis_gap))));
 
-      std::cout << "with wrapper" << std::endl;
+      printout(DEBUG, "HomogeneousCalorimeter", "with wrapper");
 
       return std::make_tuple(modVol, Position{sx, sy, sz});
     }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
HomogeneousCalorimeter_geo.cpp had some `cout` statements that were replaced by printout statements to the DEBUG stream. This keeps the terminal output clean and organized.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators @johnny8266 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.