### PR TITLE
fix: split overlap check jobs for barrel hcal

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -372,7 +372,33 @@ jobs:
     strategy:
       matrix:
         option: ['m'] #, 's'] # FIXME
-        detector_config: [epic_arches, epic_brycecanyon, epic_arches_no_barrel_hcal, epic_brycecanyon_no_barrel_hcal] # FIXME
+        detector_config: [epic_arches_no_barrel_hcal, epic_brycecanyon_no_barrel_hcal] # FIXME
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
+      with:
+        name: build-gcc-full-eic-shell
+        path: install/
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        platform-release: "jug_xl:nightly"
+        network_types: "bridge" # this job must succeed even when new artifacts
+        setup: install/setup.sh
+        run: |
+          mkdir -p doc
+          checkOverlaps --option ${{ matrix.option }} -c ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml | tee doc/overlap_check_tgeo.out
+          noverlaps="$(grep -c ovlp doc/overlap_check_tgeo.out || true)"
+          if [[ "${noverlaps}" -gt "0" ]] ; then echo "${noverlaps} overlaps found!" && false ; fi
+
+  check-overlap-tgeo-with-barrel-hcal:
+    runs-on: ubuntu-latest
+    needs: build-gcc
+    strategy:
+      matrix:
+        option: ['m'] #, 's'] # FIXME
+        detector_config: [epic_arches, epic_brycecanyon] # FIXME
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
@@ -449,7 +475,32 @@ jobs:
     needs: build-gcc
     strategy:
       matrix:
-        detector_config: [epic_inner_detector, epic_arches, epic_brycecanyon, epic_arches_no_barrel_hcal, epic_brycecanyon_no_barrel_hcal] # FIXME
+        detector_config: [epic_inner_detector, epic_arches_no_barrel_hcal, epic_brycecanyon_no_barrel_hcal] # FIXME
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
+      with:
+        name: build-gcc-fast-eic-shell
+        path: install/
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        platform-release: "jug_xl:nightly"
+        network_types: "bridge" # this job must succeed even when new artifacts
+        setup: install/setup.sh
+        run: |
+          mkdir -p doc
+          python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml | tee doc/overlap_check_geant4.out
+          noverlaps="$(grep -c GeomVol1002 doc/overlap_check_geant4.out || true)"
+          if [[ "${noverlaps}" -gt "0" ]] ; then echo "${noverlaps} overlaps found!" && false ; fi
+
+  check-overlap-geant4-fast-with-barrel-hcal:
+    runs-on: ubuntu-latest
+    needs: build-gcc
+    strategy:
+      matrix:
+        detector_config: [epic_arches, epic_brycecanyon] # FIXME
       fail-fast: false
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### Briefly, what does this PR introduce?
With the merge of the barrel hcal, we have temprorarily failing overlap checks due to (it appears) a bug in the underlying classes. While this is being solved, we want to continue having a working CI system, so we disable the barrel hcal from some jobs. This PR moves stuff around so at least the eicweb benchmarks pipelines are started again (even if they may fail).

### What kind of change does this PR introduce?
- [X] Bug fix (issue: eicweb benchmark pipelines are not started)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.