### PR TITLE
Update insert hole parameters, fix backplate attribute bug

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -538,8 +538,8 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="EcalEndcapPInsert_height"         value="60.0*cm"/>
     <constant name="EcalEndcapPInsert_xposition"      value="-10.0*cm"/>
     <constant name="EcalEndcapPInsert_yposition"      value="0.0*cm"/>
-    <constant name="EcalEndcapPInsert_hole_radius"    value="14.67*cm"/>
-    <constant name="EcalEndcapPInsert_hole_xposition" value="-7.29*cm"/>
+    <constant name="EcalEndcapPInsert_hole_radius"    value="14.61*cm"/>
+    <constant name="EcalEndcapPInsert_hole_xposition" value="-7.20*cm"/>
     <constant name="EcalEndcapPInsert_hole_yposition" value="0.0*cm"/>
 
     <!-- <constant name="EcalEndcapN_zmin"               value="BackwardPIDRegion_zmin + BackwardInnerEndcapRegion_length"/> -->

--- a/compact/hcal/hcal_forward_insert.xml
+++ b/compact/hcal/hcal_forward_insert.xml
@@ -69,7 +69,7 @@
         y="HcalEndcapPInsert_height"
         z="HcalEndcapPInsert_length"
       />
-      <constant name="backplate_thickness" value="HcalEndcapPInsertBackplateThickness"/>
+      <backplate thickness="HcalEndcapPInsertBackplateThickness"/>
       <comment> Tungsten/Scintillator layers </comment>
       <comment> Slices will be ordered according to the slice order listed here </comment>
       <layer repeat="HcalEndcapPInsertLayer_NTungstenRepeat" thickness="HcalEndcapPInsertSingleLayerThickness">
@@ -106,9 +106,9 @@
       </documentation>
       <beampipe_hole
         initial_hole_radius="EcalEndcapPInsert_hole_radius"
-        final_hole_radius="17.1*cm"
+        final_hole_radius="17.04*cm"
         initial_hole_x="EcalEndcapPInsert_hole_xposition"
-        final_hole_x="-10.363*cm"
+        final_hole_x="-10.27*cm"
         initial_hole_y="EcalEndcapPInsert_hole_yposition"
         final_hole_y="0.*cm"
       />

--- a/src/InsertCalorimeter_geo.cpp
+++ b/src/InsertCalorimeter_geo.cpp
@@ -49,7 +49,7 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
   const std::pair<double, double> hole_y_parameters(hole_y_initial, hole_y_final);
 
   // Getting thickness of backplate
-  auto backplate_thickness = dd4hep::getAttrOrDefault<double>(detElem, _Unicode(backplate_thickness), 0. * cm);
+  auto backplate_thickness = detElem.hasChild(_Unicode(backplate))? detElem.child(_Unicode(backplate)).attr<double>(_Unicode(thickness)) : 0.;
 
   // Function that returns a linearly interpolated hole radius, x-position, and y-position at a given z
   auto get_hole_rxy = [hole_radii_parameters, hole_x_parameters, hole_y_parameters, length,

--- a/src/InsertCalorimeter_geo.cpp
+++ b/src/InsertCalorimeter_geo.cpp
@@ -30,16 +30,16 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
   // Getting beampipe hole dimensions
   const xml::Component& beampipe_hole_xml = detElem.child(_Unicode(beampipe_hole));
   const double          hole_radius_initial =
-      dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(initial_hole_radius), 14.67 * cm);
+      dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(initial_hole_radius), 14.61 * cm);
   const double hole_radius_final =
-      dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(final_hole_radius), 17.1 * cm);
+      dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(final_hole_radius), 17.04 * cm);
   const std::pair<double, double> hole_radii_parameters(hole_radius_initial, hole_radius_final);
 
   // Subtract by pos.x() and pos.y() to convert from global to local coordinates
   const double hole_x_initial =
-      dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(initial_hole_x), -7.29 * cm) - pos.x();
+      dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(initial_hole_x), -7.20 * cm) - pos.x();
   const double hole_x_final =
-      dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(final_hole_x), -10.363 * cm) - pos.x();
+      dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(final_hole_x), -10.27 * cm) - pos.x();
   const std::pair<double, double> hole_x_parameters(hole_x_initial, hole_x_final);
 
   const double hole_y_initial =

--- a/src/InsertCalorimeter_geo.cpp
+++ b/src/InsertCalorimeter_geo.cpp
@@ -49,6 +49,14 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
   const std::pair<double, double> hole_y_parameters(hole_y_initial, hole_y_final);
 
   // Getting thickness of backplate
+  /*
+    The hole radius & position is determined by liner interpolation 
+    The HCal insert has multiple layers; interpolation goes from front of insert to front of final layer
+    So need final layer thickness (backplate thickness) for interpolation
+    
+    For the ECal insert, the hole radius & position is constant 
+    Also has only one layer so don't have a backplate_thickness there (so set to 0)
+  */
   auto backplate_thickness = detElem.hasChild(_Unicode(backplate))? detElem.child(_Unicode(backplate)).attr<double>(_Unicode(thickness)) : 0.;
 
   // Function that returns a linearly interpolated hole radius, x-position, and y-position at a given z


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Updated the forward insert's hole initial/final radius and x-position after the z positions of the forward endcap were changed to managerie values (329.6 cm for ECal, 359.6 for HCal).
Fixed bug where the attribute backplate_thickness wasn't being read in.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #243 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
None
### Does this PR change default behavior?
Adjusts default shape of the forward inserts