### PR TITLE
feat: use upstream DD4hep materials

### DIFF
--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -55,6 +55,7 @@
 
   <includes>
     <gdmlFile ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile ref="${DD4hepINSTALL}/DDDetectors/compact/materials.xml"/>
     <gdmlFile ref="${DETECTOR_PATH}/compact/materials.xml"/>
     <file     ref="${DETECTOR_PATH}/compact/optical_materials.xml"/>
   </includes>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
DD4hep installs a materials.xml file. We should use the materials there if available.

### What kind of change does this PR introduce?
- [X] Bug fix (issue: material duplication with potential for inconsistent definitions)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.