### PR TITLE
hotfix: restore tracker in default epic.xml

### DIFF
--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -17,7 +17,7 @@
     <type name="surface"       value="0"/>
     <type name="material"      value="0"/>
     <type name="readout"       value="0"/>
-    <type name="segmentation"  value="0"/>TrackerEndcapHits
+    <type name="segmentation"  value="0"/>
     <type name="limits"        value="0"/>
     <type name="region"        value="0"/>
     <type name="includes"      value="0"/>

--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -115,13 +115,13 @@
   <include ref="${DETECTOR_PATH}/compact/tracking/{{ tracker }}.xml"/>
   {%   endfor -%}
   {% else -%}
-  <include ref="${DETECTOR_PATH}/compact/tracker/silicon_barrel.xml"/>
-  <include ref="${DETECTOR_PATH}/compact/tracker/mpgd_barrel.xml"/>
-  <include ref="${DETECTOR_PATH}/compact/tracker/mpgd_dirc.xml"/>
-  <include ref="${DETECTOR_PATH}/compact/tracker/silicon_disks.xml"/>
-  <include ref="${DETECTOR_PATH}/compact/tracker/support_service_assembly.xml"/>
-  <include ref="${DETECTOR_PATH}/compact/tracker/tof_barrel.xml"/>
-  <include ref="${DETECTOR_PATH}/compact/tracker/tof_endcap.xml"/>
+  <include ref="${DETECTOR_PATH}/compact/tracking/silicon_barrel.xml"/>
+  <include ref="${DETECTOR_PATH}/compact/tracking/mpgd_barrel.xml"/>
+  <include ref="${DETECTOR_PATH}/compact/tracking/mpgd_dirc.xml"/>
+  <include ref="${DETECTOR_PATH}/compact/tracking/silicon_disks.xml"/>
+  <include ref="${DETECTOR_PATH}/compact/tracking/support_service_assembly.xml"/>
+  <include ref="${DETECTOR_PATH}/compact/tracking/tof_barrel.xml"/>
+  <include ref="${DETECTOR_PATH}/compact/tracking/tof_endcap.xml"/>
   {% endif -%}
 {% endif -%}
 

--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -17,7 +17,7 @@
     <type name="surface"       value="0"/>
     <type name="material"      value="0"/>
     <type name="readout"       value="0"/>
-    <type name="segmentation"  value="0"/>
+    <type name="segmentation"  value="0"/>TrackerEndcapHits
     <type name="limits"        value="0"/>
     <type name="region"        value="0"/>
     <type name="includes"      value="0"/>
@@ -114,6 +114,14 @@
   {%   for tracker in features['tracking'] -%}
   <include ref="${DETECTOR_PATH}/compact/tracking/{{ tracker }}.xml"/>
   {%   endfor -%}
+  {% else -%}
+  <include ref="${DETECTOR_PATH}/compact/tracker/silicon_barrel.xml"/>
+  <include ref="${DETECTOR_PATH}/compact/tracker/mpgd_barrel.xml"/>
+  <include ref="${DETECTOR_PATH}/compact/tracker/mpgd_dirc.xml"/>
+  <include ref="${DETECTOR_PATH}/compact/tracker/silicon_disks.xml"/>
+  <include ref="${DETECTOR_PATH}/compact/tracker/support_service_assembly.xml"/>
+  <include ref="${DETECTOR_PATH}/compact/tracker/tof_barrel.xml"/>
+  <include ref="${DETECTOR_PATH}/compact/tracker/tof_endcap.xml"/>
   {% endif -%}
 {% endif -%}
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Restore the tracker in `epic.xml`, which is generated by default from the template.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators @faustus123 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.