### PR TITLE
fix(ci): only trigger eicweb for arches, brycecanyon

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -419,7 +419,7 @@ jobs:
     needs: [check-overlap-tgeo, check-overlap-geant4-fast]
     strategy:
       matrix:
-        detector_config: [epic_sciglass, epic_imaging, epic_arches, epic_brycecanyon]
+        detector_config: [epic_arches, epic_brycecanyon]
     steps:
     - uses: eic/trigger-gitlab-ci@v2
       id: trigger


### PR DESCRIPTION
### Briefly, what does this PR introduce?
No need for eicweb pipelines for imaging and sciglass.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: eicweb oversubscribed)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.