### PR TITLE
BUGFIX: SciGlassCalorimeter: fix cutout margins

### DIFF
--- a/src/SciGlassCalorimeter_geo.cpp
+++ b/src/SciGlassCalorimeter_geo.cpp
@@ -367,7 +367,7 @@ static Ref_t create_detector(Detector &lcdd, xml_h handle,
               alpha2
             };
             Trap trap_trans_2{
-              z - (margin_top + 2 * non_overlap_long + margin_bottom) / 2,
+              z - (margin_top + non_overlap_long + margin_bottom) / 2,
               theta,
               phi,
               carbon_fiber_support_handle.thickness(), // no division by 2 to ensure subtrahend volume is thicker than the minuend
@@ -381,7 +381,7 @@ static Ref_t create_detector(Detector &lcdd, xml_h handle,
             };
             SubtractionSolid trap_trans{
               trap_trans_1, trap_trans_2,
-              Position{0., 0., (margin_bottom + non_overlap_long - margin_top) / 2}
+              Position{0., 0., (margin_bottom - margin_top) / 2 + (overhang_bottom - overhang_top) / 2}
             };
 
             envelope_v


### PR DESCRIPTION
The full "z" length includes only a single "non_overlap_length".

### Briefly, what does this PR introduce?

#### Before

![image](https://user-images.githubusercontent.com/245573/198908008-4ff0a9ca-e4a8-4be6-8d28-1460f38d879f.png)

#### After
<img width="878" alt="image" src="https://user-images.githubusercontent.com/245573/198908022-a8bda7cf-ead2-4553-9e3b-2270be50fcda.png">

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes