### PR TITLE
fix: decrease negative eta of cutout sciglass envelope

### DIFF
--- a/compact/ecal_barrel_sciglass.xml
+++ b/compact/ecal_barrel_sciglass.xml
@@ -11,7 +11,7 @@
       The current numbers are not based on any design in particular, but
       provide some extra space for other detectors.
     </comment>
-    <constant name="EcalBarrel_etamin" value="-1.9"/>
+    <constant name="EcalBarrel_etamin" value="-1.87"/>
     <constant name="EcalBarrel_etamax" value="+1.4"/>
   </define>
 

--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -115,7 +115,7 @@
   <documentation level="10">
     ## PID detectors
   </documentation>
-  {% if features is defined and features['pid'] is not none and 'dirc' in features['pid'] -%}
+  {% if features is not defined or features['pid'] is none or 'dirc' in features['pid'] -%}
   <include ref="${DETECTOR_PATH}/compact/dirc.xml"/>
   {% endif -%}
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The DIRC and Ecal barrel sciglass envelope volume were overlapping about 2 cm at the DIRC readout box. This change from -1.9 to -1.87 does not introduce overlaps in the sciglass and removes overlaps between the DIRC and the sciglass. With an MCP height of 23.746 cm starting at 70 cm radius, the DIRC is well within the 100 cm outer radius, so I think modifying the sciglass is the right approach here.

### What kind of change does this PR introduce?
- [X] Bug fix (issue overlap fixed)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added: DIRC enabled in default `epic.xml`
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators @veprbl 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.