### PR TITLE
feat: de-duplicate imaging/sciglass EcalBarrelHits

### DIFF
--- a/compact/ecal_barrel_interlayers.xml
+++ b/compact/ecal_barrel_interlayers.xml
@@ -176,7 +176,7 @@
   </detectors>
 
   <readouts>
-    <readout name="EcalBarrelHits">
+    <readout name="EcalBarrelImagingHits">
       <segmentation type="CartesianGridXY" grid_size_x="0.5 * mm" grid_size_y="0.5 * mm"/>
       <id>system:8,module:8,layer:8,slice:8,x:32:-16,y:-16</id>
     </readout>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
A collection name should be used for all hits that are similar. `EcalBarrelHits` was used for both sciglass and imaging (silicon pixel) hits. Those are not (at all) comparable and are more appropriately given different names.

### What kind of change does this PR introduce?
- [X] Bug fix (issue: name clashes in EICrecon tag resolution)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added:
  - [ ] TODO: will need changes to juggler and eicweb benchmarks (sigh)
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators @veprbl @mariakzurek @faustus123 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes. Calorimeter simulated hit collections are being renamed without backwards compatibility.

### Does this PR change default behavior?
Yes.