### PR TITLE
Simplified tile shapes for outer HCAL

### DIFF
--- a/compact/hcal/barrel_gdml.xml
+++ b/compact/hcal/barrel_gdml.xml
@@ -225,7 +225,6 @@
   <position name="Mesh2Tess_13" unit="mm" x="705.4271850585938" y="5780.03564453125" z="-1593.4134521484375"/>
   <position name="Mesh2Tess_14" unit="mm" x="804.42236328125" y="6474.501953125" z="3120.0"/>
   <position name="Mesh2Tess_15" unit="mm" x="712.2080688476562" y="5647.85400390625" z="1500.0"/>
-  <position name="center" x="0" y="0" z="0" unit="mm"/>
    </define>
   <tessellated name="HCAL_Sector_Plate">
       <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
@@ -261,7387 +260,845 @@
 
   <solid name="OuterHCalTile01" material="PlasticScint" unit="mm" x="102.707" y="426.850" z="-5.4212">
     <define>
-  <position name="Mesh2Tess_0" unit="mm" x="65.94231414794922" y="805.4404907226562" z="3.5"/>
-  <position name="Mesh2Tess_1" unit="mm" x="65.54114532470703" y="804.7456665039062" z="-2.0"/>
-  <position name="Mesh2Tess_2" unit="mm" x="140.00552368164062" y="804.7456665039062" z="-2.0"/>
-  <position name="Mesh2Tess_3" unit="mm" x="0.5" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_4" unit="mm" x="66.26333618164062" y="803.0021362304688" z="-2.0"/>
-  <position name="Mesh2Tess_5" unit="mm" x="66.46379852294922" y="799.57470703125" z="3.5"/>
-  <position name="Mesh2Tess_6" unit="mm" x="66.87969207763672" y="798.9342651367188" z="3.5"/>
-  <position name="Mesh2Tess_7" unit="mm" x="68.3201904296875" y="798.6080322265625" z="-2.0"/>
-  <position name="Mesh2Tess_8" unit="mm" x="138.91635131835938" y="799.2275390625" z="3.5"/>
-  <position name="Mesh2Tess_9" unit="mm" x="140.05833435058594" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_10" unit="mm" x="138.307373046875" y="800.4244995117188" z="-3.5"/>
-  <position name="Mesh2Tess_11" unit="mm" x="65.94231414794922" y="803.2484741210938" z="3.5"/>
-  <position name="Mesh2Tess_12" unit="mm" x="67.5570068359375" y="798.58154296875" z="-2.0"/>
-  <position name="Mesh2Tess_13" unit="mm" x="137.60635375976562" y="798.54541015625" z="-2.0"/>
-  <position name="Mesh2Tess_14" unit="mm" x="67.038330078125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_15" unit="mm" x="137.98965454101562" y="798.58154296875" z="3.5"/>
-  <position name="Mesh2Tess_16" unit="mm" x="66.63716125488281" y="802.8472900390625" z="3.5"/>
-  <position name="Mesh2Tess_17" unit="mm" x="138.06900024414062" y="800.1138305664062" z="-2.0"/>
-  <position name="Mesh2Tess_18" unit="mm" x="66.63031005859375" y="799.2275390625" z="3.5"/>
-  <position name="Mesh2Tess_19" unit="mm" x="139.2833251953125" y="805.6868286132812" z="3.5"/>
-  <position name="Mesh2Tess_20" unit="mm" x="136.57522583007812" y="799.0067749023438" z="-2.0"/>
-  <position name="Mesh2Tess_21" unit="mm" x="138.45721435546875" y="800.7862548828125" z="-3.5"/>
-  <position name="Mesh2Tess_22" unit="mm" x="139.08287048339844" y="799.57470703125" z="-2.0"/>
-  <position name="Mesh2Tess_23" unit="mm" x="136.20468139648438" y="799.6744995117188" z="-2.0"/>
-  <position name="Mesh2Tess_24" unit="mm" x="138.9095001220703" y="802.8472900390625" z="-2.0"/>
-  <position name="Mesh2Tess_25" unit="mm" x="139.00665283203125" y="800.7017822265625" z="-2.0"/>
-  <position name="Mesh2Tess_26" unit="mm" x="68.538330078125" y="799.6744995117188" z="-2.0"/>
-  <position name="Mesh2Tess_27" unit="mm" x="66.54000854492188" y="800.7017822265625" z="3.5"/>
-  <position name="Mesh2Tess_28" unit="mm" x="65.94231414794922" y="805.4404907226562" z="-2.0"/>
-  <position name="Mesh2Tess_29" unit="mm" x="138.66697692871094" y="798.9342651367188" z="3.5"/>
-  <position name="Mesh2Tess_30" unit="mm" x="65.69599151611328" y="805.1195068359375" z="3.5"/>
-  <position name="Mesh2Tess_31" unit="mm" x="66.46379852294922" y="799.57470703125" z="-2.0"/>
-  <position name="Mesh2Tess_32" unit="mm" x="68.67161560058594" y="798.7652587890625" z="3.5"/>
-  <position name="Mesh2Tess_33" unit="mm" x="65.69599151611328" y="803.5695190429688" z="3.5"/>
-  <position name="Mesh2Tess_34" unit="mm" x="66.87969207763672" y="798.9342651367188" z="-2.0"/>
-  <position name="Mesh2Tess_35" unit="mm" x="66.4171142578125" y="800.3369140625" z="3.5"/>
-  <position name="Mesh2Tess_36" unit="mm" x="138.91635131835938" y="799.2275390625" z="-2.0"/>
-  <position name="Mesh2Tess_37" unit="mm" x="137.00833129882812" y="799.6744995117188" z="-3.5"/>
-  <position name="Mesh2Tess_38" unit="mm" x="140.05833435058594" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_39" unit="mm" x="0.5" y="0.0" z="3.5"/>
-  <position name="Mesh2Tess_40" unit="mm" x="69.34197998046875" y="799.6744995117188" z="3.5"/>
-  <position name="Mesh2Tess_41" unit="mm" x="67.1955337524414" y="798.7140502929688" z="3.5"/>
-  <position name="Mesh2Tess_42" unit="mm" x="65.94231414794922" y="803.2484741210938" z="-2.0"/>
-  <position name="Mesh2Tess_43" unit="mm" x="140.00552368164062" y="803.943359375" z="3.5"/>
-  <position name="Mesh2Tess_44" unit="mm" x="67.788330078125" y="799.87548828125" z="-2.0"/>
-  <position name="Mesh2Tess_45" unit="mm" x="238.98008728027344" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_46" unit="mm" x="138.9095001220703" y="805.8416748046875" z="3.5"/>
-  <position name="Mesh2Tess_47" unit="mm" x="65.54114532470703" y="803.943359375" z="3.5"/>
-  <position name="Mesh2Tess_48" unit="mm" x="137.22647094726562" y="798.6080322265625" z="3.5"/>
-  <position name="Mesh2Tess_49" unit="mm" x="66.63716125488281" y="802.8472900390625" z="-2.0"/>
-  <position name="Mesh2Tess_50" unit="mm" x="66.63031005859375" y="799.2275390625" z="-2.0"/>
-  <position name="Mesh2Tess_51" unit="mm" x="68.97144317626953" y="799.0067749023438" z="3.5"/>
-  <position name="Mesh2Tess_52" unit="mm" x="139.2833251953125" y="805.6868286132812" z="-2.0"/>
-  <position name="Mesh2Tess_53" unit="mm" x="138.50833129882812" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_54" unit="mm" x="67.23929595947266" y="800.4244995117188" z="-2.0"/>
-  <position name="Mesh2Tess_55" unit="mm" x="68.15010070800781" y="799.7255859375" z="-3.5"/>
-  <position name="Mesh2Tess_56" unit="mm" x="66.54000854492188" y="800.7017822265625" z="-2.0"/>
-  <position name="Mesh2Tess_57" unit="mm" x="139.12954711914062" y="800.3369140625" z="3.5"/>
-  <position name="Mesh2Tess_58" unit="mm" x="138.66697692871094" y="798.9342651367188" z="-2.0"/>
-  <position name="Mesh2Tess_59" unit="mm" x="65.69599151611328" y="805.1195068359375" z="-2.0"/>
-  <position name="Mesh2Tess_60" unit="mm" x="67.038330078125" y="802.7944946289062" z="3.5"/>
-  <position name="Mesh2Tess_61" unit="mm" x="68.67161560058594" y="798.7652587890625" z="-2.0"/>
-  <position name="Mesh2Tess_62" unit="mm" x="67.47766876220703" y="800.1138305664062" z="-3.5"/>
-  <position name="Mesh2Tess_63" unit="mm" x="66.4171142578125" y="800.3369140625" z="-2.0"/>
-  <position name="Mesh2Tess_64" unit="mm" x="139.2833251953125" y="803.0021362304688" z="-2.0"/>
-  <position name="Mesh2Tess_65" unit="mm" x="136.34674072265625" y="799.316650390625" z="3.5"/>
-  <position name="Mesh2Tess_66" unit="mm" x="67.1955337524414" y="798.7140502929688" z="-2.0"/>
-  <position name="Mesh2Tess_67" unit="mm" x="66.63716125488281" y="805.8416748046875" z="3.5"/>
-  <position name="Mesh2Tess_68" unit="mm" x="140.00552368164062" y="803.943359375" z="-2.0"/>
-  <position name="Mesh2Tess_69" unit="mm" x="65.48833465576172" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_70" unit="mm" x="67.038330078125" y="801.1744995117188" z="-2.0"/>
-  <position name="Mesh2Tess_71" unit="mm" x="166.52439880371094" y="6.134781810156198e-15" z="-3.5"/>
-  <position name="Mesh2Tess_72" unit="mm" x="66.7517318725586" y="801.0233154296875" z="3.5"/>
-  <position name="Mesh2Tess_73" unit="mm" x="138.9095001220703" y="805.8416748046875" z="-2.0"/>
-  <position name="Mesh2Tess_74" unit="mm" x="139.60435485839844" y="803.2484741210938" z="3.5"/>
-  <position name="Mesh2Tess_75" unit="mm" x="69.19992065429688" y="799.316650390625" z="-2.0"/>
-  <position name="Mesh2Tess_76" unit="mm" x="65.54114532470703" y="803.943359375" z="-2.0"/>
-  <position name="Mesh2Tess_77" unit="mm" x="137.22647094726562" y="798.6080322265625" z="-2.0"/>
-  <position name="Mesh2Tess_78" unit="mm" x="67.9403076171875" y="798.54541015625" z="3.5"/>
-  <position name="Mesh2Tess_79" unit="mm" x="137.3965606689453" y="799.7255859375" z="-2.0"/>
-  <position name="Mesh2Tess_80" unit="mm" x="139.12954711914062" y="800.3369140625" z="-2.0"/>
-  <position name="Mesh2Tess_81" unit="mm" x="137.75833129882812" y="799.87548828125" z="-3.5"/>
-  <position name="Mesh2Tess_82" unit="mm" x="139.15553283691406" y="799.9528198242188" z="3.5"/>
-  <position name="Mesh2Tess_83" unit="mm" x="67.08944702148438" y="800.7862548828125" z="-2.0"/>
-  <position name="Mesh2Tess_84" unit="mm" x="67.038330078125" y="802.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_85" unit="mm" x="67.038330078125" y="805.8944702148438" z="3.5"/>
-  <position name="Mesh2Tess_86" unit="mm" x="0.5" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_87" unit="mm" x="137.98965454101562" y="798.58154296875" z="-2.0"/>
-  <position name="Mesh2Tess_88" unit="mm" x="136.34674072265625" y="799.316650390625" z="-2.0"/>
-  <position name="Mesh2Tess_89" unit="mm" x="66.63716125488281" y="805.8416748046875" z="-2.0"/>
-  <position name="Mesh2Tess_90" unit="mm" x="138.50833129882812" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_91" unit="mm" x="65.48833465576172" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_92" unit="mm" x="67.788330078125" y="799.87548828125" z="-3.5"/>
-  <position name="Mesh2Tess_93" unit="mm" x="138.50833129882812" y="801.1744995117188" z="-2.0"/>
-  <position name="Mesh2Tess_94" unit="mm" x="66.7517318725586" y="801.0233154296875" z="-2.0"/>
-  <position name="Mesh2Tess_95" unit="mm" x="138.79493713378906" y="801.0233154296875" z="3.5"/>
-  <position name="Mesh2Tess_96" unit="mm" x="139.60435485839844" y="803.2484741210938" z="-2.0"/>
-  <position name="Mesh2Tess_97" unit="mm" x="67.038330078125" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_98" unit="mm" x="140.00552368164062" y="804.7456665039062" z="3.5"/>
-  <position name="Mesh2Tess_99" unit="mm" x="67.9403076171875" y="798.54541015625" z="-2.0"/>
-  <position name="Mesh2Tess_100" unit="mm" x="66.3911361694336" y="799.9528198242188" z="3.5"/>
-  <position name="Mesh2Tess_101" unit="mm" x="65.69599151611328" y="803.5695190429688" z="-2.0"/>
-  <position name="Mesh2Tess_102" unit="mm" x="137.00833129882812" y="799.6744995117188" z="-2.0"/>
-  <position name="Mesh2Tess_103" unit="mm" x="69.34197998046875" y="799.6744995117188" z="-2.0"/>
-  <position name="Mesh2Tess_104" unit="mm" x="67.5570068359375" y="798.58154296875" z="3.5"/>
-  <position name="Mesh2Tess_105" unit="mm" x="139.15553283691406" y="799.9528198242188" z="-2.0"/>
-  <position name="Mesh2Tess_106" unit="mm" x="139.60435485839844" y="805.4404907226562" z="3.5"/>
-  <position name="Mesh2Tess_107" unit="mm" x="67.038330078125" y="805.8944702148438" z="-2.0"/>
-  <position name="Mesh2Tess_108" unit="mm" x="138.35113525390625" y="798.7140502929688" z="3.5"/>
-  <position name="Mesh2Tess_109" unit="mm" x="138.50833129882812" y="805.8944702148438" z="3.5"/>
-  <position name="Mesh2Tess_110" unit="mm" x="139.85067749023438" y="805.1195068359375" z="3.5"/>
-  <position name="Mesh2Tess_111" unit="mm" x="0.5" y="0.0" z="-3.5"/>
-  <position name="Mesh2Tess_112" unit="mm" x="139.85067749023438" y="803.5695190429688" z="3.5"/>
-  <position name="Mesh2Tess_113" unit="mm" x="68.97144317626953" y="799.0067749023438" z="-2.0"/>
-  <position name="Mesh2Tess_114" unit="mm" x="138.06900024414062" y="800.1138305664062" z="-3.5"/>
-  <position name="Mesh2Tess_115" unit="mm" x="67.038330078125" y="801.1744995117188" z="-3.5"/>
-  <position name="Mesh2Tess_116" unit="mm" x="138.79493713378906" y="801.0233154296875" z="-2.0"/>
-  <position name="Mesh2Tess_117" unit="mm" x="138.307373046875" y="800.4244995117188" z="-2.0"/>
-  <position name="Mesh2Tess_118" unit="mm" x="68.15010070800781" y="799.7255859375" z="-2.0"/>
-  <position name="Mesh2Tess_119" unit="mm" x="67.038330078125" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_120" unit="mm" x="139.00665283203125" y="800.7017822265625" z="3.5"/>
-  <position name="Mesh2Tess_121" unit="mm" x="138.50833129882812" y="802.7944946289062" z="3.5"/>
-  <position name="Mesh2Tess_122" unit="mm" x="68.538330078125" y="799.6744995117188" z="-3.5"/>
-  <position name="Mesh2Tess_123" unit="mm" x="238.98008728027344" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_124" unit="mm" x="67.47766876220703" y="800.1138305664062" z="-2.0"/>
-  <position name="Mesh2Tess_125" unit="mm" x="138.50833129882812" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_126" unit="mm" x="66.3911361694336" y="799.9528198242188" z="-2.0"/>
-  <position name="Mesh2Tess_127" unit="mm" x="66.26333618164062" y="805.6868286132812" z="3.5"/>
-  <position name="Mesh2Tess_128" unit="mm" x="137.3965606689453" y="799.7255859375" z="-3.5"/>
-  <position name="Mesh2Tess_129" unit="mm" x="136.8750457763672" y="798.7652587890625" z="3.5"/>
-  <position name="Mesh2Tess_130" unit="mm" x="139.60435485839844" y="805.4404907226562" z="-2.0"/>
-  <position name="Mesh2Tess_131" unit="mm" x="67.08944702148438" y="800.7862548828125" z="-3.5"/>
-  <position name="Mesh2Tess_132" unit="mm" x="138.45721435546875" y="800.7862548828125" z="-2.0"/>
-  <position name="Mesh2Tess_133" unit="mm" x="138.35113525390625" y="798.7140502929688" z="-2.0"/>
-  <position name="Mesh2Tess_134" unit="mm" x="67.038330078125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_135" unit="mm" x="138.50833129882812" y="805.8944702148438" z="-2.0"/>
-  <position name="Mesh2Tess_136" unit="mm" x="139.85067749023438" y="805.1195068359375" z="-2.0"/>
-  <position name="Mesh2Tess_137" unit="mm" x="65.54114532470703" y="804.7456665039062" z="3.5"/>
-  <position name="Mesh2Tess_138" unit="mm" x="139.85067749023438" y="803.5695190429688" z="-2.0"/>
-  <position name="Mesh2Tess_139" unit="mm" x="66.26333618164062" y="803.0021362304688" z="3.5"/>
-  <position name="Mesh2Tess_140" unit="mm" x="68.3201904296875" y="798.6080322265625" z="3.5"/>
-  <position name="Mesh2Tess_141" unit="mm" x="67.23929595947266" y="800.4244995117188" z="-3.5"/>
-  <position name="Mesh2Tess_142" unit="mm" x="138.50833129882812" y="801.1744995117188" z="-3.5"/>
-  <position name="Mesh2Tess_143" unit="mm" x="137.75833129882812" y="799.87548828125" z="-2.0"/>
-  <position name="Mesh2Tess_144" unit="mm" x="138.50833129882812" y="802.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_145" unit="mm" x="137.60635375976562" y="798.54541015625" z="3.5"/>
-  <position name="Mesh2Tess_146" unit="mm" x="166.52439880371094" y="6.134781810156198e-15" z="3.5"/>
-  <position name="Mesh2Tess_147" unit="mm" x="138.50833129882812" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_148" unit="mm" x="139.2833251953125" y="803.0021362304688" z="3.5"/>
-  <position name="Mesh2Tess_149" unit="mm" x="66.26333618164062" y="805.6868286132812" z="-2.0"/>
-  <position name="Mesh2Tess_150" unit="mm" x="136.8750457763672" y="798.7652587890625" z="-2.0"/>
-  <position name="Mesh2Tess_151" unit="mm" x="136.57522583007812" y="799.0067749023438" z="3.5"/>
-  <position name="Mesh2Tess_152" unit="mm" x="139.08287048339844" y="799.57470703125" z="3.5"/>
-  <position name="Mesh2Tess_153" unit="mm" x="136.20468139648438" y="799.6744995117188" z="3.5"/>
-  <position name="Mesh2Tess_154" unit="mm" x="138.9095001220703" y="802.8472900390625" z="3.5"/>
-  <position name="Mesh2Tess_155" unit="mm" x="69.19992065429688" y="799.316650390625" z="3.5"/>
+  <position name="Mesh2Tess_0" unit="mm" x="0.5" y="0.0" z="3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="238.98008728027344" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="0.5" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="67.038330078125" y="799.6744995117188" z="3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="166.52439880371094" y="6.134781810156198e-15" z="-3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="67.038330078125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="67.038330078125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="166.52439880371094" y="6.134781810156198e-15" z="3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="138.50833129882812" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="138.50833129882812" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="238.98008728027344" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="138.50833129882812" y="799.6744995117188" z="-3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="138.50833129882812" y="799.6744995117188" z="3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="0.5" y="0.0" z="-3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="0.5" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="67.038330078125" y="799.6744995117188" z="-3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalTile01_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_153" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_153" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_155" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_155" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_154" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_154" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_154" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_152" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_152" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_152" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_153" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_155" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_155" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_153" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_154" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_154" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_154" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_152" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_152" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
          </tessellated>
   </solid>
 
   <solid name="OuterHCalTile02" material="PlasticScint" unit="mm" x="310.850" y="426.422" z="0.0">
     <define>
-   <position name="Mesh2Tess_0" unit="mm" x="375.0416259765625" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_1" unit="mm" x="376.34063720703125" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_2" unit="mm" x="303.1833801269531" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_3" unit="mm" x="375.0416259765625" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_4" unit="mm" x="302.2725830078125" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_5" unit="mm" x="375.6617736816406" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_6" unit="mm" x="303.5716247558594" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_7" unit="mm" x="374.53887939453125" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_8" unit="mm" x="376.4905090332031" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_9" unit="mm" x="375.7916259765625" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_10" unit="mm" x="374.6022644042969" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_11" unit="mm" x="303.7725830078125" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_12" unit="mm" x="302.95147705078125" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_13" unit="mm" x="303.5716247558594" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_14" unit="mm" x="373.5416259765625" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_15" unit="mm" x="303.1576843261719" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_16" unit="mm" x="375.61895751953125" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_17" unit="mm" x="375.4298400878906" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_18" unit="mm" x="375.4298400878906" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_19" unit="mm" x="303.7159423828125" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_20" unit="mm" x="376.1022644042969" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_21" unit="mm" x="302.8216247558594" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_22" unit="mm" x="376.34063720703125" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_23" unit="mm" x="167.52841186523438" y="3.469446951953614e-17" z="-3.5"/>
-  <position name="Mesh2Tess_24" unit="mm" x="375.0416259765625" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_25" unit="mm" x="375.2096252441406" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_26" unit="mm" x="484.6166687011719" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_27" unit="mm" x="302.2725830078125" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_28" unit="mm" x="239.98410034179688" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_29" unit="mm" x="372.892578125" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_30" unit="mm" x="374.53887939453125" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_31" unit="mm" x="303.6227111816406" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_32" unit="mm" x="375.7916259765625" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_33" unit="mm" x="375.0416259765625" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_34" unit="mm" x="374.89727783203125" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_35" unit="mm" x="376.34063720703125" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_36" unit="mm" x="375.0416259765625" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_37" unit="mm" x="303.4035949707031" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_38" unit="mm" x="375.4298400878906" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_39" unit="mm" x="302.5109558105469" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_40" unit="mm" x="303.5716247558594" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_41" unit="mm" x="304.3216247558594" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_42" unit="mm" x="374.9905090332031" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_43" unit="mm" x="303.7159423828125" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_44" unit="mm" x="376.1022644042969" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_45" unit="mm" x="302.8216247558594" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_46" unit="mm" x="302.0716247558594" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_47" unit="mm" x="375.2096252441406" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_48" unit="mm" x="374.2916259765625" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_49" unit="mm" x="305.72064208984375" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_50" unit="mm" x="302.2725830078125" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_51" unit="mm" x="372.892578125" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_52" unit="mm" x="373.7789611816406" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_53" unit="mm" x="374.1578063964844" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_54" unit="mm" x="375.538330078125" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_55" unit="mm" x="305.1861877441406" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_56" unit="mm" x="375.0416259765625" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_57" unit="mm" x="303.5716247558594" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_58" unit="mm" x="375.3270263671875" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_59" unit="mm" x="373.5416259765625" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_60" unit="mm" x="374.89727783203125" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_61" unit="mm" x="303.4035949707031" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_62" unit="mm" x="304.0109558105469" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_63" unit="mm" x="375.4555358886719" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_64" unit="mm" x="302.5109558105469" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_65" unit="mm" x="303.1833801269531" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_66" unit="mm" x="374.84063720703125" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_67" unit="mm" x="239.98410034179688" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_68" unit="mm" x="376.4905090332031" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_69" unit="mm" x="302.1227111816406" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_70" unit="mm" x="304.6833801269531" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_71" unit="mm" x="305.72064208984375" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_72" unit="mm" x="302.1227111816406" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_73" unit="mm" x="303.5716247558594" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_74" unit="mm" x="305.0716247558594" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_75" unit="mm" x="373.7789611816406" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_76" unit="mm" x="303.5716247558594" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_77" unit="mm" x="302.8216247558594" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_78" unit="mm" x="374.1578063964844" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_79" unit="mm" x="375.538330078125" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_80" unit="mm" x="305.1861877441406" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_81" unit="mm" x="303.5716247558594" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_82" unit="mm" x="375.3270263671875" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_83" unit="mm" x="375.0416259765625" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_84" unit="mm" x="375.4555358886719" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_85" unit="mm" x="304.0743408203125" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_86" unit="mm" x="303.07489013671875" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_87" unit="mm" x="303.1833801269531" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_88" unit="mm" x="373.125" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_89" unit="mm" x="373.4270324707031" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_90" unit="mm" x="304.3216247558594" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_91" unit="mm" x="374.9905090332031" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_92" unit="mm" x="376.4905090332031" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_93" unit="mm" x="375.7916259765625" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_94" unit="mm" x="303.6227111816406" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_95" unit="mm" x="303.28619384765625" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_96" unit="mm" x="373.9298400878906" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_97" unit="mm" x="302.1227111816406" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_98" unit="mm" x="376.1022644042969" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_99" unit="mm" x="303.7725830078125" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_100" unit="mm" x="302.1227111816406" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_101" unit="mm" x="167.52841186523438" y="3.469446951953614e-17" z="3.5"/>
-  <position name="Mesh2Tess_102" unit="mm" x="302.9239807128906" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_103" unit="mm" x="303.5716247558594" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_104" unit="mm" x="303.5716247558594" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_105" unit="mm" x="338.91033935546875" y="0.0" z="-3.5"/>
-  <position name="Mesh2Tess_106" unit="mm" x="302.0716247558594" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_107" unit="mm" x="375.6892395019531" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_108" unit="mm" x="374.2916259765625" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_109" unit="mm" x="375.4298400878906" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_110" unit="mm" x="374.6022644042969" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_111" unit="mm" x="375.0416259765625" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_112" unit="mm" x="304.0109558105469" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_113" unit="mm" x="304.4554138183594" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_114" unit="mm" x="303.07489013671875" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_115" unit="mm" x="302.5109558105469" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_116" unit="mm" x="373.125" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_117" unit="mm" x="373.4270324707031" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_118" unit="mm" x="376.5416259765625" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_119" unit="mm" x="375.7916259765625" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_120" unit="mm" x="304.8342590332031" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_121" unit="mm" x="303.5716247558594" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_122" unit="mm" x="303.28619384765625" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_123" unit="mm" x="304.0743408203125" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_124" unit="mm" x="302.9942626953125" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_125" unit="mm" x="376.1022644042969" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_126" unit="mm" x="305.48822021484375" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_127" unit="mm" x="375.0416259765625" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_128" unit="mm" x="376.34063720703125" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_129" unit="mm" x="303.1833801269531" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_130" unit="mm" x="302.9239807128906" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_131" unit="mm" x="302.2725830078125" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_132" unit="mm" x="375.6617736816406" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_133" unit="mm" x="374.84063720703125" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_134" unit="mm" x="375.6892395019531" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_135" unit="mm" x="376.4905090332031" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_136" unit="mm" x="304.6833801269531" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_137" unit="mm" x="375.0416259765625" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_138" unit="mm" x="304.4554138183594" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_139" unit="mm" x="302.5109558105469" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_140" unit="mm" x="302.95147705078125" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_141" unit="mm" x="484.6166687011719" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_142" unit="mm" x="376.5416259765625" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_143" unit="mm" x="305.0716247558594" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_144" unit="mm" x="303.1576843261719" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_145" unit="mm" x="375.61895751953125" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_146" unit="mm" x="304.8342590332031" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_147" unit="mm" x="338.91033935546875" y="0.0" z="3.5"/>
-  <position name="Mesh2Tess_148" unit="mm" x="302.8216247558594" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_149" unit="mm" x="373.9298400878906" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_150" unit="mm" x="302.9942626953125" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_151" unit="mm" x="305.48822021484375" y="798.9898071289062" z="-2.0"/>
-   </define>
+  <position name="Mesh2Tess_0" unit="mm" x="484.6166687011719" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="167.52841186523438" y="3.469446951953614e-17" z="3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="484.6166687011719" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="303.5716247558594" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="303.5716247558594" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="338.91033935546875" y="0.0" z="-3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="375.0416259765625" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="338.91033935546875" y="0.0" z="3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="375.0416259765625" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="239.98410034179688" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="375.0416259765625" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="239.98410034179688" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="375.0416259765625" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="167.52841186523438" y="3.469446951953614e-17" z="-3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="303.5716247558594" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="303.5716247558594" y="808.344482421875" z="3.5" />
+    </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalTile02_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
         </tessellated>
   </solid>
 
   <solid name="OuterHCalTile03" material="PlasticScint" unit="mm" x="520.610" y="427.08" z="0.0">
     <define>
-  <position name="Mesh2Tess_0" unit="mm" x="545.0171508789062" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_1" unit="mm" x="614.9871826171875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_2" unit="mm" x="612.838134765625" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_3" unit="mm" x="613.8753662109375" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_4" unit="mm" x="543.12890625" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_5" unit="mm" x="543.2317504882812" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_6" unit="mm" x="613.070556640625" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_7" unit="mm" x="485.6327819824219" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_8" unit="mm" x="543.12890625" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_9" unit="mm" x="615.6072998046875" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_10" unit="mm" x="507.87432861328125" y="-5.030698080332741e-16" z="-3.5"/>
-  <position name="Mesh2Tess_11" unit="mm" x="542.0682373046875" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_12" unit="mm" x="542.9398193359375" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_13" unit="mm" x="542.7671508789062" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_14" unit="mm" x="542.0682373046875" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_15" unit="mm" x="614.9871826171875" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_16" unit="mm" x="545.4337768554688" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_17" unit="mm" x="615.7371826171875" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_18" unit="mm" x="616.2861938476562" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_19" unit="mm" x="616.0477905273438" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_20" unit="mm" x="542.8970336914062" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_21" unit="mm" x="614.1033325195312" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_22" unit="mm" x="543.5171508789062" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_23" unit="mm" x="614.4844360351562" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_24" unit="mm" x="543.12890625" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_25" unit="mm" x="613.070556640625" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_26" unit="mm" x="615.48388671875" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_27" unit="mm" x="543.9564819335938" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_28" unit="mm" x="614.9871826171875" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_29" unit="mm" x="615.2725830078125" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_30" unit="mm" x="614.2371826171875" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_31" unit="mm" x="614.5477905273438" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_32" unit="mm" x="543.5171508789062" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_33" unit="mm" x="544.0198974609375" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_34" unit="mm" x="615.7371826171875" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_35" unit="mm" x="615.3753662109375" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_36" unit="mm" x="544.62890625" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_37" unit="mm" x="616.4871826171875" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_38" unit="mm" x="616.2861938476562" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_39" unit="mm" x="616.0477905273438" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_40" unit="mm" x="544.77978515625" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_41" unit="mm" x="542.2181396484375" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_42" unit="mm" x="543.7181396484375" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_43" unit="mm" x="339.92645263671875" y="-4.683753385137379e-16" z="-3.5"/>
-  <position name="Mesh2Tess_44" unit="mm" x="614.9871826171875" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_45" unit="mm" x="614.1033325195312" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_46" unit="mm" x="542.4564819335938" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_47" unit="mm" x="727.8602905273438" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_48" unit="mm" x="544.2671508789062" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_49" unit="mm" x="614.4844360351562" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_50" unit="mm" x="545.1317138671875" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_51" unit="mm" x="542.0171508789062" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_52" unit="mm" x="615.48388671875" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_53" unit="mm" x="616.43603515625" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_54" unit="mm" x="614.7861938476562" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_55" unit="mm" x="543.6614990234375" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_56" unit="mm" x="543.5171508789062" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_57" unit="mm" x="614.9871826171875" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_58" unit="mm" x="615.2725830078125" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_59" unit="mm" x="543.5682373046875" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_60" unit="mm" x="545.0171508789062" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_61" unit="mm" x="615.3753662109375" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_62" unit="mm" x="544.0198974609375" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_63" unit="mm" x="613.7244873046875" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_64" unit="mm" x="613.8753662109375" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_65" unit="mm" x="616.4871826171875" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_66" unit="mm" x="543.34912109375" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_67" unit="mm" x="544.77978515625" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_68" unit="mm" x="542.2181396484375" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_69" unit="mm" x="614.93603515625" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_70" unit="mm" x="615.4010620117188" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_71" unit="mm" x="542.4564819335938" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_72" unit="mm" x="614.9871826171875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_73" unit="mm" x="615.634765625" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_74" unit="mm" x="614.8428344726562" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_75" unit="mm" x="545.1317138671875" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_76" unit="mm" x="615.7371826171875" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_77" unit="mm" x="542.0171508789062" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_78" unit="mm" x="543.5171508789062" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_79" unit="mm" x="616.43603515625" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_80" unit="mm" x="613.4871826171875" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_81" unit="mm" x="544.4009399414062" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_82" unit="mm" x="543.6614990234375" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_83" unit="mm" x="542.4564819335938" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_84" unit="mm" x="543.5171508789062" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_85" unit="mm" x="485.6327819824219" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_86" unit="mm" x="543.9564819335938" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_87" unit="mm" x="339.92645263671875" y="-4.683753385137379e-16" z="3.5"/>
-  <position name="Mesh2Tess_88" unit="mm" x="615.3753662109375" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_89" unit="mm" x="542.8970336914062" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_90" unit="mm" x="614.2371826171875" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_91" unit="mm" x="545.6661987304688" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_92" unit="mm" x="613.7244873046875" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_93" unit="mm" x="542.7671508789062" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_94" unit="mm" x="507.87432861328125" y="-5.030698080332741e-16" z="3.5"/>
-  <position name="Mesh2Tess_95" unit="mm" x="543.34912109375" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_96" unit="mm" x="616.0477905273438" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_97" unit="mm" x="615.1551513671875" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_98" unit="mm" x="542.2181396484375" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_99" unit="mm" x="615.4010620117188" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_100" unit="mm" x="615.6072998046875" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_101" unit="mm" x="616.43603515625" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_102" unit="mm" x="543.5171508789062" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_103" unit="mm" x="543.5171508789062" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_104" unit="mm" x="615.634765625" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_105" unit="mm" x="613.37255859375" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_106" unit="mm" x="544.2671508789062" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_107" unit="mm" x="615.7371826171875" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_108" unit="mm" x="615.5645141601562" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_109" unit="mm" x="543.5171508789062" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_110" unit="mm" x="544.4009399414062" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_111" unit="mm" x="614.9871826171875" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_112" unit="mm" x="614.7861938476562" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_113" unit="mm" x="615.3753662109375" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_114" unit="mm" x="614.9871826171875" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_115" unit="mm" x="545.6661987304688" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_116" unit="mm" x="542.8695068359375" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_117" unit="mm" x="542.7671508789062" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_118" unit="mm" x="616.2861938476562" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_119" unit="mm" x="614.9871826171875" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_120" unit="mm" x="616.0477905273438" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_121" unit="mm" x="615.1551513671875" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_122" unit="mm" x="542.2181396484375" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_123" unit="mm" x="543.1032104492188" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_124" unit="mm" x="614.93603515625" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_125" unit="mm" x="616.43603515625" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_126" unit="mm" x="543.5171508789062" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_127" unit="mm" x="727.8602905273438" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_128" unit="mm" x="543.5682373046875" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_129" unit="mm" x="613.37255859375" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_130" unit="mm" x="543.0204467773438" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_131" unit="mm" x="615.5645141601562" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_132" unit="mm" x="543.5171508789062" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_133" unit="mm" x="612.838134765625" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_134" unit="mm" x="613.4871826171875" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_135" unit="mm" x="543.2317504882812" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_136" unit="mm" x="543.12890625" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_137" unit="mm" x="542.8695068359375" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_138" unit="mm" x="616.2861938476562" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_139" unit="mm" x="614.9871826171875" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_140" unit="mm" x="614.8428344726562" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_141" unit="mm" x="542.0682373046875" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_142" unit="mm" x="614.5477905273438" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_143" unit="mm" x="542.9398193359375" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_144" unit="mm" x="542.7671508789062" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_145" unit="mm" x="542.0682373046875" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_146" unit="mm" x="545.4337768554688" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_147" unit="mm" x="543.1032104492188" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_148" unit="mm" x="544.62890625" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_149" unit="mm" x="542.4564819335938" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_150" unit="mm" x="543.7181396484375" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_151" unit="mm" x="543.0204467773438" y="800.705078125" z="-2.0"/>
-  <position name="center" x="0" y="0" z="0" unit="mm"/>
+  <position name="Mesh2Tess_0" unit="mm" x="339.92645263671875" y="-4.683753385137379e-16" z="-3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="543.5171508789062" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="339.92645263671875" y="-4.683753385137379e-16" z="3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="614.9871826171875" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="727.8602905273438" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="543.5171508789062" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="507.87432861328125" y="-5.030698080332741e-16" z="-3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="543.5171508789062" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="507.87432861328125" y="-5.030698080332741e-16" z="3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="485.6327819824219" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="543.5171508789062" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="614.9871826171875" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="614.9871826171875" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="485.6327819824219" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="614.9871826171875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="727.8602905273438" y="808.344482421875" z="-3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalTile03_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
         </tessellated>
   </solid>
 
   <solid name="OuterHCalTile04" material="PlasticScint" unit="mm" x="732.802" y="426.818" z="0.0">
     <define>
-  <position name="Mesh2Tess_0" unit="mm" x="785.9348754882812" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_1" unit="mm" x="786.18212890625" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_2" unit="mm" x="856.3994140625" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_3" unit="mm" x="785.0181884765625" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_4" unit="mm" x="856.8510131835938" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_5" unit="mm" x="858.4021606445312" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_6" unit="mm" x="855.6394653320312" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_7" unit="mm" x="784.68212890625" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_8" unit="mm" x="785.43212890625" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_9" unit="mm" x="858.3510131835938" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_10" unit="mm" x="854.7531127929688" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_11" unit="mm" x="857.5222778320312" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_12" unit="mm" x="785.43212890625" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_13" unit="mm" x="856.9021606445312" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_14" unit="mm" x="856.4627685546875" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_15" unit="mm" x="857.6521606445312" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_16" unit="mm" x="856.9021606445312" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_17" unit="mm" x="787.0467529296875" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_18" unit="mm" x="856.1521606445312" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_19" unit="mm" x="786.31591796875" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_20" unit="mm" x="857.0701904296875" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_21" unit="mm" x="856.701171875" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_22" unit="mm" x="783.9832763671875" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_23" unit="mm" x="785.0181884765625" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_24" unit="mm" x="786.5438842773438" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_25" unit="mm" x="858.201171875" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_26" unit="mm" x="508.9106750488281" y="3.5561831257524545e-15" z="3.5"/>
-  <position name="Mesh2Tess_27" unit="mm" x="855.7903442382812" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_28" unit="mm" x="784.1331176757812" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_29" unit="mm" x="857.5222778320312" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_30" unit="mm" x="785.43212890625" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_31" unit="mm" x="784.7845458984375" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_32" unit="mm" x="980.078369140625" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_33" unit="mm" x="787.0467529296875" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_34" unit="mm" x="857.6521606445312" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_35" unit="mm" x="855.4021606445312" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_36" unit="mm" x="857.9627685546875" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_37" unit="mm" x="858.201171875" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_38" unit="mm" x="785.5764770507812" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_39" unit="mm" x="857.0701904296875" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_40" unit="mm" x="783.9832763671875" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_41" unit="mm" x="785.0438842773438" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_42" unit="mm" x="785.4832763671875" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_43" unit="mm" x="858.201171875" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_44" unit="mm" x="857.3161010742188" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_45" unit="mm" x="728.8966674804688" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_46" unit="mm" x="784.7845458984375" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_47" unit="mm" x="785.0438842773438" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_48" unit="mm" x="785.6331176757812" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_49" unit="mm" x="787.5811767578125" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_50" unit="mm" x="857.3988647460938" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_51" unit="mm" x="683.914306640625" y="3.5214886562329184e-15" z="-3.5"/>
-  <position name="Mesh2Tess_52" unit="mm" x="857.6521606445312" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_53" unit="mm" x="857.9627685546875" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_54" unit="mm" x="784.1331176757812" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_55" unit="mm" x="785.0438842773438" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_56" unit="mm" x="854.9855346679688" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_57" unit="mm" x="786.5438842773438" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_58" unit="mm" x="784.9354248046875" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_59" unit="mm" x="857.9627685546875" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_60" unit="mm" x="784.68212890625" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_61" unit="mm" x="858.3510131835938" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_62" unit="mm" x="783.93212890625" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_63" unit="mm" x="856.9021606445312" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_64" unit="mm" x="856.9021606445312" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_65" unit="mm" x="856.9021606445312" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_66" unit="mm" x="784.3714599609375" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_67" unit="mm" x="786.93212890625" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_68" unit="mm" x="787.5811767578125" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_69" unit="mm" x="785.43212890625" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_70" unit="mm" x="784.81201171875" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_71" unit="mm" x="857.3988647460938" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_72" unit="mm" x="786.18212890625" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_73" unit="mm" x="785.43212890625" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_74" unit="mm" x="858.3510131835938" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_75" unit="mm" x="857.4794921875" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_76" unit="mm" x="787.3487548828125" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_77" unit="mm" x="857.2903442382812" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_78" unit="mm" x="856.9021606445312" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_79" unit="mm" x="728.8966674804688" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_80" unit="mm" x="854.9855346679688" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_81" unit="mm" x="785.8714599609375" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_82" unit="mm" x="784.9354248046875" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_83" unit="mm" x="785.2640991210938" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_84" unit="mm" x="857.9627685546875" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_85" unit="mm" x="857.5497436523438" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_86" unit="mm" x="857.1875610351562" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_87" unit="mm" x="508.9106750488281" y="3.5561831257524545e-15" z="-3.5"/>
-  <position name="Mesh2Tess_88" unit="mm" x="784.68212890625" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_89" unit="mm" x="858.3510131835938" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_90" unit="mm" x="683.914306640625" y="3.5214886562329184e-15" z="3.5"/>
-  <position name="Mesh2Tess_91" unit="mm" x="856.8510131835938" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_92" unit="mm" x="856.4627685546875" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_93" unit="mm" x="783.93212890625" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_94" unit="mm" x="785.43212890625" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_95" unit="mm" x="856.9021606445312" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_96" unit="mm" x="785.43212890625" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_97" unit="mm" x="784.3714599609375" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_98" unit="mm" x="855.4021606445312" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_99" unit="mm" x="857.2903442382812" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_100" unit="mm" x="856.0183715820312" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_101" unit="mm" x="858.201171875" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_102" unit="mm" x="856.7578125" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_103" unit="mm" x="786.6947631835938" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_104" unit="mm" x="783.9832763671875" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_105" unit="mm" x="785.6331176757812" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_106" unit="mm" x="784.81201171875" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_107" unit="mm" x="785.4832763671875" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_108" unit="mm" x="856.701171875" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_109" unit="mm" x="784.3714599609375" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_110" unit="mm" x="785.43212890625" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_111" unit="mm" x="784.8547973632812" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_112" unit="mm" x="857.4794921875" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_113" unit="mm" x="787.3487548828125" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_114" unit="mm" x="857.3161010742188" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_115" unit="mm" x="857.2903442382812" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_116" unit="mm" x="980.078369140625" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_117" unit="mm" x="856.1521606445312" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_118" unit="mm" x="784.1331176757812" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_119" unit="mm" x="785.146728515625" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_120" unit="mm" x="785.2640991210938" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_121" unit="mm" x="857.5497436523438" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_122" unit="mm" x="855.2875366210938" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_123" unit="mm" x="857.1875610351562" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_124" unit="mm" x="785.43212890625" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_125" unit="mm" x="785.9348754882812" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_126" unit="mm" x="785.43212890625" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_127" unit="mm" x="856.3994140625" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_128" unit="mm" x="858.4021606445312" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_129" unit="mm" x="855.6394653320312" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_130" unit="mm" x="784.68212890625" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_131" unit="mm" x="856.9021606445312" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_132" unit="mm" x="855.7903442382812" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_133" unit="mm" x="857.2903442382812" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_134" unit="mm" x="856.0183715820312" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_135" unit="mm" x="854.7531127929688" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_136" unit="mm" x="856.7578125" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_137" unit="mm" x="785.5764770507812" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_138" unit="mm" x="786.6947631835938" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_139" unit="mm" x="783.9832763671875" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_140" unit="mm" x="784.1331176757812" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_141" unit="mm" x="856.9021606445312" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_142" unit="mm" x="786.93212890625" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_143" unit="mm" x="784.3714599609375" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_144" unit="mm" x="784.8547973632812" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_145" unit="mm" x="856.9021606445312" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_146" unit="mm" x="857.6521606445312" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_147" unit="mm" x="786.31591796875" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_148" unit="mm" x="785.146728515625" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_149" unit="mm" x="785.0438842773438" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_150" unit="mm" x="785.8714599609375" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_151" unit="mm" x="855.2875366210938" y="798.7539672851562" z="-2.0"/>
+  <position name="Mesh2Tess_0" unit="mm" x="856.9021606445312" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="856.9021606445312" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="856.9021606445312" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="785.43212890625" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="728.8966674804688" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="785.43212890625" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="728.8966674804688" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="980.078369140625" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="785.43212890625" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="980.078369140625" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="508.9106750488281" y="3.5561831257524545e-15" z="-3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="785.43212890625" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="683.914306640625" y="3.5214886562329184e-15" z="3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="683.914306640625" y="3.5214886562329184e-15" z="-3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="508.9106750488281" y="3.5561831257524545e-15" z="3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="856.9021606445312" y="799.2944946289062" z="-3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalTile04_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
         </tessellated>
   </solid>
 
   <solid name="OuterHCalTile05" material="PlasticScint" unit="mm" x="952.594" y="426.866" z="0.0">
     <define>
-  <position name="Mesh2Tess_0" unit="mm" x="1102.339599609375" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_1" unit="mm" x="1098.8916015625" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_2" unit="mm" x="1100.1905517578125" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_3" unit="mm" x="1173.1094970703125" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_4" unit="mm" x="1100.1905517578125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_5" unit="mm" x="1099.54296875" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_6" unit="mm" x="1171.82861328125" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_7" unit="mm" x="1171.66064453125" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_8" unit="mm" x="1171.2213134765625" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_9" unit="mm" x="1100.1905517578125" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_10" unit="mm" x="1171.5162353515625" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_11" unit="mm" x="1098.74169921875" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_12" unit="mm" x="1099.776611328125" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_13" unit="mm" x="1099.5704345703125" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_14" unit="mm" x="1099.1298828125" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_15" unit="mm" x="1100.3916015625" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_16" unit="mm" x="1171.4595947265625" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_17" unit="mm" x="1100.3349609375" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_18" unit="mm" x="1171.66064453125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_19" unit="mm" x="1099.8023681640625" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_20" unit="mm" x="1171.1578369140625" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_21" unit="mm" x="1102.339599609375" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_22" unit="mm" x="1170.548828125" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_23" unit="mm" x="1098.8916015625" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_24" unit="mm" x="1172.9595947265625" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_25" unit="mm" x="1240.965087890625" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_26" unit="mm" x="1099.8023681640625" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_27" unit="mm" x="1169.7440185546875" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_28" unit="mm" x="981.1433715820312" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_29" unit="mm" x="1100.1905517578125" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_30" unit="mm" x="1100.9405517578125" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_31" unit="mm" x="1171.66064453125" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_32" unit="mm" x="1099.9051513671875" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_33" unit="mm" x="1100.1905517578125" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_34" unit="mm" x="1098.74169921875" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_35" unit="mm" x="1101.6905517578125" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_36" unit="mm" x="1100.3349609375" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_37" unit="mm" x="1100.24169921875" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_38" unit="mm" x="1172.9595947265625" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_39" unit="mm" x="1172.0745849609375" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_40" unit="mm" x="1172.7213134765625" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_41" unit="mm" x="1170.91064453125" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_42" unit="mm" x="1101.0743408203125" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_43" unit="mm" x="1099.8023681640625" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_44" unit="mm" x="1172.1573486328125" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_45" unit="mm" x="1169.7440185546875" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_46" unit="mm" x="1171.66064453125" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_47" unit="mm" x="1098.8916015625" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_48" unit="mm" x="1099.4405517578125" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_49" unit="mm" x="1171.2213134765625" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_50" unit="mm" x="1099.9051513671875" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_51" unit="mm" x="1172.41064453125" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_52" unit="mm" x="1172.048828125" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_53" unit="mm" x="1240.965087890625" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_54" unit="mm" x="1100.3916015625" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_55" unit="mm" x="1101.3023681640625" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_56" unit="mm" x="1099.61328125" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_57" unit="mm" x="1172.0745849609375" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_58" unit="mm" x="1099.69384765625" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_59" unit="mm" x="1172.7213134765625" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_60" unit="mm" x="684.9793090820312" y="1.734723475976807e-17" z="-3.5"/>
-  <position name="Mesh2Tess_61" unit="mm" x="1101.0743408203125" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_62" unit="mm" x="1172.9595947265625" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_63" unit="mm" x="1171.66064453125" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_64" unit="mm" x="1172.1573486328125" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_65" unit="mm" x="1173.1094970703125" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_66" unit="mm" x="1098.6905517578125" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_67" unit="mm" x="1171.66064453125" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_68" unit="mm" x="1170.0460205078125" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_69" unit="mm" x="1170.16064453125" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_70" unit="mm" x="1098.8916015625" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_71" unit="mm" x="1099.4405517578125" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_72" unit="mm" x="1100.693359375" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_73" unit="mm" x="1172.048828125" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_74" unit="mm" x="1170.39794921875" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_75" unit="mm" x="1170.548828125" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_76" unit="mm" x="1169.5115966796875" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_77" unit="mm" x="1100.0225830078125" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_78" unit="mm" x="1171.6094970703125" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_79" unit="mm" x="1099.61328125" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_80" unit="mm" x="1171.66064453125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_81" unit="mm" x="1171.66064453125" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_82" unit="mm" x="1172.3082275390625" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_83" unit="mm" x="1100.6298828125" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_84" unit="mm" x="1099.69384765625" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_85" unit="mm" x="1172.41064453125" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_86" unit="mm" x="1170.77685546875" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_87" unit="mm" x="1172.9595947265625" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_88" unit="mm" x="1170.91064453125" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_89" unit="mm" x="1171.66064453125" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_90" unit="mm" x="1173.1094970703125" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_91" unit="mm" x="1098.6905517578125" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_92" unit="mm" x="1100.1905517578125" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_93" unit="mm" x="1100.1905517578125" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_94" unit="mm" x="1100.1905517578125" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_95" unit="mm" x="866.001220703125" y="0.0" z="-3.5"/>
-  <position name="Mesh2Tess_96" unit="mm" x="1172.048828125" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_97" unit="mm" x="1100.693359375" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_98" unit="mm" x="1101.4532470703125" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_99" unit="mm" x="1170.39794921875" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_100" unit="mm" x="1171.1578369140625" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_101" unit="mm" x="1101.80517578125" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_102" unit="mm" x="1100.24169921875" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_103" unit="mm" x="1099.4405517578125" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_104" unit="mm" x="1169.5115966796875" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_105" unit="mm" x="981.1433715820312" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_106" unit="mm" x="1100.0225830078125" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_107" unit="mm" x="1099.1298828125" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_108" unit="mm" x="1171.946044921875" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_109" unit="mm" x="684.9793090820312" y="1.734723475976807e-17" z="3.5"/>
-  <position name="Mesh2Tess_110" unit="mm" x="1098.74169921875" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_111" unit="mm" x="1102.107177734375" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_112" unit="mm" x="1172.28076171875" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_113" unit="mm" x="1100.1905517578125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_114" unit="mm" x="1172.3082275390625" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_115" unit="mm" x="1171.4595947265625" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_116" unit="mm" x="1172.41064453125" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_117" unit="mm" x="1172.7213134765625" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_118" unit="mm" x="1172.2379150390625" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_119" unit="mm" x="1170.77685546875" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_120" unit="mm" x="1173.16064453125" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_121" unit="mm" x="1171.66064453125" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_122" unit="mm" x="1100.1905517578125" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_123" unit="mm" x="1172.048828125" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_124" unit="mm" x="1173.1094970703125" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_125" unit="mm" x="1101.4532470703125" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_126" unit="mm" x="1101.3023681640625" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_127" unit="mm" x="1099.54296875" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_128" unit="mm" x="1101.80517578125" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_129" unit="mm" x="1099.4405517578125" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_130" unit="mm" x="1171.82861328125" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_131" unit="mm" x="1171.946044921875" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_132" unit="mm" x="1099.1298828125" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_133" unit="mm" x="1100.9405517578125" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_134" unit="mm" x="1102.107177734375" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_135" unit="mm" x="1098.74169921875" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_136" unit="mm" x="1171.5162353515625" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_137" unit="mm" x="1171.6094970703125" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_138" unit="mm" x="1172.28076171875" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_139" unit="mm" x="1101.6905517578125" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_140" unit="mm" x="1099.776611328125" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_141" unit="mm" x="1170.0460205078125" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_142" unit="mm" x="1099.5704345703125" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_143" unit="mm" x="1170.16064453125" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_144" unit="mm" x="1099.1298828125" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_145" unit="mm" x="866.001220703125" y="0.0" z="3.5"/>
-  <position name="Mesh2Tess_146" unit="mm" x="1172.7213134765625" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_147" unit="mm" x="1172.2379150390625" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_148" unit="mm" x="1100.6298828125" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_149" unit="mm" x="1173.16064453125" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_150" unit="mm" x="1099.8023681640625" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_151" unit="mm" x="1172.41064453125" y="805.6435546875" z="3.5"/>
+  <position name="Mesh2Tess_0" unit="mm" x="1171.66064453125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="1100.1905517578125" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="866.001220703125" y="0.0" z="3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="1171.66064453125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="684.9793090820312" y="1.734723475976807e-17" z="-3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="866.001220703125" y="0.0" z="-3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="1100.1905517578125" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="1100.1905517578125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="1100.1905517578125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="981.1433715820312" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="1240.965087890625" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="1240.965087890625" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="981.1433715820312" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="1171.66064453125" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="1171.66064453125" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="684.9793090820312" y="1.734723475976807e-17" z="3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalTile05_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-         </tessellated>
+      <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+          </tessellated>
   </solid>
 
   <solid name="OuterHCalTile06" material="PlasticScint" unit="mm" x="1180.725" y="426.919" z="0.0">
     <define>
-  <position name="Mesh2Tess_0" unit="mm" x="1295.174560546875" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_1" unit="mm" x="1368.14453125" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_2" unit="mm" x="1367.5626220703125" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_3" unit="mm" x="1366.5107421875" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_4" unit="mm" x="1368.89453125" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_5" unit="mm" x="1366.64453125" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_6" unit="mm" x="1367.39453125" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_7" unit="mm" x="1295.9757080078125" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_8" unit="mm" x="1296.06884765625" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_9" unit="mm" x="1365.89453125" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_10" unit="mm" x="1296.3638916015625" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_11" unit="mm" x="1296.42724609375" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_12" unit="mm" x="1295.304443359375" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_13" unit="mm" x="1054.8138427734375" y="4.128641872824801e-15" z="-3.5"/>
-  <position name="Mesh2Tess_14" unit="mm" x="1367.679931640625" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_15" unit="mm" x="1295.4278564453125" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_16" unit="mm" x="1294.8638916015625" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_17" unit="mm" x="1295.924560546875" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_18" unit="mm" x="1367.8912353515625" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_19" unit="mm" x="1297.5391845703125" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_20" unit="mm" x="1367.250244140625" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_21" unit="mm" x="1368.0146484375" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_22" unit="mm" x="1294.424560546875" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_23" unit="mm" x="1368.843505859375" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_24" unit="mm" x="1242.0673828125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_25" unit="mm" x="1296.808349609375" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_26" unit="mm" x="1294.62548828125" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_27" unit="mm" x="1294.424560546875" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_28" unit="mm" x="1368.14453125" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_29" unit="mm" x="1366.5107421875" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_30" unit="mm" x="1368.89453125" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_31" unit="mm" x="1297.8411865234375" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_32" unit="mm" x="1294.4757080078125" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_33" unit="mm" x="1367.39453125" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_34" unit="mm" x="1368.693603515625" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_35" unit="mm" x="1367.193603515625" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_36" unit="mm" x="1295.924560546875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_37" unit="mm" x="1297.424560546875" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_38" unit="mm" x="1295.924560546875" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_39" unit="mm" x="1367.39453125" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_40" unit="mm" x="1367.679931640625" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_41" unit="mm" x="1367.8912353515625" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_42" unit="mm" x="1297.036376953125" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_43" unit="mm" x="1296.674560546875" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_44" unit="mm" x="1367.971923828125" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_45" unit="mm" x="1368.843505859375" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_46" unit="mm" x="1296.808349609375" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_47" unit="mm" x="1294.62548828125" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_48" unit="mm" x="1368.042236328125" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_49" unit="mm" x="1297.8411865234375" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_50" unit="mm" x="1054.8138427734375" y="4.128641872824801e-15" z="3.5"/>
-  <position name="Mesh2Tess_51" unit="mm" x="1294.4757080078125" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_52" unit="mm" x="1367.343505859375" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_53" unit="mm" x="1295.9757080078125" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_54" unit="mm" x="1365.2454833984375" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_55" unit="mm" x="1368.693603515625" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_56" unit="mm" x="1366.9552001953125" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_57" unit="mm" x="1296.3638916015625" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_58" unit="mm" x="1297.187255859375" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_59" unit="mm" x="1295.924560546875" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_60" unit="mm" x="1511.50146484375" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_61" unit="mm" x="1365.4779052734375" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_62" unit="mm" x="1295.174560546875" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_63" unit="mm" x="1367.39453125" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_64" unit="mm" x="1366.891845703125" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_65" unit="mm" x="1295.34716796875" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_66" unit="mm" x="1295.63916015625" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_67" unit="mm" x="1294.8638916015625" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_68" unit="mm" x="867.1035766601562" y="4.128641872824801e-15" z="-3.5"/>
-  <position name="Mesh2Tess_69" unit="mm" x="1298.0736083984375" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_70" unit="mm" x="1367.971923828125" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_71" unit="mm" x="1296.12548828125" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_72" unit="mm" x="1368.042236328125" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_73" unit="mm" x="1367.39453125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_74" unit="mm" x="1365.2454833984375" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_75" unit="mm" x="1366.1319580078125" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_76" unit="mm" x="1367.7828369140625" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_77" unit="mm" x="1366.2828369140625" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_78" unit="mm" x="1367.193603515625" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_79" unit="mm" x="1294.62548828125" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_80" unit="mm" x="1297.187255859375" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_81" unit="mm" x="1297.5391845703125" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_82" unit="mm" x="1295.7564697265625" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_83" unit="mm" x="1368.0146484375" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_84" unit="mm" x="1295.174560546875" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_85" unit="mm" x="1366.891845703125" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_86" unit="mm" x="1295.2769775390625" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_87" unit="mm" x="1368.693603515625" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_88" unit="mm" x="1295.34716796875" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_89" unit="mm" x="1295.924560546875" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_90" unit="mm" x="1295.536376953125" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_91" unit="mm" x="1367.39453125" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_92" unit="mm" x="1295.63916015625" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_93" unit="mm" x="1294.8638916015625" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_94" unit="mm" x="1368.14453125" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_95" unit="mm" x="1298.0736083984375" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_96" unit="mm" x="1294.4757080078125" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_97" unit="mm" x="1368.4552001953125" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_98" unit="mm" x="1365.780029296875" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_99" unit="mm" x="1295.5106201171875" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_100" unit="mm" x="1367.7828369140625" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_101" unit="mm" x="1242.0673828125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_102" unit="mm" x="1367.343505859375" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_103" unit="mm" x="1366.1319580078125" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_104" unit="mm" x="1367.7828369140625" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_105" unit="mm" x="1366.64453125" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_106" unit="mm" x="1296.674560546875" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_107" unit="mm" x="1295.924560546875" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_108" unit="mm" x="1366.9552001953125" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_109" unit="mm" x="1294.62548828125" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_110" unit="mm" x="1295.7564697265625" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_111" unit="mm" x="1367.39453125" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_112" unit="mm" x="1365.89453125" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_113" unit="mm" x="1295.536376953125" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_114" unit="mm" x="1295.924560546875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_115" unit="mm" x="1295.2769775390625" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_116" unit="mm" x="1368.693603515625" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_117" unit="mm" x="1295.924560546875" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_118" unit="mm" x="1295.536376953125" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_119" unit="mm" x="1295.924560546875" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_120" unit="mm" x="1368.14453125" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_121" unit="mm" x="1294.4757080078125" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_122" unit="mm" x="1368.4552001953125" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_123" unit="mm" x="1365.780029296875" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_124" unit="mm" x="1368.843505859375" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_125" unit="mm" x="1296.12548828125" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_126" unit="mm" x="1295.5106201171875" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_127" unit="mm" x="1367.7828369140625" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_128" unit="mm" x="1368.4552001953125" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_129" unit="mm" x="1367.8084716796875" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_130" unit="mm" x="1295.174560546875" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_131" unit="mm" x="1367.5626220703125" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_132" unit="mm" x="1366.2828369140625" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_133" unit="mm" x="1367.39453125" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_134" unit="mm" x="1297.036376953125" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_135" unit="mm" x="1296.06884765625" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_136" unit="mm" x="1511.50146484375" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_137" unit="mm" x="1367.39453125" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_138" unit="mm" x="1295.536376953125" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_139" unit="mm" x="1297.424560546875" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_140" unit="mm" x="1296.42724609375" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_141" unit="mm" x="1295.304443359375" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_142" unit="mm" x="1295.924560546875" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_143" unit="mm" x="1295.4278564453125" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_144" unit="mm" x="1294.8638916015625" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_145" unit="mm" x="1368.843505859375" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_146" unit="mm" x="867.1035766601562" y="4.128641872824801e-15" z="3.5"/>
-  <position name="Mesh2Tess_147" unit="mm" x="1365.4779052734375" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_148" unit="mm" x="1367.250244140625" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_149" unit="mm" x="1367.39453125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_150" unit="mm" x="1368.4552001953125" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_151" unit="mm" x="1367.8084716796875" y="799.2367553710938" z="-2.0"/>
+  <position name="Mesh2Tess_0" unit="mm" x="1511.50146484375" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="867.1035766601562" y="4.128641872824801e-15" z="-3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="1511.50146484375" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="1295.924560546875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="1242.0673828125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="1054.8138427734375" y="4.128641872824801e-15" z="3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="1054.8138427734375" y="4.128641872824801e-15" z="-3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="867.1035766601562" y="4.128641872824801e-15" z="3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="1367.39453125" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="1367.39453125" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="1242.0673828125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="1295.924560546875" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="1367.39453125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="1295.924560546875" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="1295.924560546875" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="1367.39453125" y="808.344482421875" z="3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalTile06_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
         </tessellated>
   </solid>
 
   <solid name="OuterHCalTile07" material="PlasticScint" unit="mm" x="1418.405" y="426.976" z="0.0">
     <define>
-  <position name="Mesh2Tess_0" unit="mm" x="1639.345703125" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_1" unit="mm" x="1640.256591796875" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_2" unit="mm" x="1566.1884765625" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_3" unit="mm" x="1566.737548828125" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_4" unit="mm" x="1567.3194580078125" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_5" unit="mm" x="1638.756591796875" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_6" unit="mm" x="1640.4063720703125" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_7" unit="mm" x="1638.95751953125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_8" unit="mm" x="1639.534912109375" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_9" unit="mm" x="1567.2021484375" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_10" unit="mm" x="1569.10205078125" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_11" unit="mm" x="1639.3714599609375" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_12" unit="mm" x="1639.4542236328125" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_13" unit="mm" x="1638.454833984375" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_14" unit="mm" x="1567.487548828125" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_15" unit="mm" x="1639.242919921875" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_16" unit="mm" x="1639.70751953125" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_17" unit="mm" x="1568.371337890625" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_18" unit="mm" x="1566.4268798828125" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_19" unit="mm" x="1639.345703125" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_20" unit="mm" x="1567.487548828125" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_21" unit="mm" x="1638.95751953125" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_22" unit="mm" x="1639.345703125" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_23" unit="mm" x="1569.4041748046875" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_24" unit="mm" x="1566.1884765625" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_25" unit="mm" x="1566.737548828125" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_26" unit="mm" x="1640.256591796875" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_27" unit="mm" x="1795.1790771484375" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_28" unit="mm" x="1640.4063720703125" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_29" unit="mm" x="1569.10205078125" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_30" unit="mm" x="1567.53857421875" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_31" unit="mm" x="1637.45751953125" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_32" unit="mm" x="1567.0736083984375" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_33" unit="mm" x="1638.95751953125" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_34" unit="mm" x="1638.20751953125" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_35" unit="mm" x="1639.345703125" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_36" unit="mm" x="1566.867431640625" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_37" unit="mm" x="1567.487548828125" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_38" unit="mm" x="1637.0408935546875" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_39" unit="mm" x="1639.12548828125" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_40" unit="mm" x="1569.4041748046875" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_41" unit="mm" x="1639.6051025390625" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_42" unit="mm" x="1567.990234375" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_43" unit="mm" x="1512.6500244140625" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_44" unit="mm" x="1640.256591796875" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_45" unit="mm" x="1566.737548828125" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_46" unit="mm" x="1566.03857421875" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_47" unit="mm" x="1566.03857421875" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_48" unit="mm" x="1566.1884765625" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_49" unit="mm" x="1567.487548828125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_50" unit="mm" x="1567.6318359375" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_51" unit="mm" x="1638.95751953125" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_52" unit="mm" x="1568.987548828125" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_53" unit="mm" x="1568.5992431640625" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_54" unit="mm" x="1638.07373046875" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_55" unit="mm" x="1640.4063720703125" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_56" unit="mm" x="1637.69482421875" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_57" unit="mm" x="1639.12548828125" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_58" unit="mm" x="1252.8128662109375" y="2.048137313163923e-15" z="-3.5"/>
-  <position name="Mesh2Tess_59" unit="mm" x="1567.6884765625" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_60" unit="mm" x="1567.990234375" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_61" unit="mm" x="1636.8084716796875" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_62" unit="mm" x="1639.6051025390625" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_63" unit="mm" x="1637.3428955078125" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_64" unit="mm" x="1566.9908447265625" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_65" unit="mm" x="1638.9063720703125" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_66" unit="mm" x="1638.813232421875" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_67" unit="mm" x="1566.737548828125" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_68" unit="mm" x="1567.9268798828125" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_69" unit="mm" x="1638.95751953125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_70" unit="mm" x="1637.845703125" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_71" unit="mm" x="1567.0992431640625" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_72" unit="mm" x="1566.03857421875" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_73" unit="mm" x="1566.4268798828125" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_74" unit="mm" x="1566.03857421875" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_75" unit="mm" x="1568.237548828125" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_76" unit="mm" x="1638.5181884765625" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_77" unit="mm" x="1566.1884765625" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_78" unit="mm" x="1567.487548828125" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_79" unit="mm" x="1640.0181884765625" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_80" unit="mm" x="1567.487548828125" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_81" unit="mm" x="1566.83984375" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_82" unit="mm" x="1639.70751953125" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_83" unit="mm" x="1638.95751953125" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_84" unit="mm" x="1638.756591796875" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_85" unit="mm" x="1638.07373046875" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_86" unit="mm" x="1640.4063720703125" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_87" unit="mm" x="1569.6365966796875" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_88" unit="mm" x="1639.3714599609375" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_89" unit="mm" x="1566.91015625" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_90" unit="mm" x="1637.3428955078125" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_91" unit="mm" x="1566.9908447265625" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_92" unit="mm" x="1055.96240234375" y="1.0321604682062002e-15" z="-3.5"/>
-  <position name="Mesh2Tess_93" unit="mm" x="1568.7501220703125" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_94" unit="mm" x="1638.813232421875" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_95" unit="mm" x="1567.0992431640625" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_96" unit="mm" x="1566.4268798828125" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_97" unit="mm" x="1567.487548828125" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_98" unit="mm" x="1640.0181884765625" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_99" unit="mm" x="1638.95751953125" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_100" unit="mm" x="1567.0992431640625" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_101" unit="mm" x="1566.83984375" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_102" unit="mm" x="1640.45751953125" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_103" unit="mm" x="1252.8128662109375" y="2.048137313163923e-15" z="3.5"/>
-  <position name="Mesh2Tess_104" unit="mm" x="1639.57763671875" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_105" unit="mm" x="1639.70751953125" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_106" unit="mm" x="1640.0181884765625" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_107" unit="mm" x="1638.95751953125" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_108" unit="mm" x="1568.5992431640625" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_109" unit="mm" x="1569.6365966796875" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_110" unit="mm" x="1638.95751953125" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_111" unit="mm" x="1566.91015625" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_112" unit="mm" x="1565.987548828125" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_113" unit="mm" x="1567.53857421875" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_114" unit="mm" x="1638.9063720703125" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_115" unit="mm" x="1567.0736083984375" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_116" unit="mm" x="1568.7501220703125" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_117" unit="mm" x="1567.6318359375" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_118" unit="mm" x="1640.256591796875" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_119" unit="mm" x="1512.6500244140625" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_120" unit="mm" x="1567.9268798828125" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_121" unit="mm" x="1568.987548828125" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_122" unit="mm" x="1637.845703125" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_123" unit="mm" x="1567.3194580078125" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_124" unit="mm" x="1566.867431640625" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_125" unit="mm" x="1638.20751953125" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_126" unit="mm" x="1637.0408935546875" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_127" unit="mm" x="1568.237548828125" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_128" unit="mm" x="1567.487548828125" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_129" unit="mm" x="1567.0992431640625" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_130" unit="mm" x="1640.45751953125" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_131" unit="mm" x="1639.534912109375" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_132" unit="mm" x="1567.2021484375" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_133" unit="mm" x="1567.6884765625" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_134" unit="mm" x="1639.57763671875" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_135" unit="mm" x="1637.69482421875" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_136" unit="mm" x="1055.96240234375" y="1.0321604682062002e-15" z="3.5"/>
-  <position name="Mesh2Tess_137" unit="mm" x="1637.45751953125" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_138" unit="mm" x="1636.8084716796875" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_139" unit="mm" x="1567.487548828125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_140" unit="mm" x="1639.4542236328125" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_141" unit="mm" x="1795.1790771484375" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_142" unit="mm" x="1640.0181884765625" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_143" unit="mm" x="1638.454833984375" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_144" unit="mm" x="1638.95751953125" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_145" unit="mm" x="1567.487548828125" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_146" unit="mm" x="1639.70751953125" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_147" unit="mm" x="1639.242919921875" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_148" unit="mm" x="1638.5181884765625" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_149" unit="mm" x="1568.371337890625" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_150" unit="mm" x="1565.987548828125" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_151" unit="mm" x="1566.4268798828125" y="805.4051513671875" z="3.5"/>
+  <position name="Mesh2Tess_0" unit="mm" x="1638.95751953125" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="1795.1790771484375" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="1795.1790771484375" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="1567.487548828125" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="1638.95751953125" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="1055.96240234375" y="1.0321604682062002e-15" z="3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="1512.6500244140625" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="1567.487548828125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="1638.95751953125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="1055.96240234375" y="1.0321604682062002e-15" z="-3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="1512.6500244140625" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="1567.487548828125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="1638.95751953125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="1252.8128662109375" y="2.048137313163923e-15" z="-3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="1252.8128662109375" y="2.048137313163923e-15" z="3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="1567.487548828125" y="799.2944946289062" z="-3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalTile07_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
         </tessellated>
   </solid>
 
   <solid name="OuterHCalTile08" material="PlasticScint" unit="mm" x="1668.665" y="426.824" z="0.0">
     <define>
-  <position name="Mesh2Tess_0" unit="mm" x="1852.057861328125" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_1" unit="mm" x="1924.27783203125" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_2" unit="mm" x="1923.775146484375" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_3" unit="mm" x="1462.767822265625" y="0.0" z="3.5"/>
-  <position name="Mesh2Tess_4" unit="mm" x="1851.5087890625" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_5" unit="mm" x="1925.02783203125" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_6" unit="mm" x="1852.639892578125" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_7" unit="mm" x="1923.39404296875" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_8" unit="mm" x="1854.7244873046875" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_9" unit="mm" x="1925.576904296875" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_10" unit="mm" x="1924.855224609375" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_11" unit="mm" x="1853.0087890625" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_12" unit="mm" x="1852.807861328125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_13" unit="mm" x="1852.807861328125" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_14" unit="mm" x="1924.27783203125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_15" unit="mm" x="1923.0152587890625" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_16" unit="mm" x="1852.807861328125" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_17" unit="mm" x="1854.4224853515625" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_18" unit="mm" x="1852.057861328125" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_19" unit="mm" x="1853.919677734375" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_20" unit="mm" x="1923.1661376953125" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_21" unit="mm" x="1851.5087890625" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_22" unit="mm" x="1854.7244873046875" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_23" unit="mm" x="1925.02783203125" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_24" unit="mm" x="1922.1287841796875" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_25" unit="mm" x="1925.576904296875" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_26" unit="mm" x="1925.576904296875" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_27" unit="mm" x="1925.3385009765625" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_28" unit="mm" x="2094.974853515625" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_29" unit="mm" x="1852.8590087890625" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_30" unit="mm" x="1853.2471923828125" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_31" unit="mm" x="1852.807861328125" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_32" unit="mm" x="1924.6661376953125" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_33" unit="mm" x="1923.0152587890625" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_34" unit="mm" x="1922.3612060546875" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_35" unit="mm" x="1852.23046875" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_36" unit="mm" x="1923.52783203125" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_37" unit="mm" x="1854.9569091796875" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_38" unit="mm" x="1852.807861328125" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_39" unit="mm" x="1852.5224609375" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_40" unit="mm" x="1851.7471923828125" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_41" unit="mm" x="1924.774658203125" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_42" unit="mm" x="1922.77783203125" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_43" unit="mm" x="1852.419677734375" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_44" unit="mm" x="1852.807861328125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_45" unit="mm" x="1924.925537109375" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_46" unit="mm" x="1796.38330078125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_47" unit="mm" x="1852.807861328125" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_48" unit="mm" x="1925.726806640625" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_49" unit="mm" x="1924.133544921875" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_50" unit="mm" x="1925.02783203125" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_51" unit="mm" x="1922.1287841796875" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_52" unit="mm" x="1925.576904296875" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_53" unit="mm" x="1925.3385009765625" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_54" unit="mm" x="1924.6661376953125" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_55" unit="mm" x="1924.076904296875" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_56" unit="mm" x="1925.77783203125" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_57" unit="mm" x="1851.5087890625" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_58" unit="mm" x="1852.9521484375" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_59" unit="mm" x="1923.775146484375" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_60" unit="mm" x="1852.1602783203125" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_61" unit="mm" x="1852.057861328125" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_62" unit="mm" x="1852.23046875" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_63" unit="mm" x="1924.4459228515625" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_64" unit="mm" x="1854.9569091796875" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_65" unit="mm" x="1852.419677734375" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_66" unit="mm" x="1924.27783203125" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_67" unit="mm" x="1924.27783203125" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_68" unit="mm" x="1852.5224609375" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_69" unit="mm" x="1851.7471923828125" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_70" unit="mm" x="1924.774658203125" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_71" unit="mm" x="1852.419677734375" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_72" unit="mm" x="1851.3590087890625" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_73" unit="mm" x="1924.925537109375" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_74" unit="mm" x="1923.1661376953125" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_75" unit="mm" x="1854.307861328125" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_76" unit="mm" x="1852.3939208984375" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_77" unit="mm" x="1922.663330078125" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_78" unit="mm" x="1852.187744140625" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_79" unit="mm" x="1852.807861328125" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_80" unit="mm" x="1925.726806640625" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_81" unit="mm" x="1924.133544921875" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_82" unit="mm" x="1254.01708984375" y="3.469446951953614e-17" z="-3.5"/>
-  <position name="Mesh2Tess_83" unit="mm" x="1924.226806640625" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_84" unit="mm" x="1852.3111572265625" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_85" unit="mm" x="1924.6661376953125" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_86" unit="mm" x="1851.7471923828125" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_87" unit="mm" x="1925.77783203125" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_88" unit="mm" x="1853.557861328125" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_89" unit="mm" x="1923.8385009765625" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_90" unit="mm" x="1851.5087890625" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_91" unit="mm" x="1924.27783203125" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_92" unit="mm" x="1851.307861328125" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_93" unit="mm" x="1852.1602783203125" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_94" unit="mm" x="1852.057861328125" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_95" unit="mm" x="1924.4459228515625" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_96" unit="mm" x="1796.38330078125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_97" unit="mm" x="1852.419677734375" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_98" unit="mm" x="1924.27783203125" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_99" unit="mm" x="1851.3590087890625" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_100" unit="mm" x="1922.77783203125" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_101" unit="mm" x="1922.663330078125" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_102" unit="mm" x="1853.0087890625" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_103" unit="mm" x="1852.3939208984375" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_104" unit="mm" x="1852.187744140625" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_105" unit="mm" x="1924.6661376953125" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_106" unit="mm" x="1925.3385009765625" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_107" unit="mm" x="1924.6917724609375" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_108" unit="mm" x="1852.3111572265625" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_109" unit="mm" x="1851.7471923828125" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_110" unit="mm" x="1924.27783203125" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_111" unit="mm" x="1851.307861328125" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_112" unit="mm" x="1924.563232421875" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_113" unit="mm" x="1924.8980712890625" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_114" unit="mm" x="1853.691650390625" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_115" unit="mm" x="1854.070556640625" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_116" unit="mm" x="1853.310546875" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_117" unit="mm" x="1462.767822265625" y="0.0" z="-3.5"/>
-  <position name="Mesh2Tess_118" unit="mm" x="1851.3590087890625" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_119" unit="mm" x="1254.01708984375" y="3.469446951953614e-17" z="3.5"/>
-  <position name="Mesh2Tess_120" unit="mm" x="1924.27783203125" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_121" unit="mm" x="1925.726806640625" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_122" unit="mm" x="1924.076904296875" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_123" unit="mm" x="1854.307861328125" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_124" unit="mm" x="1852.8590087890625" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_125" unit="mm" x="1922.3612060546875" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_126" unit="mm" x="1853.919677734375" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_127" unit="mm" x="1924.27783203125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_128" unit="mm" x="1924.27783203125" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_129" unit="mm" x="1852.9521484375" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_130" unit="mm" x="1925.3385009765625" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_131" unit="mm" x="1924.6917724609375" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_132" unit="mm" x="1925.02783203125" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_133" unit="mm" x="1852.639892578125" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_134" unit="mm" x="1923.39404296875" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_135" unit="mm" x="1923.52783203125" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_136" unit="mm" x="1853.557861328125" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_137" unit="mm" x="1924.855224609375" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_138" unit="mm" x="1924.563232421875" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_139" unit="mm" x="1924.8980712890625" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_140" unit="mm" x="1853.2471923828125" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_141" unit="mm" x="1853.691650390625" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_142" unit="mm" x="1854.070556640625" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_143" unit="mm" x="1853.310546875" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_144" unit="mm" x="1851.3590087890625" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_145" unit="mm" x="1924.226806640625" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_146" unit="mm" x="1925.726806640625" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_147" unit="mm" x="1852.807861328125" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_148" unit="mm" x="1852.807861328125" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_149" unit="mm" x="1923.8385009765625" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_150" unit="mm" x="2094.974853515625" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_151" unit="mm" x="1854.4224853515625" y="798.7539672851562" z="3.5"/>
+  <position name="Mesh2Tess_0" unit="mm" x="1852.807861328125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="1852.807861328125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="1462.767822265625" y="0.0" z="-3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="1852.807861328125" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="1462.767822265625" y="0.0" z="3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="1254.01708984375" y="3.469446951953614e-17" z="-3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="1254.01708984375" y="3.469446951953614e-17" z="3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="1924.27783203125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="1852.807861328125" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="1924.27783203125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="1796.38330078125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="1796.38330078125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="1924.27783203125" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="2094.974853515625" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="2094.974853515625" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="1924.27783203125" y="799.2944946289062" z="3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalTile08_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
         </tessellated>
   </solid>
 
   <solid name="OuterHCalTile09" material="PlasticScint" unit="mm" x="-1980.199" y="482.037" z="0.0">
     <define>
-  <position name="Mesh2Tess_0" unit="mm" x="-2222.422607421875" y="803.2838134765625" z="2.0"/>
-  <position name="Mesh2Tess_1" unit="mm" x="-2149.891845703125" y="800.7944946289062" z="3.5"/>
-  <position name="Mesh2Tess_2" unit="mm" x="-2149.244140625" y="799.9600830078125" z="-3.5"/>
-  <position name="Mesh2Tess_3" unit="mm" x="-2221.647216796875" y="801.0247192382812" z="2.0"/>
-  <position name="Mesh2Tess_4" unit="mm" x="-2222.810791015625" y="803.956298828125" z="2.0"/>
-  <position name="Mesh2Tess_5" unit="mm" x="-2149.141845703125" y="805.6435546875" z="-3.5"/>
-  <position name="Mesh2Tess_6" unit="mm" x="-2149.891845703125" y="801.2803955078125" z="-3.5"/>
-  <position name="Mesh2Tess_7" unit="mm" x="-2221.75" y="802.8956298828125" z="2.0"/>
-  <position name="Mesh2Tess_8" unit="mm" x="-2221.77587890625" y="799.2367553710938" z="-3.5"/>
-  <position name="Mesh2Tess_9" unit="mm" x="-2219.212890625" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_10" unit="mm" x="-2222.660888671875" y="803.594482421875" z="2.0"/>
-  <position name="Mesh2Tess_11" unit="mm" x="-2149.47802734375" y="799.2367553710938" z="-3.5"/>
-  <position name="Mesh2Tess_12" unit="mm" x="-2149.891845703125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_13" unit="mm" x="-2148.831298828125" y="803.2838134765625" z="-3.5"/>
-  <position name="Mesh2Tess_14" unit="mm" x="-2151.391845703125" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_15" unit="mm" x="-2222.660888671875" y="805.094482421875" z="-3.5"/>
-  <position name="Mesh2Tess_16" unit="mm" x="-2222.11181640625" y="803.0454711914062" z="2.0"/>
-  <position name="Mesh2Tess_17" unit="mm" x="-2221.939208984375" y="799.5833740234375" z="2.0"/>
-  <position name="Mesh2Tess_18" unit="mm" x="-2149.891845703125" y="802.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_19" unit="mm" x="-2221.858642578125" y="800.705078125" z="2.0"/>
-  <position name="Mesh2Tess_20" unit="mm" x="-2149.891845703125" y="805.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_21" unit="mm" x="-2148.5927734375" y="803.594482421875" z="2.0"/>
-  <position name="Mesh2Tess_22" unit="mm" x="-2150.331298828125" y="799.7338256835938" z="3.5"/>
-  <position name="Mesh2Tess_23" unit="mm" x="-2222.422607421875" y="803.2838134765625" z="-3.5"/>
-  <position name="Mesh2Tess_24" unit="mm" x="-2221.75" y="805.7933959960938" z="2.0"/>
-  <position name="Mesh2Tess_25" unit="mm" x="-2221.647216796875" y="801.0247192382812" z="-3.5"/>
-  <position name="Mesh2Tess_26" unit="mm" x="-2149.395263671875" y="800.705078125" z="2.0"/>
-  <position name="Mesh2Tess_27" unit="mm" x="-2222.810791015625" y="803.956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_28" unit="mm" x="-2096.244384765625" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_29" unit="mm" x="-2221.36181640625" y="800.7944946289062" z="3.5"/>
-  <position name="Mesh2Tess_30" unit="mm" x="-2222.422607421875" y="805.4051513671875" z="2.0"/>
-  <position name="Mesh2Tess_31" unit="mm" x="-2220.859130859375" y="798.5852661132812" z="-3.5"/>
-  <position name="Mesh2Tess_32" unit="mm" x="-2221.160888671875" y="800.0444946289062" z="3.5"/>
-  <position name="Mesh2Tess_33" unit="mm" x="-2149.6064453125" y="801.0247192382812" z="2.0"/>
-  <position name="Mesh2Tess_34" unit="mm" x="-2222.11181640625" y="803.0454711914062" z="-3.5"/>
-  <position name="Mesh2Tess_35" unit="mm" x="-2150.0927734375" y="800.0444946289062" z="3.5"/>
-  <position name="Mesh2Tess_36" unit="mm" x="-2221.939208984375" y="799.5833740234375" z="-3.5"/>
-  <position name="Mesh2Tess_37" unit="mm" x="-2220.47802734375" y="798.5448608398438" z="2.0"/>
-  <position name="Mesh2Tess_38" unit="mm" x="-2152.041015625" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_39" unit="mm" x="-2221.858642578125" y="800.705078125" z="-3.5"/>
-  <position name="Mesh2Tess_40" unit="mm" x="-2151.003662109375" y="799.3455810546875" z="2.0"/>
-  <position name="Mesh2Tess_41" unit="mm" x="-2149.94287109375" y="800.40625" z="2.0"/>
-  <position name="Mesh2Tess_42" unit="mm" x="-2149.503662109375" y="802.8956298828125" z="2.0"/>
-  <position name="Mesh2Tess_43" unit="mm" x="-2149.891845703125" y="805.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_44" unit="mm" x="-2148.5927734375" y="803.594482421875" z="-3.5"/>
-  <position name="Mesh2Tess_45" unit="mm" x="-1560.988525390625" y="123.9625015258789" z="-3.5"/>
-  <position name="Mesh2Tess_46" unit="mm" x="-2220.61181640625" y="799.4954833984375" z="2.0"/>
-  <position name="Mesh2Tess_47" unit="mm" x="-2221.75" y="805.7933959960938" z="-3.5"/>
-  <position name="Mesh2Tess_48" unit="mm" x="-2221.36181640625" y="805.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_49" unit="mm" x="-2149.395263671875" y="800.705078125" z="-3.5"/>
-  <position name="Mesh2Tess_50" unit="mm" x="-2221.98193359375" y="800.34228515625" z="-3.5"/>
-  <position name="Mesh2Tess_51" unit="mm" x="-2219.747314453125" y="798.7539672851562" z="2.0"/>
-  <position name="Mesh2Tess_52" unit="mm" x="-2219.4453125" y="798.9898071289062" z="2.0"/>
-  <position name="Mesh2Tess_53" unit="mm" x="-2222.422607421875" y="805.4051513671875" z="-3.5"/>
-  <position name="Mesh2Tess_54" unit="mm" x="-2221.217529296875" y="798.7208862304688" z="2.0"/>
-  <position name="Mesh2Tess_55" unit="mm" x="-2149.723876953125" y="798.94287109375" z="2.0"/>
-  <position name="Mesh2Tess_56" unit="mm" x="-2220.922607421875" y="799.7338256835938" z="3.5"/>
-  <position name="Mesh2Tess_57" unit="mm" x="-2149.6064453125" y="801.0247192382812" z="-3.5"/>
-  <position name="Mesh2Tess_58" unit="mm" x="-2220.47802734375" y="798.5448608398438" z="-3.5"/>
-  <position name="Mesh2Tess_59" unit="mm" x="-2220.09912109375" y="798.6023559570312" z="2.0"/>
-  <position name="Mesh2Tess_60" unit="mm" x="-2413.33154296875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_61" unit="mm" x="-2148.391845703125" y="804.344482421875" z="2.0"/>
-  <position name="Mesh2Tess_62" unit="mm" x="-2219.86181640625" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_63" unit="mm" x="-2151.154541015625" y="798.6023559570312" z="2.0"/>
-  <position name="Mesh2Tess_64" unit="mm" x="-2222.11181640625" y="805.6435546875" z="2.0"/>
-  <position name="Mesh2Tess_65" unit="mm" x="-2221.310791015625" y="800.40625" z="2.0"/>
-  <position name="Mesh2Tess_66" unit="mm" x="-2221.36181640625" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_67" unit="mm" x="-2149.503662109375" y="802.8956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_68" unit="mm" x="-2221.75" y="802.8956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_69" unit="mm" x="-2222.660888671875" y="803.594482421875" z="-3.5"/>
-  <position name="Mesh2Tess_70" unit="mm" x="-2150.331298828125" y="799.7338256835938" z="2.0"/>
-  <position name="Mesh2Tess_71" unit="mm" x="-2148.5927734375" y="805.094482421875" z="2.0"/>
-  <position name="Mesh2Tess_72" unit="mm" x="-2221.36181640625" y="805.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_73" unit="mm" x="-2222.86181640625" y="804.344482421875" z="2.0"/>
-  <position name="Mesh2Tess_74" unit="mm" x="-2149.503662109375" y="805.7933959960938" z="2.0"/>
-  <position name="Mesh2Tess_75" unit="mm" x="-2222.009521484375" y="799.9600830078125" z="2.0"/>
-  <position name="Mesh2Tess_76" unit="mm" x="-2150.641845703125" y="799.4954833984375" z="2.0"/>
-  <position name="Mesh2Tess_77" unit="mm" x="-2221.36181640625" y="801.2803955078125" z="2.0"/>
-  <position name="Mesh2Tess_78" unit="mm" x="-2221.36181640625" y="800.7944946289062" z="2.0"/>
-  <position name="Mesh2Tess_79" unit="mm" x="-2219.747314453125" y="798.7539672851562" z="-3.5"/>
-  <position name="Mesh2Tess_80" unit="mm" x="-2219.4453125" y="798.9898071289062" z="-3.5"/>
-  <position name="Mesh2Tess_81" unit="mm" x="-2149.141845703125" y="803.0454711914062" z="2.0"/>
-  <position name="Mesh2Tess_82" unit="mm" x="-2149.891845703125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_83" unit="mm" x="-2221.217529296875" y="798.7208862304688" z="-3.5"/>
-  <position name="Mesh2Tess_84" unit="mm" x="-2149.723876953125" y="798.94287109375" z="-3.5"/>
-  <position name="Mesh2Tess_85" unit="mm" x="-2221.160888671875" y="800.0444946289062" z="2.0"/>
-  <position name="Mesh2Tess_86" unit="mm" x="-1795.8123779296875" y="123.9625015258789" z="-3.5"/>
-  <position name="Mesh2Tess_87" unit="mm" x="-2150.775634765625" y="798.5448608398438" z="2.0"/>
-  <position name="Mesh2Tess_88" unit="mm" x="-2221.52978515625" y="798.94287109375" z="2.0"/>
-  <position name="Mesh2Tess_89" unit="mm" x="-2220.09912109375" y="798.6023559570312" z="-3.5"/>
-  <position name="Mesh2Tess_90" unit="mm" x="-2148.391845703125" y="804.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_91" unit="mm" x="-2149.891845703125" y="800.7944946289062" z="2.0"/>
-  <position name="Mesh2Tess_92" unit="mm" x="-2151.154541015625" y="798.6023559570312" z="-3.5"/>
-  <position name="Mesh2Tess_93" unit="mm" x="-2222.11181640625" y="805.6435546875" z="-3.5"/>
-  <position name="Mesh2Tess_94" unit="mm" x="-2220.25" y="799.3455810546875" z="3.5"/>
-  <position name="Mesh2Tess_95" unit="mm" x="-2221.36181640625" y="802.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_96" unit="mm" x="-2150.0361328125" y="798.7208862304688" z="2.0"/>
-  <position name="Mesh2Tess_97" unit="mm" x="-2148.5927734375" y="805.094482421875" z="-3.5"/>
-  <position name="Mesh2Tess_98" unit="mm" x="-2148.831298828125" y="805.4051513671875" z="2.0"/>
-  <position name="Mesh2Tess_99" unit="mm" x="-2222.86181640625" y="804.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_100" unit="mm" x="-2149.503662109375" y="805.7933959960938" z="-3.5"/>
-  <position name="Mesh2Tess_101" unit="mm" x="-2222.009521484375" y="799.9600830078125" z="-3.5"/>
-  <position name="Mesh2Tess_102" unit="mm" x="-2149.271728515625" y="800.34228515625" z="2.0"/>
-  <position name="Mesh2Tess_103" unit="mm" x="-2151.391845703125" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_104" unit="mm" x="-2221.36181640625" y="801.2803955078125" z="-3.5"/>
-  <position name="Mesh2Tess_105" unit="mm" x="-2222.810791015625" y="804.7327270507812" z="2.0"/>
-  <position name="Mesh2Tess_106" unit="mm" x="-2149.141845703125" y="803.0454711914062" z="-3.5"/>
-  <position name="Mesh2Tess_107" unit="mm" x="-2152.041015625" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_108" unit="mm" x="-2150.39453125" y="798.5852661132812" z="2.0"/>
-  <position name="Mesh2Tess_109" unit="mm" x="-2151.003662109375" y="799.3455810546875" z="3.5"/>
-  <position name="Mesh2Tess_110" unit="mm" x="-2149.94287109375" y="800.40625" z="3.5"/>
-  <position name="Mesh2Tess_111" unit="mm" x="-2221.36181640625" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_112" unit="mm" x="-2220.61181640625" y="799.4954833984375" z="3.5"/>
-  <position name="Mesh2Tess_113" unit="mm" x="-2220.922607421875" y="799.7338256835938" z="2.0"/>
-  <position name="Mesh2Tess_114" unit="mm" x="-2150.775634765625" y="798.5448608398438" z="-3.5"/>
-  <position name="Mesh2Tess_115" unit="mm" x="-2221.52978515625" y="798.94287109375" z="-3.5"/>
-  <position name="Mesh2Tess_116" unit="mm" x="-2151.80859375" y="798.9898071289062" z="2.0"/>
-  <position name="Mesh2Tess_117" unit="mm" x="-2219.86181640625" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_118" unit="mm" x="-2221.36181640625" y="802.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_119" unit="mm" x="-2148.44287109375" y="804.7327270507812" z="2.0"/>
-  <position name="Mesh2Tess_120" unit="mm" x="-2148.44287109375" y="803.956298828125" z="2.0"/>
-  <position name="Mesh2Tess_121" unit="mm" x="-2151.50634765625" y="798.7539672851562" z="2.0"/>
-  <position name="Mesh2Tess_122" unit="mm" x="-2150.0361328125" y="798.7208862304688" z="-3.5"/>
-  <position name="Mesh2Tess_123" unit="mm" x="-2148.831298828125" y="805.4051513671875" z="-3.5"/>
-  <position name="Mesh2Tess_124" unit="mm" x="-2220.859130859375" y="798.5852661132812" z="2.0"/>
-  <position name="Mesh2Tess_125" unit="mm" x="-2149.314453125" y="799.5833740234375" z="2.0"/>
-  <position name="Mesh2Tess_126" unit="mm" x="-2149.271728515625" y="800.34228515625" z="-3.5"/>
-  <position name="Mesh2Tess_127" unit="mm" x="-1795.8123779296875" y="123.9625015258789" z="3.5"/>
-  <position name="Mesh2Tess_128" unit="mm" x="-1560.988525390625" y="123.9625015258789" z="3.5"/>
-  <position name="Mesh2Tess_129" unit="mm" x="-2222.810791015625" y="804.7327270507812" z="-3.5"/>
-  <position name="Mesh2Tess_130" unit="mm" x="-2149.244140625" y="799.9600830078125" z="2.0"/>
-  <position name="Mesh2Tess_131" unit="mm" x="-2150.0927734375" y="800.0444946289062" z="2.0"/>
-  <position name="Mesh2Tess_132" unit="mm" x="-2150.39453125" y="798.5852661132812" z="-3.5"/>
-  <position name="Mesh2Tess_133" unit="mm" x="-2221.310791015625" y="800.40625" z="3.5"/>
-  <position name="Mesh2Tess_134" unit="mm" x="-2149.141845703125" y="805.6435546875" z="2.0"/>
-  <position name="Mesh2Tess_135" unit="mm" x="-2149.891845703125" y="801.2803955078125" z="2.0"/>
-  <position name="Mesh2Tess_136" unit="mm" x="-2221.77587890625" y="799.2367553710938" z="2.0"/>
-  <position name="Mesh2Tess_137" unit="mm" x="-2219.212890625" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_138" unit="mm" x="-2149.47802734375" y="799.2367553710938" z="2.0"/>
-  <position name="Mesh2Tess_139" unit="mm" x="-2151.80859375" y="798.9898071289062" z="-3.5"/>
-  <position name="Mesh2Tess_140" unit="mm" x="-2150.641845703125" y="799.4954833984375" z="3.5"/>
-  <position name="Mesh2Tess_141" unit="mm" x="-2148.831298828125" y="803.2838134765625" z="2.0"/>
-  <position name="Mesh2Tess_142" unit="mm" x="-2148.44287109375" y="804.7327270507812" z="-3.5"/>
-  <position name="Mesh2Tess_143" unit="mm" x="-2221.98193359375" y="800.34228515625" z="2.0"/>
-  <position name="Mesh2Tess_144" unit="mm" x="-2220.25" y="799.3455810546875" z="2.0"/>
-  <position name="Mesh2Tess_145" unit="mm" x="-2222.660888671875" y="805.094482421875" z="2.0"/>
-  <position name="Mesh2Tess_146" unit="mm" x="-2148.44287109375" y="803.956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_147" unit="mm" x="-2096.244384765625" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_148" unit="mm" x="-2413.33154296875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_149" unit="mm" x="-2151.50634765625" y="798.7539672851562" z="-3.5"/>
-  <position name="Mesh2Tess_150" unit="mm" x="-2149.314453125" y="799.5833740234375" z="-3.5"/>
-  <position name="Mesh2Tess_151" unit="mm" x="-2149.891845703125" y="802.844482421875" z="2.0"/>
+  <position name="Mesh2Tess_0" unit="mm" x="-2413.33154296875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="-1560.988525390625" y="123.9625015258789" z="-3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="-2149.891845703125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="-2096.244384765625" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="-2096.244384765625" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="-2413.33154296875" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="-1795.8123779296875" y="123.9625015258789" z="-3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="-1795.8123779296875" y="123.9625015258789" z="3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="-1560.988525390625" y="123.9625015258789" z="3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="-2221.36181640625" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="-2221.36181640625" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="-2221.36181640625" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="-2149.891845703125" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="-2149.891845703125" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="-2221.36181640625" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="-2149.891845703125" y="808.344482421875" z="-3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalTile09_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
         </tessellated>
   </solid>
 
   <solid name="OuterHCalTile10" material="PlasticScint" unit="mm" x="-2267.609" y="481.906" z="0.0">
     <define>
-  <position name="Mesh2Tess_0" unit="mm" x="-2537.329833984375" y="798.94287109375" z="2.0"/>
-  <position name="Mesh2Tess_1" unit="mm" x="-2537.8095703125" y="799.9600830078125" z="-3.5"/>
-  <position name="Mesh2Tess_2" unit="mm" x="-2465.69189453125" y="805.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_3" unit="mm" x="-2537.7392578125" y="799.5833740234375" z="2.0"/>
-  <position name="Mesh2Tess_4" unit="mm" x="-2465.69189453125" y="801.2803955078125" z="2.0"/>
-  <position name="Mesh2Tess_5" unit="mm" x="-2465.69189453125" y="800.7944946289062" z="2.0"/>
-  <position name="Mesh2Tess_6" unit="mm" x="-2466.8037109375" y="799.3455810546875" z="3.5"/>
-  <position name="Mesh2Tess_7" unit="mm" x="-2467.6083984375" y="798.9898071289062" z="-3.5"/>
-  <position name="Mesh2Tess_8" unit="mm" x="-2537.447265625" y="801.0247192382812" z="2.0"/>
-  <position name="Mesh2Tess_9" unit="mm" x="-2465.195068359375" y="800.705078125" z="2.0"/>
-  <position name="Mesh2Tess_10" unit="mm" x="-2465.892822265625" y="800.0444946289062" z="3.5"/>
-  <position name="Mesh2Tess_11" unit="mm" x="-2465.114501953125" y="799.5833740234375" z="-3.5"/>
-  <position name="Mesh2Tess_12" unit="mm" x="-2535.012939453125" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_13" unit="mm" x="-2465.044189453125" y="799.9600830078125" z="2.0"/>
-  <position name="Mesh2Tess_14" unit="mm" x="-2535.661865234375" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_15" unit="mm" x="-2465.3037109375" y="805.7933959960938" z="-3.5"/>
-  <position name="Mesh2Tess_16" unit="mm" x="-2538.222412109375" y="805.4051513671875" z="2.0"/>
-  <position name="Mesh2Tess_17" unit="mm" x="-2464.19189453125" y="804.344482421875" z="2.0"/>
-  <position name="Mesh2Tess_18" unit="mm" x="-2464.392822265625" y="803.594482421875" z="-3.5"/>
-  <position name="Mesh2Tess_19" unit="mm" x="-2537.161865234375" y="802.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_20" unit="mm" x="-2466.44189453125" y="799.4954833984375" z="2.0"/>
-  <position name="Mesh2Tess_21" unit="mm" x="-2536.050048828125" y="799.3455810546875" z="2.0"/>
-  <position name="Mesh2Tess_22" unit="mm" x="-2536.411865234375" y="799.4954833984375" z="2.0"/>
-  <position name="Mesh2Tess_23" unit="mm" x="-2538.4609375" y="803.594482421875" z="2.0"/>
-  <position name="Mesh2Tess_24" unit="mm" x="-2537.11083984375" y="800.40625" z="2.0"/>
-  <position name="Mesh2Tess_25" unit="mm" x="-2465.07177734375" y="800.34228515625" z="2.0"/>
-  <position name="Mesh2Tess_26" unit="mm" x="-2537.65869140625" y="800.705078125" z="2.0"/>
-  <position name="Mesh2Tess_27" unit="mm" x="-2046.523193359375" y="123.9625015258789" z="-3.5"/>
-  <position name="Mesh2Tess_28" unit="mm" x="-2537.7392578125" y="799.5833740234375" z="-3.5"/>
-  <position name="Mesh2Tess_29" unit="mm" x="-2538.61083984375" y="803.956298828125" z="2.0"/>
-  <position name="Mesh2Tess_30" unit="mm" x="-2465.69189453125" y="801.2803955078125" z="-3.5"/>
-  <position name="Mesh2Tess_31" unit="mm" x="-2537.550048828125" y="805.7933959960938" z="2.0"/>
-  <position name="Mesh2Tess_32" unit="mm" x="-2466.131103515625" y="799.7338256835938" z="2.0"/>
-  <position name="Mesh2Tess_33" unit="mm" x="-2537.447265625" y="801.0247192382812" z="-3.5"/>
-  <position name="Mesh2Tess_34" unit="mm" x="-1797.1593017578125" y="123.9625015258789" z="-3.5"/>
-  <position name="Mesh2Tess_35" unit="mm" x="-2465.195068359375" y="800.705078125" z="-3.5"/>
-  <position name="Mesh2Tess_36" unit="mm" x="-2464.94189453125" y="805.6435546875" z="2.0"/>
-  <position name="Mesh2Tess_37" unit="mm" x="-2537.781982421875" y="800.34228515625" z="2.0"/>
-  <position name="Mesh2Tess_38" unit="mm" x="-2537.161865234375" y="800.7944946289062" z="3.5"/>
-  <position name="Mesh2Tess_39" unit="mm" x="-2465.69189453125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_40" unit="mm" x="-2467.306396484375" y="798.7539672851562" z="2.0"/>
-  <position name="Mesh2Tess_41" unit="mm" x="-2465.742919921875" y="800.40625" z="2.0"/>
-  <position name="Mesh2Tess_42" unit="mm" x="-2467.8408203125" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_43" unit="mm" x="-2465.52392578125" y="798.94287109375" z="-3.5"/>
-  <position name="Mesh2Tess_44" unit="mm" x="-2464.631103515625" y="803.2838134765625" z="2.0"/>
-  <position name="Mesh2Tess_45" unit="mm" x="-2464.19189453125" y="804.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_46" unit="mm" x="-2536.722412109375" y="799.7338256835938" z="3.5"/>
-  <position name="Mesh2Tess_47" unit="mm" x="-2467.19189453125" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_48" unit="mm" x="-2538.4609375" y="803.594482421875" z="-3.5"/>
-  <position name="Mesh2Tess_49" unit="mm" x="-2465.07177734375" y="800.34228515625" z="-3.5"/>
-  <position name="Mesh2Tess_50" unit="mm" x="-2537.65869140625" y="800.705078125" z="-3.5"/>
-  <position name="Mesh2Tess_51" unit="mm" x="-2536.9609375" y="800.0444946289062" z="3.5"/>
-  <position name="Mesh2Tess_52" unit="mm" x="-2537.550048828125" y="802.8956298828125" z="2.0"/>
-  <position name="Mesh2Tess_53" unit="mm" x="-2538.61083984375" y="803.956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_54" unit="mm" x="-2537.550048828125" y="805.7933959960938" z="-3.5"/>
-  <position name="Mesh2Tess_55" unit="mm" x="-2537.161865234375" y="805.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_56" unit="mm" x="-2465.836181640625" y="798.7208862304688" z="2.0"/>
-  <position name="Mesh2Tess_57" unit="mm" x="-2466.8037109375" y="799.3455810546875" z="2.0"/>
-  <position name="Mesh2Tess_58" unit="mm" x="-2464.94189453125" y="805.6435546875" z="-3.5"/>
-  <position name="Mesh2Tess_59" unit="mm" x="-2537.781982421875" y="800.34228515625" z="-3.5"/>
-  <position name="Mesh2Tess_60" unit="mm" x="-2538.61083984375" y="804.7327270507812" z="2.0"/>
-  <position name="Mesh2Tess_61" unit="mm" x="-2467.306396484375" y="798.7539672851562" z="-3.5"/>
-  <position name="Mesh2Tess_62" unit="mm" x="-2535.54736328125" y="798.7539672851562" z="2.0"/>
-  <position name="Mesh2Tess_63" unit="mm" x="-2464.242919921875" y="804.7327270507812" z="2.0"/>
-  <position name="Mesh2Tess_64" unit="mm" x="-2537.329833984375" y="798.94287109375" z="-3.5"/>
-  <position name="Mesh2Tess_65" unit="mm" x="-2467.8408203125" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_66" unit="mm" x="-2537.017578125" y="798.7208862304688" z="2.0"/>
-  <position name="Mesh2Tess_67" unit="mm" x="-2464.631103515625" y="803.2838134765625" z="-3.5"/>
-  <position name="Mesh2Tess_68" unit="mm" x="-2537.911865234375" y="803.0454711914062" z="2.0"/>
-  <position name="Mesh2Tess_69" unit="mm" x="-2535.245361328125" y="798.9898071289062" z="2.0"/>
-  <position name="Mesh2Tess_70" unit="mm" x="-2465.69189453125" y="802.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_71" unit="mm" x="-2464.242919921875" y="803.956298828125" z="2.0"/>
-  <position name="Mesh2Tess_72" unit="mm" x="-2537.161865234375" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_73" unit="mm" x="-2464.631103515625" y="805.4051513671875" z="2.0"/>
-  <position name="Mesh2Tess_74" unit="mm" x="-2537.550048828125" y="802.8956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_75" unit="mm" x="-2465.044189453125" y="799.9600830078125" z="-3.5"/>
-  <position name="Mesh2Tess_76" unit="mm" x="-2537.575927734375" y="799.2367553710938" z="2.0"/>
-  <position name="Mesh2Tess_77" unit="mm" x="-2536.6591796875" y="798.5852661132812" z="2.0"/>
-  <position name="Mesh2Tess_78" unit="mm" x="-2537.161865234375" y="805.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_79" unit="mm" x="-2466.95458984375" y="798.6023559570312" z="2.0"/>
-  <position name="Mesh2Tess_80" unit="mm" x="-2465.836181640625" y="798.7208862304688" z="-3.5"/>
-  <position name="Mesh2Tess_81" unit="mm" x="-2538.222412109375" y="805.4051513671875" z="-3.5"/>
-  <position name="Mesh2Tess_82" unit="mm" x="-2466.44189453125" y="799.4954833984375" z="3.5"/>
-  <position name="Mesh2Tess_83" unit="mm" x="-2537.161865234375" y="801.2803955078125" z="2.0"/>
-  <position name="Mesh2Tess_84" unit="mm" x="-2538.61083984375" y="804.7327270507812" z="-3.5"/>
-  <position name="Mesh2Tess_85" unit="mm" x="-2536.050048828125" y="799.3455810546875" z="3.5"/>
-  <position name="Mesh2Tess_86" unit="mm" x="-2537.161865234375" y="800.7944946289062" z="2.0"/>
-  <position name="Mesh2Tess_87" unit="mm" x="-2535.54736328125" y="798.7539672851562" z="-3.5"/>
-  <position name="Mesh2Tess_88" unit="mm" x="-2464.242919921875" y="804.7327270507812" z="-3.5"/>
-  <position name="Mesh2Tess_89" unit="mm" x="-2537.017578125" y="798.7208862304688" z="-3.5"/>
-  <position name="Mesh2Tess_90" unit="mm" x="-2538.661865234375" y="804.344482421875" z="2.0"/>
-  <position name="Mesh2Tess_91" unit="mm" x="-2537.911865234375" y="803.0454711914062" z="-3.5"/>
-  <position name="Mesh2Tess_92" unit="mm" x="-2535.245361328125" y="798.9898071289062" z="-3.5"/>
-  <position name="Mesh2Tess_93" unit="mm" x="-2464.94189453125" y="803.0454711914062" z="2.0"/>
-  <position name="Mesh2Tess_94" unit="mm" x="-2466.131103515625" y="799.7338256835938" z="3.5"/>
-  <position name="Mesh2Tess_95" unit="mm" x="-2466.57568359375" y="798.5448608398438" z="2.0"/>
-  <position name="Mesh2Tess_96" unit="mm" x="-2467.19189453125" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_97" unit="mm" x="-2465.69189453125" y="802.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_98" unit="mm" x="-2464.631103515625" y="805.4051513671875" z="-3.5"/>
-  <position name="Mesh2Tess_99" unit="mm" x="-2465.892822265625" y="800.0444946289062" z="2.0"/>
-  <position name="Mesh2Tess_100" unit="mm" x="-2465.3037109375" y="805.7933959960938" z="2.0"/>
-  <position name="Mesh2Tess_101" unit="mm" x="-2537.575927734375" y="799.2367553710938" z="-3.5"/>
-  <position name="Mesh2Tess_102" unit="mm" x="-2536.6591796875" y="798.5852661132812" z="-3.5"/>
-  <position name="Mesh2Tess_103" unit="mm" x="-2538.222412109375" y="803.2838134765625" z="2.0"/>
-  <position name="Mesh2Tess_104" unit="mm" x="-2414.678466796875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_105" unit="mm" x="-2466.95458984375" y="798.6023559570312" z="-3.5"/>
-  <position name="Mesh2Tess_106" unit="mm" x="-2046.523193359375" y="123.9625015258789" z="3.5"/>
-  <position name="Mesh2Tess_107" unit="mm" x="-2537.161865234375" y="801.2803955078125" z="-3.5"/>
-  <position name="Mesh2Tess_108" unit="mm" x="-2750.239501953125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_109" unit="mm" x="-2465.69189453125" y="800.7944946289062" z="3.5"/>
-  <position name="Mesh2Tess_110" unit="mm" x="-1797.1593017578125" y="123.9625015258789" z="3.5"/>
-  <position name="Mesh2Tess_111" unit="mm" x="-2466.194580078125" y="798.5852661132812" z="2.0"/>
-  <position name="Mesh2Tess_112" unit="mm" x="-2537.161865234375" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_113" unit="mm" x="-2538.661865234375" y="804.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_114" unit="mm" x="-2465.406494140625" y="801.0247192382812" z="2.0"/>
-  <position name="Mesh2Tess_115" unit="mm" x="-2465.27783203125" y="799.2367553710938" z="2.0"/>
-  <position name="Mesh2Tess_116" unit="mm" x="-2535.661865234375" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_117" unit="mm" x="-2538.4609375" y="805.094482421875" z="2.0"/>
-  <position name="Mesh2Tess_118" unit="mm" x="-2536.278076171875" y="798.5448608398438" z="2.0"/>
-  <position name="Mesh2Tess_119" unit="mm" x="-2464.94189453125" y="803.0454711914062" z="-3.5"/>
-  <position name="Mesh2Tess_120" unit="mm" x="-2466.57568359375" y="798.5448608398438" z="-3.5"/>
-  <position name="Mesh2Tess_121" unit="mm" x="-2535.899169921875" y="798.6023559570312" z="2.0"/>
-  <position name="Mesh2Tess_122" unit="mm" x="-2465.3037109375" y="802.8956298828125" z="2.0"/>
-  <position name="Mesh2Tess_123" unit="mm" x="-2537.911865234375" y="805.6435546875" z="2.0"/>
-  <position name="Mesh2Tess_124" unit="mm" x="-2464.392822265625" y="805.094482421875" z="2.0"/>
-  <position name="Mesh2Tess_125" unit="mm" x="-2536.411865234375" y="799.4954833984375" z="3.5"/>
-  <position name="Mesh2Tess_126" unit="mm" x="-2537.11083984375" y="800.40625" z="3.5"/>
-  <position name="Mesh2Tess_127" unit="mm" x="-2538.222412109375" y="803.2838134765625" z="-3.5"/>
-  <position name="Mesh2Tess_128" unit="mm" x="-2537.8095703125" y="799.9600830078125" z="2.0"/>
-  <position name="Mesh2Tess_129" unit="mm" x="-2465.52392578125" y="798.94287109375" z="2.0"/>
-  <position name="Mesh2Tess_130" unit="mm" x="-2465.69189453125" y="805.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_131" unit="mm" x="-2536.722412109375" y="799.7338256835938" z="2.0"/>
-  <position name="Mesh2Tess_132" unit="mm" x="-2466.194580078125" y="798.5852661132812" z="-3.5"/>
-  <position name="Mesh2Tess_133" unit="mm" x="-2467.6083984375" y="798.9898071289062" z="2.0"/>
-  <position name="Mesh2Tess_134" unit="mm" x="-2465.114501953125" y="799.5833740234375" z="2.0"/>
-  <position name="Mesh2Tess_135" unit="mm" x="-2464.242919921875" y="803.956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_136" unit="mm" x="-2465.406494140625" y="801.0247192382812" z="-3.5"/>
-  <position name="Mesh2Tess_137" unit="mm" x="-2465.27783203125" y="799.2367553710938" z="-3.5"/>
-  <position name="Mesh2Tess_138" unit="mm" x="-2535.012939453125" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_139" unit="mm" x="-2465.742919921875" y="800.40625" z="3.5"/>
-  <position name="Mesh2Tess_140" unit="mm" x="-2536.9609375" y="800.0444946289062" z="2.0"/>
-  <position name="Mesh2Tess_141" unit="mm" x="-2538.4609375" y="805.094482421875" z="-3.5"/>
-  <position name="Mesh2Tess_142" unit="mm" x="-2536.278076171875" y="798.5448608398438" z="-3.5"/>
-  <position name="Mesh2Tess_143" unit="mm" x="-2414.678466796875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_144" unit="mm" x="-2535.899169921875" y="798.6023559570312" z="-3.5"/>
-  <position name="Mesh2Tess_145" unit="mm" x="-2465.3037109375" y="802.8956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_146" unit="mm" x="-2537.911865234375" y="805.6435546875" z="-3.5"/>
-  <position name="Mesh2Tess_147" unit="mm" x="-2464.392822265625" y="805.094482421875" z="-3.5"/>
-  <position name="Mesh2Tess_148" unit="mm" x="-2464.392822265625" y="803.594482421875" z="2.0"/>
-  <position name="Mesh2Tess_149" unit="mm" x="-2750.239501953125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_150" unit="mm" x="-2537.161865234375" y="802.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_151" unit="mm" x="-2465.69189453125" y="808.344482421875" z="-3.5"/>
+  <position name="Mesh2Tess_0" unit="mm" x="-2537.161865234375" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="-2537.161865234375" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="-2414.678466796875" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="-2414.678466796875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="-2046.523193359375" y="123.9625015258789" z="-3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="-2537.161865234375" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="-2046.523193359375" y="123.9625015258789" z="3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="-2537.161865234375" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="-1797.1593017578125" y="123.9625015258789" z="-3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="-2465.69189453125" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="-2750.239501953125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="-2750.239501953125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="-1797.1593017578125" y="123.9625015258789" z="3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="-2465.69189453125" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="-2465.69189453125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="-2465.69189453125" y="808.344482421875" z="3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalTile10_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
         </tessellated>
   </solid>
 
   <solid name="OuterHCalTile11" material="PlasticScint" unit="mm" x="-2530.727" y="470.159" z="0.0">
    <define>
-  <position name="Mesh2Tess_0" unit="mm" x="-2775.204833984375" y="799.4954833984375" z="2.0"/>
-  <position name="Mesh2Tess_1" unit="mm" x="-2775.954833984375" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_2" unit="mm" x="-2844.662109375" y="798.6023559570312" z="-3.5"/>
-  <position name="Mesh2Tess_3" unit="mm" x="-2774.59912109375" y="798.7208862304688" z="2.0"/>
-  <position name="Mesh2Tess_4" unit="mm" x="-2774.066650390625" y="805.7933959960938" z="-3.5"/>
-  <position name="Mesh2Tess_5" unit="mm" x="-2846.6748046875" y="805.6435546875" z="-3.5"/>
-  <position name="Mesh2Tess_6" unit="mm" x="-2846.421630859375" y="800.705078125" z="2.0"/>
-  <position name="Mesh2Tess_7" unit="mm" x="-2774.89404296875" y="799.7338256835938" z="3.5"/>
-  <position name="Mesh2Tess_8" unit="mm" x="-2773.15576171875" y="803.594482421875" z="2.0"/>
-  <position name="Mesh2Tess_9" unit="mm" x="-2776.0693359375" y="798.7539672851562" z="-3.5"/>
-  <position name="Mesh2Tess_10" unit="mm" x="-2846.572509765625" y="799.9600830078125" z="-3.5"/>
-  <position name="Mesh2Tess_11" unit="mm" x="-2776.603759765625" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_12" unit="mm" x="-2751.673828125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_13" unit="mm" x="-2773.704833984375" y="803.0454711914062" z="-3.5"/>
-  <position name="Mesh2Tess_14" unit="mm" x="-2846.31298828125" y="802.8956298828125" z="2.0"/>
-  <position name="Mesh2Tess_15" unit="mm" x="-2775.566650390625" y="799.3455810546875" z="3.5"/>
-  <position name="Mesh2Tess_16" unit="mm" x="-2846.210205078125" y="801.0247192382812" z="2.0"/>
-  <position name="Mesh2Tess_17" unit="mm" x="-2847.373779296875" y="803.956298828125" z="2.0"/>
-  <position name="Mesh2Tess_18" unit="mm" x="-2845.780517578125" y="798.7208862304688" z="2.0"/>
-  <position name="Mesh2Tess_19" unit="mm" x="-2774.454833984375" y="801.2803955078125" z="-3.5"/>
-  <position name="Mesh2Tess_20" unit="mm" x="-2774.16943359375" y="801.0247192382812" z="2.0"/>
-  <position name="Mesh2Tess_21" unit="mm" x="-2845.422119140625" y="798.5852661132812" z="2.0"/>
-  <position name="Mesh2Tess_22" unit="mm" x="-2774.454833984375" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_23" unit="mm" x="-2774.59912109375" y="798.7208862304688" z="-3.5"/>
-  <position name="Mesh2Tess_24" unit="mm" x="-2846.421630859375" y="800.705078125" z="-3.5"/>
-  <position name="Mesh2Tess_25" unit="mm" x="-2845.873779296875" y="800.40625" z="2.0"/>
-  <position name="Mesh2Tess_26" unit="mm" x="-2845.9248046875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_27" unit="mm" x="-2772.954833984375" y="804.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_28" unit="mm" x="-2847.373779296875" y="804.7327270507812" z="-3.5"/>
-  <position name="Mesh2Tess_29" unit="mm" x="-2847.4248046875" y="804.344482421875" z="2.0"/>
-  <position name="Mesh2Tess_30" unit="mm" x="-2774.454833984375" y="805.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_31" unit="mm" x="-2845.9248046875" y="801.2803955078125" z="2.0"/>
-  <position name="Mesh2Tess_32" unit="mm" x="-2773.005859375" y="804.7327270507812" z="2.0"/>
-  <position name="Mesh2Tess_33" unit="mm" x="-2773.005859375" y="803.956298828125" z="2.0"/>
-  <position name="Mesh2Tess_34" unit="mm" x="-2846.31298828125" y="805.7933959960938" z="2.0"/>
-  <position name="Mesh2Tess_35" unit="mm" x="-2846.31298828125" y="802.8956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_36" unit="mm" x="-2774.454833984375" y="802.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_37" unit="mm" x="-2776.371337890625" y="798.9898071289062" z="2.0"/>
-  <position name="Mesh2Tess_38" unit="mm" x="-2847.373779296875" y="803.956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_39" unit="mm" x="-2773.704833984375" y="805.6435546875" z="2.0"/>
-  <position name="Mesh2Tess_40" unit="mm" x="-2845.780517578125" y="798.7208862304688" z="-3.5"/>
-  <position name="Mesh2Tess_41" unit="mm" x="-2774.16943359375" y="801.0247192382812" z="-3.5"/>
-  <position name="Mesh2Tess_42" unit="mm" x="-2846.544921875" y="800.34228515625" z="2.0"/>
-  <position name="Mesh2Tess_43" unit="mm" x="-2774.65576171875" y="800.0444946289062" z="2.0"/>
-  <position name="Mesh2Tess_44" unit="mm" x="-2846.502197265625" y="799.5833740234375" z="-3.5"/>
-  <position name="Mesh2Tess_45" unit="mm" x="-2845.422119140625" y="798.5852661132812" z="-3.5"/>
-  <position name="Mesh2Tess_46" unit="mm" x="-2775.954833984375" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_47" unit="mm" x="-2846.0927734375" y="798.94287109375" z="2.0"/>
-  <position name="Mesh2Tess_48" unit="mm" x="-2751.673828125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_49" unit="mm" x="-2845.9248046875" y="802.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_50" unit="mm" x="-2773.39404296875" y="803.2838134765625" z="2.0"/>
-  <position name="Mesh2Tess_51" unit="mm" x="-2774.89404296875" y="799.7338256835938" z="2.0"/>
-  <position name="Mesh2Tess_52" unit="mm" x="-3016.282958984375" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_53" unit="mm" x="-2846.3388671875" y="799.2367553710938" z="2.0"/>
-  <position name="Mesh2Tess_54" unit="mm" x="-2773.15576171875" y="805.094482421875" z="2.0"/>
-  <position name="Mesh2Tess_55" unit="mm" x="-2846.985595703125" y="805.4051513671875" z="2.0"/>
-  <position name="Mesh2Tess_56" unit="mm" x="-2774.454833984375" y="800.7944946289062" z="3.5"/>
-  <position name="Mesh2Tess_57" unit="mm" x="-2847.4248046875" y="804.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_58" unit="mm" x="-2774.454833984375" y="805.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_59" unit="mm" x="-2845.9248046875" y="801.2803955078125" z="-3.5"/>
-  <position name="Mesh2Tess_60" unit="mm" x="-2773.005859375" y="804.7327270507812" z="-3.5"/>
-  <position name="Mesh2Tess_61" unit="mm" x="-2847.223876953125" y="805.094482421875" z="2.0"/>
-  <position name="Mesh2Tess_62" unit="mm" x="-2845.041015625" y="798.5448608398438" z="2.0"/>
-  <position name="Mesh2Tess_63" unit="mm" x="-2846.31298828125" y="805.7933959960938" z="-3.5"/>
-  <position name="Mesh2Tess_64" unit="mm" x="-2774.95751953125" y="798.5852661132812" z="2.0"/>
-  <position name="Mesh2Tess_65" unit="mm" x="-2845.9248046875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_66" unit="mm" x="-2775.566650390625" y="799.3455810546875" z="2.0"/>
-  <position name="Mesh2Tess_67" unit="mm" x="-2774.066650390625" y="802.8956298828125" z="2.0"/>
-  <position name="Mesh2Tess_68" unit="mm" x="-2773.704833984375" y="805.6435546875" z="-3.5"/>
-  <position name="Mesh2Tess_69" unit="mm" x="-2289.19580078125" y="123.9625015258789" z="-3.5"/>
-  <position name="Mesh2Tess_70" unit="mm" x="-2773.15576171875" y="803.594482421875" z="-3.5"/>
-  <position name="Mesh2Tess_71" unit="mm" x="-2846.544921875" y="800.34228515625" z="-3.5"/>
-  <position name="Mesh2Tess_72" unit="mm" x="-2844.310302734375" y="798.7539672851562" z="2.0"/>
-  <position name="Mesh2Tess_73" unit="mm" x="-2845.1748046875" y="799.4954833984375" z="3.5"/>
-  <position name="Mesh2Tess_74" unit="mm" x="-2844.81298828125" y="799.3455810546875" z="3.5"/>
-  <position name="Mesh2Tess_75" unit="mm" x="-2773.9580078125" y="800.705078125" z="2.0"/>
-  <position name="Mesh2Tess_76" unit="mm" x="-2846.0927734375" y="798.94287109375" z="-3.5"/>
-  <position name="Mesh2Tess_77" unit="mm" x="-2773.80712890625" y="799.9600830078125" z="2.0"/>
-  <position name="Mesh2Tess_78" unit="mm" x="-2773.39404296875" y="803.2838134765625" z="-3.5"/>
-  <position name="Mesh2Tess_79" unit="mm" x="-2774.286865234375" y="798.94287109375" z="2.0"/>
-  <position name="Mesh2Tess_80" unit="mm" x="-2845.485595703125" y="799.7338256835938" z="3.5"/>
-  <position name="Mesh2Tess_81" unit="mm" x="-2845.9248046875" y="805.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_82" unit="mm" x="-2846.6748046875" y="803.0454711914062" z="2.0"/>
-  <position name="Mesh2Tess_83" unit="mm" x="-2846.3388671875" y="799.2367553710938" z="-3.5"/>
-  <position name="Mesh2Tess_84" unit="mm" x="-2844.00830078125" y="798.9898071289062" z="2.0"/>
-  <position name="Mesh2Tess_85" unit="mm" x="-2846.210205078125" y="801.0247192382812" z="-3.5"/>
-  <position name="Mesh2Tess_86" unit="mm" x="-2844.4248046875" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_87" unit="mm" x="-2773.39404296875" y="805.4051513671875" z="2.0"/>
-  <position name="Mesh2Tess_88" unit="mm" x="-2774.505859375" y="800.40625" z="3.5"/>
-  <position name="Mesh2Tess_89" unit="mm" x="-2845.723876953125" y="800.0444946289062" z="2.0"/>
-  <position name="Mesh2Tess_90" unit="mm" x="-2773.834716796875" y="800.34228515625" z="2.0"/>
-  <position name="Mesh2Tess_91" unit="mm" x="-2847.223876953125" y="805.094482421875" z="-3.5"/>
-  <position name="Mesh2Tess_92" unit="mm" x="-2845.041015625" y="798.5448608398438" z="-3.5"/>
-  <position name="Mesh2Tess_93" unit="mm" x="-2775.717529296875" y="798.6023559570312" z="2.0"/>
-  <position name="Mesh2Tess_94" unit="mm" x="-2774.95751953125" y="798.5852661132812" z="-3.5"/>
-  <position name="Mesh2Tess_95" unit="mm" x="-2774.066650390625" y="802.8956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_96" unit="mm" x="-2773.87744140625" y="799.5833740234375" z="2.0"/>
-  <position name="Mesh2Tess_97" unit="mm" x="-3016.282958984375" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_98" unit="mm" x="-2843.77587890625" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_99" unit="mm" x="-2844.310302734375" y="798.7539672851562" z="-3.5"/>
-  <position name="Mesh2Tess_100" unit="mm" x="-2773.9580078125" y="800.705078125" z="-3.5"/>
-  <position name="Mesh2Tess_101" unit="mm" x="-2047.95751953125" y="123.9625015258789" z="-3.5"/>
-  <position name="Mesh2Tess_102" unit="mm" x="-2845.9248046875" y="800.7944946289062" z="3.5"/>
-  <position name="Mesh2Tess_103" unit="mm" x="-2846.985595703125" y="803.2838134765625" z="2.0"/>
-  <position name="Mesh2Tess_104" unit="mm" x="-2773.80712890625" y="799.9600830078125" z="-3.5"/>
-  <position name="Mesh2Tess_105" unit="mm" x="-2776.603759765625" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_106" unit="mm" x="-2775.204833984375" y="799.4954833984375" z="3.5"/>
-  <position name="Mesh2Tess_107" unit="mm" x="-2774.286865234375" y="798.94287109375" z="-3.5"/>
-  <position name="Mesh2Tess_108" unit="mm" x="-2846.6748046875" y="803.0454711914062" z="-3.5"/>
-  <position name="Mesh2Tess_109" unit="mm" x="-2844.00830078125" y="798.9898071289062" z="-3.5"/>
-  <position name="Mesh2Tess_110" unit="mm" x="-2773.704833984375" y="803.0454711914062" z="2.0"/>
-  <position name="Mesh2Tess_111" unit="mm" x="-2773.005859375" y="803.956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_112" unit="mm" x="-2774.040771484375" y="799.2367553710938" z="2.0"/>
-  <position name="Mesh2Tess_113" unit="mm" x="-2774.454833984375" y="800.7944946289062" z="2.0"/>
-  <position name="Mesh2Tess_114" unit="mm" x="-2776.371337890625" y="798.9898071289062" z="-3.5"/>
-  <position name="Mesh2Tess_115" unit="mm" x="-2774.65576171875" y="800.0444946289062" z="3.5"/>
-  <position name="Mesh2Tess_116" unit="mm" x="-2775.338623046875" y="798.5448608398438" z="2.0"/>
-  <position name="Mesh2Tess_117" unit="mm" x="-2773.834716796875" y="800.34228515625" z="-3.5"/>
-  <position name="Mesh2Tess_118" unit="mm" x="-2775.717529296875" y="798.6023559570312" z="-3.5"/>
-  <position name="Mesh2Tess_119" unit="mm" x="-2773.87744140625" y="799.5833740234375" z="-3.5"/>
-  <position name="Mesh2Tess_120" unit="mm" x="-2845.9248046875" y="802.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_121" unit="mm" x="-2772.954833984375" y="804.344482421875" z="2.0"/>
-  <position name="Mesh2Tess_122" unit="mm" x="-2843.77587890625" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_123" unit="mm" x="-2847.373779296875" y="804.7327270507812" z="2.0"/>
-  <position name="Mesh2Tess_124" unit="mm" x="-2773.15576171875" y="805.094482421875" z="-3.5"/>
-  <position name="Mesh2Tess_125" unit="mm" x="-2846.985595703125" y="805.4051513671875" z="-3.5"/>
-  <position name="Mesh2Tess_126" unit="mm" x="-2845.1748046875" y="799.4954833984375" z="2.0"/>
-  <position name="Mesh2Tess_127" unit="mm" x="-2844.81298828125" y="799.3455810546875" z="2.0"/>
-  <position name="Mesh2Tess_128" unit="mm" x="-2847.223876953125" y="803.594482421875" z="2.0"/>
-  <position name="Mesh2Tess_129" unit="mm" x="-2846.985595703125" y="803.2838134765625" z="-3.5"/>
-  <position name="Mesh2Tess_130" unit="mm" x="-2845.485595703125" y="799.7338256835938" z="2.0"/>
-  <position name="Mesh2Tess_131" unit="mm" x="-2844.662109375" y="798.6023559570312" z="2.0"/>
-  <position name="Mesh2Tess_132" unit="mm" x="-2774.040771484375" y="799.2367553710938" z="-3.5"/>
-  <position name="Mesh2Tess_133" unit="mm" x="-2774.454833984375" y="802.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_134" unit="mm" x="-2774.066650390625" y="805.7933959960938" z="2.0"/>
-  <position name="Mesh2Tess_135" unit="mm" x="-2845.873779296875" y="800.40625" z="3.5"/>
-  <position name="Mesh2Tess_136" unit="mm" x="-2846.6748046875" y="805.6435546875" z="2.0"/>
-  <position name="Mesh2Tess_137" unit="mm" x="-2844.4248046875" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_138" unit="mm" x="-2846.502197265625" y="799.5833740234375" z="2.0"/>
-  <position name="Mesh2Tess_139" unit="mm" x="-2775.338623046875" y="798.5448608398438" z="-3.5"/>
-  <position name="Mesh2Tess_140" unit="mm" x="-2776.0693359375" y="798.7539672851562" z="2.0"/>
-  <position name="Mesh2Tess_141" unit="mm" x="-2047.95751953125" y="123.9625015258789" z="3.5"/>
-  <position name="Mesh2Tess_142" unit="mm" x="-2774.505859375" y="800.40625" z="2.0"/>
-  <position name="Mesh2Tess_143" unit="mm" x="-2846.572509765625" y="799.9600830078125" z="2.0"/>
-  <position name="Mesh2Tess_144" unit="mm" x="-2774.454833984375" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_145" unit="mm" x="-2845.9248046875" y="805.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_146" unit="mm" x="-2847.223876953125" y="803.594482421875" z="-3.5"/>
-  <position name="Mesh2Tess_147" unit="mm" x="-2289.19580078125" y="123.9625015258789" z="3.5"/>
-  <position name="Mesh2Tess_148" unit="mm" x="-2845.9248046875" y="800.7944946289062" z="2.0"/>
-  <position name="Mesh2Tess_149" unit="mm" x="-2774.454833984375" y="801.2803955078125" z="2.0"/>
-  <position name="Mesh2Tess_150" unit="mm" x="-2773.39404296875" y="805.4051513671875" z="-3.5"/>
-  <position name="Mesh2Tess_151" unit="mm" x="-2845.723876953125" y="800.0444946289062" z="3.5"/>
+  <position name="Mesh2Tess_0" unit="mm" x="-3016.282958984375" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="-2774.454833984375" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="-2845.9248046875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="-2774.454833984375" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="-2845.9248046875" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="-2289.19580078125" y="123.9625015258789" z="-3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="-2047.95751953125" y="123.9625015258789" z="-3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="-2047.95751953125" y="123.9625015258789" z="3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="-2845.9248046875" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="-2751.673828125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="-2751.673828125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="-2289.19580078125" y="123.9625015258789" z="3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="-2845.9248046875" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="-2774.454833984375" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="-2774.454833984375" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="-3016.282958984375" y="808.344482421875" z="-3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalTile11_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-         </tessellated>
+      <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+        </tessellated>
   </solid>
 
   <solid name="OuterHCalTile12" material="PlasticScint" unit="mm" x="-2785.926" y="432.797" z="0.0">
     <define>
-  <position name="Mesh2Tess_0" unit="mm" x="-3038.48193359375" y="803.2838134765625" z="-3.5"/>
-  <position name="Mesh2Tess_1" unit="mm" x="-3041.04248046875" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_2" unit="mm" x="-3112.3115234375" y="805.094482421875" z="-3.5"/>
-  <position name="Mesh2Tess_3" unit="mm" x="-3111.58984375" y="799.5833740234375" z="2.0"/>
-  <position name="Mesh2Tess_4" unit="mm" x="-3041.691650390625" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_5" unit="mm" x="-3039.54248046875" y="802.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_6" unit="mm" x="-3111.50927734375" y="800.705078125" z="2.0"/>
-  <position name="Mesh2Tess_7" unit="mm" x="-3039.54248046875" y="805.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_8" unit="mm" x="-3111.400634765625" y="805.7933959960938" z="2.0"/>
-  <position name="Mesh2Tess_9" unit="mm" x="-3111.2978515625" y="801.0247192382812" z="-3.5"/>
-  <position name="Mesh2Tess_10" unit="mm" x="-3039.0458984375" y="800.705078125" z="2.0"/>
-  <position name="Mesh2Tess_11" unit="mm" x="-3039.37451171875" y="798.94287109375" z="-3.5"/>
-  <position name="Mesh2Tess_12" unit="mm" x="-2290.65478515625" y="123.9625015258789" z="-3.5"/>
-  <position name="Mesh2Tess_13" unit="mm" x="-3039.154296875" y="805.7933959960938" z="2.0"/>
-  <position name="Mesh2Tess_14" unit="mm" x="-3040.29248046875" y="799.4954833984375" z="2.0"/>
-  <position name="Mesh2Tess_15" unit="mm" x="-3110.509765625" y="798.5852661132812" z="-3.5"/>
-  <position name="Mesh2Tess_16" unit="mm" x="-3111.012451171875" y="800.7944946289062" z="2.0"/>
-  <position name="Mesh2Tess_17" unit="mm" x="-2600.395263671875" y="123.9625015258789" z="3.5"/>
-  <position name="Mesh2Tess_18" unit="mm" x="-3111.762451171875" y="805.6435546875" z="-3.5"/>
-  <position name="Mesh2Tess_19" unit="mm" x="-3039.257080078125" y="801.0247192382812" z="2.0"/>
-  <position name="Mesh2Tess_20" unit="mm" x="-3116.512451171875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_21" unit="mm" x="-3038.243408203125" y="803.594482421875" z="2.0"/>
-  <position name="Mesh2Tess_22" unit="mm" x="-3039.54248046875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_23" unit="mm" x="-3111.58984375" y="799.5833740234375" z="-3.5"/>
-  <position name="Mesh2Tess_24" unit="mm" x="-3110.128662109375" y="798.5448608398438" z="2.0"/>
-  <position name="Mesh2Tess_25" unit="mm" x="-3041.691650390625" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_26" unit="mm" x="-3111.50927734375" y="800.705078125" z="-3.5"/>
-  <position name="Mesh2Tess_27" unit="mm" x="-3039.154296875" y="802.8956298828125" z="2.0"/>
-  <position name="Mesh2Tess_28" unit="mm" x="-3040.42626953125" y="798.5448608398438" z="2.0"/>
-  <position name="Mesh2Tess_29" unit="mm" x="-3039.54248046875" y="805.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_30" unit="mm" x="-3112.46142578125" y="804.7327270507812" z="2.0"/>
-  <position name="Mesh2Tess_31" unit="mm" x="-3110.96142578125" y="800.40625" z="2.0"/>
-  <position name="Mesh2Tess_32" unit="mm" x="-3111.180419921875" y="798.94287109375" z="2.0"/>
-  <position name="Mesh2Tess_33" unit="mm" x="-3110.262451171875" y="799.4954833984375" z="2.0"/>
-  <position name="Mesh2Tess_34" unit="mm" x="-3109.900634765625" y="799.3455810546875" z="2.0"/>
-  <position name="Mesh2Tess_35" unit="mm" x="-3039.128662109375" y="799.2367553710938" z="-3.5"/>
-  <position name="Mesh2Tess_36" unit="mm" x="-3112.3115234375" y="803.594482421875" z="2.0"/>
-  <position name="Mesh2Tess_37" unit="mm" x="-3111.400634765625" y="805.7933959960938" z="-3.5"/>
-  <position name="Mesh2Tess_38" unit="mm" x="-3111.012451171875" y="805.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_39" unit="mm" x="-3039.0458984375" y="800.705078125" z="-3.5"/>
-  <position name="Mesh2Tess_40" unit="mm" x="-3040.654296875" y="799.3455810546875" z="2.0"/>
-  <position name="Mesh2Tess_41" unit="mm" x="-3038.79248046875" y="805.6435546875" z="-3.5"/>
-  <position name="Mesh2Tess_42" unit="mm" x="-3038.48193359375" y="805.4051513671875" z="2.0"/>
-  <position name="Mesh2Tess_43" unit="mm" x="-3112.46142578125" y="803.956298828125" z="2.0"/>
-  <position name="Mesh2Tess_44" unit="mm" x="-3110.8681640625" y="798.7208862304688" z="2.0"/>
-  <position name="Mesh2Tess_45" unit="mm" x="-3109.39794921875" y="798.7539672851562" z="2.0"/>
-  <position name="Mesh2Tess_46" unit="mm" x="-3039.154296875" y="805.7933959960938" z="-3.5"/>
-  <position name="Mesh2Tess_47" unit="mm" x="-3109.095947265625" y="798.9898071289062" z="2.0"/>
-  <position name="Mesh2Tess_48" unit="mm" x="-3109.512451171875" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_49" unit="mm" x="-3116.512451171875" y="519.7784423828125" z="-3.5"/>
-  <position name="Mesh2Tess_50" unit="mm" x="-3112.0732421875" y="803.2838134765625" z="2.0"/>
-  <position name="Mesh2Tess_51" unit="mm" x="-3110.5732421875" y="799.7338256835938" z="3.5"/>
-  <position name="Mesh2Tess_52" unit="mm" x="-3039.593505859375" y="800.40625" z="2.0"/>
-  <position name="Mesh2Tess_53" unit="mm" x="-3039.257080078125" y="801.0247192382812" z="-3.5"/>
-  <position name="Mesh2Tess_54" unit="mm" x="-3038.243408203125" y="803.594482421875" z="-3.5"/>
-  <position name="Mesh2Tess_55" unit="mm" x="-3038.92236328125" y="800.34228515625" z="2.0"/>
-  <position name="Mesh2Tess_56" unit="mm" x="-3110.128662109375" y="798.5448608398438" z="-3.5"/>
-  <position name="Mesh2Tess_57" unit="mm" x="-3039.98193359375" y="799.7338256835938" z="3.5"/>
-  <position name="Mesh2Tess_58" unit="mm" x="-3111.012451171875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_59" unit="mm" x="-3040.42626953125" y="798.5448608398438" z="-3.5"/>
-  <position name="Mesh2Tess_60" unit="mm" x="-2290.65478515625" y="123.9625015258789" z="3.5"/>
-  <position name="Mesh2Tess_61" unit="mm" x="-3039.154296875" y="802.8956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_62" unit="mm" x="-3112.46142578125" y="804.7327270507812" z="-3.5"/>
-  <position name="Mesh2Tess_63" unit="mm" x="-3111.180419921875" y="798.94287109375" z="-3.5"/>
-  <position name="Mesh2Tess_64" unit="mm" x="-3109.749755859375" y="798.6023559570312" z="2.0"/>
-  <position name="Mesh2Tess_65" unit="mm" x="-3110.8115234375" y="800.0444946289062" z="2.0"/>
-  <position name="Mesh2Tess_66" unit="mm" x="-3112.3115234375" y="803.594482421875" z="-3.5"/>
-  <position name="Mesh2Tess_67" unit="mm" x="-3038.093505859375" y="804.7327270507812" z="2.0"/>
-  <position name="Mesh2Tess_68" unit="mm" x="-3039.686767578125" y="798.7208862304688" z="2.0"/>
-  <position name="Mesh2Tess_69" unit="mm" x="-3111.762451171875" y="803.0454711914062" z="2.0"/>
-  <position name="Mesh2Tess_70" unit="mm" x="-3111.012451171875" y="805.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_71" unit="mm" x="-3040.80517578125" y="798.6023559570312" z="2.0"/>
-  <position name="Mesh2Tess_72" unit="mm" x="-3112.512451171875" y="804.344482421875" z="2.0"/>
-  <position name="Mesh2Tess_73" unit="mm" x="-3116.512451171875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_74" unit="mm" x="-3038.48193359375" y="805.4051513671875" z="-3.5"/>
-  <position name="Mesh2Tess_75" unit="mm" x="-3108.863525390625" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_76" unit="mm" x="-3111.012451171875" y="801.2803955078125" z="2.0"/>
-  <position name="Mesh2Tess_77" unit="mm" x="-3112.46142578125" y="803.956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_78" unit="mm" x="-3110.8681640625" y="798.7208862304688" z="-3.5"/>
-  <position name="Mesh2Tess_79" unit="mm" x="-3109.39794921875" y="798.7539672851562" z="-3.5"/>
-  <position name="Mesh2Tess_80" unit="mm" x="-3111.632568359375" y="800.34228515625" z="2.0"/>
-  <position name="Mesh2Tess_81" unit="mm" x="-3112.0732421875" y="803.2838134765625" z="-3.5"/>
-  <position name="Mesh2Tess_82" unit="mm" x="-3038.965087890625" y="799.5833740234375" z="2.0"/>
-  <position name="Mesh2Tess_83" unit="mm" x="-3038.79248046875" y="803.0454711914062" z="2.0"/>
-  <position name="Mesh2Tess_84" unit="mm" x="-3038.92236328125" y="800.34228515625" z="-3.5"/>
-  <position name="Mesh2Tess_85" unit="mm" x="-3039.54248046875" y="800.7944946289062" z="2.0"/>
-  <position name="Mesh2Tess_86" unit="mm" x="-3111.012451171875" y="802.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_87" unit="mm" x="-3039.743408203125" y="800.0444946289062" z="3.5"/>
-  <position name="Mesh2Tess_88" unit="mm" x="-3038.894775390625" y="799.9600830078125" z="2.0"/>
-  <position name="Mesh2Tess_89" unit="mm" x="-3109.749755859375" y="798.6023559570312" z="-3.5"/>
-  <position name="Mesh2Tess_90" unit="mm" x="-3112.0732421875" y="805.4051513671875" z="2.0"/>
-  <position name="Mesh2Tess_91" unit="mm" x="-3040.29248046875" y="799.4954833984375" z="3.5"/>
-  <position name="Mesh2Tess_92" unit="mm" x="-3038.093505859375" y="804.7327270507812" z="-3.5"/>
-  <position name="Mesh2Tess_93" unit="mm" x="-3039.686767578125" y="798.7208862304688" z="-3.5"/>
-  <position name="Mesh2Tess_94" unit="mm" x="-3111.762451171875" y="803.0454711914062" z="-3.5"/>
-  <position name="Mesh2Tess_95" unit="mm" x="-3040.80517578125" y="798.6023559570312" z="-3.5"/>
-  <position name="Mesh2Tess_96" unit="mm" x="-3116.512451171875" y="519.7784423828125" z="3.5"/>
-  <position name="Mesh2Tess_97" unit="mm" x="-3112.512451171875" y="804.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_98" unit="mm" x="-3108.863525390625" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_99" unit="mm" x="-3041.04248046875" y="799.2944946289062" z="2.0"/>
-  <position name="Mesh2Tess_100" unit="mm" x="-3111.012451171875" y="801.2803955078125" z="-3.5"/>
-  <position name="Mesh2Tess_101" unit="mm" x="-3040.045166015625" y="798.5852661132812" z="2.0"/>
-  <position name="Mesh2Tess_102" unit="mm" x="-3038.04248046875" y="804.344482421875" z="2.0"/>
-  <position name="Mesh2Tess_103" unit="mm" x="-3111.012451171875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_104" unit="mm" x="-3110.96142578125" y="800.40625" z="3.5"/>
-  <position name="Mesh2Tess_105" unit="mm" x="-3110.262451171875" y="799.4954833984375" z="3.5"/>
-  <position name="Mesh2Tess_106" unit="mm" x="-2600.395263671875" y="123.9625015258789" z="-3.5"/>
-  <position name="Mesh2Tess_107" unit="mm" x="-3038.965087890625" y="799.5833740234375" z="-3.5"/>
-  <position name="Mesh2Tess_108" unit="mm" x="-3017.741943359375" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_109" unit="mm" x="-3110.5732421875" y="799.7338256835938" z="2.0"/>
-  <position name="Mesh2Tess_110" unit="mm" x="-3038.79248046875" y="803.0454711914062" z="-3.5"/>
-  <position name="Mesh2Tess_111" unit="mm" x="-3041.459228515625" y="798.9898071289062" z="2.0"/>
-  <position name="Mesh2Tess_112" unit="mm" x="-3111.400634765625" y="802.8956298828125" z="2.0"/>
-  <position name="Mesh2Tess_113" unit="mm" x="-3111.012451171875" y="802.844482421875" z="-3.5"/>
-  <position name="Mesh2Tess_114" unit="mm" x="-3038.894775390625" y="799.9600830078125" z="-3.5"/>
-  <position name="Mesh2Tess_115" unit="mm" x="-3112.0732421875" y="805.4051513671875" z="-3.5"/>
-  <position name="Mesh2Tess_116" unit="mm" x="-3039.54248046875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_117" unit="mm" x="-3038.093505859375" y="803.956298828125" z="2.0"/>
-  <position name="Mesh2Tess_118" unit="mm" x="-3041.156982421875" y="798.7539672851562" z="2.0"/>
-  <position name="Mesh2Tess_119" unit="mm" x="-3109.095947265625" y="798.9898071289062" z="-3.5"/>
-  <position name="Mesh2Tess_120" unit="mm" x="-3111.66015625" y="799.9600830078125" z="2.0"/>
-  <position name="Mesh2Tess_121" unit="mm" x="-3039.593505859375" y="800.40625" z="3.5"/>
-  <position name="Mesh2Tess_122" unit="mm" x="-3111.762451171875" y="805.6435546875" z="2.0"/>
-  <position name="Mesh2Tess_123" unit="mm" x="-3040.045166015625" y="798.5852661132812" z="-3.5"/>
-  <position name="Mesh2Tess_124" unit="mm" x="-3038.04248046875" y="804.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_125" unit="mm" x="-3039.54248046875" y="801.2803955078125" z="2.0"/>
-  <position name="Mesh2Tess_126" unit="mm" x="-3111.426513671875" y="799.2367553710938" z="2.0"/>
-  <position name="Mesh2Tess_127" unit="mm" x="-3110.8115234375" y="800.0444946289062" z="3.5"/>
-  <position name="Mesh2Tess_128" unit="mm" x="-3038.243408203125" y="805.094482421875" z="2.0"/>
-  <position name="Mesh2Tess_129" unit="mm" x="-3039.128662109375" y="799.2367553710938" z="2.0"/>
-  <position name="Mesh2Tess_130" unit="mm" x="-3041.459228515625" y="798.9898071289062" z="-3.5"/>
-  <position name="Mesh2Tess_131" unit="mm" x="-3111.400634765625" y="802.8956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_132" unit="mm" x="-3111.012451171875" y="800.7944946289062" z="3.5"/>
-  <position name="Mesh2Tess_133" unit="mm" x="-3038.79248046875" y="805.6435546875" z="2.0"/>
-  <position name="Mesh2Tess_134" unit="mm" x="-3038.48193359375" y="803.2838134765625" z="2.0"/>
-  <position name="Mesh2Tess_135" unit="mm" x="-3112.3115234375" y="805.094482421875" z="2.0"/>
-  <position name="Mesh2Tess_136" unit="mm" x="-3039.743408203125" y="800.0444946289062" z="2.0"/>
-  <position name="Mesh2Tess_137" unit="mm" x="-3038.093505859375" y="803.956298828125" z="-3.5"/>
-  <position name="Mesh2Tess_138" unit="mm" x="-3041.156982421875" y="798.7539672851562" z="-3.5"/>
-  <position name="Mesh2Tess_139" unit="mm" x="-3111.66015625" y="799.9600830078125" z="-3.5"/>
-  <position name="Mesh2Tess_140" unit="mm" x="-3039.54248046875" y="802.844482421875" z="2.0"/>
-  <position name="Mesh2Tess_141" unit="mm" x="-3111.632568359375" y="800.34228515625" z="-3.5"/>
-  <position name="Mesh2Tess_142" unit="mm" x="-3017.741943359375" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_143" unit="mm" x="-3109.900634765625" y="799.3455810546875" z="3.5"/>
-  <position name="Mesh2Tess_144" unit="mm" x="-3039.54248046875" y="800.7944946289062" z="3.5"/>
-  <position name="Mesh2Tess_145" unit="mm" x="-3040.654296875" y="799.3455810546875" z="3.5"/>
-  <position name="Mesh2Tess_146" unit="mm" x="-3111.2978515625" y="801.0247192382812" z="2.0"/>
-  <position name="Mesh2Tess_147" unit="mm" x="-3039.37451171875" y="798.94287109375" z="2.0"/>
-  <position name="Mesh2Tess_148" unit="mm" x="-3039.54248046875" y="801.2803955078125" z="-3.5"/>
-  <position name="Mesh2Tess_149" unit="mm" x="-3111.426513671875" y="799.2367553710938" z="-3.5"/>
-  <position name="Mesh2Tess_150" unit="mm" x="-3039.98193359375" y="799.7338256835938" z="2.0"/>
-  <position name="Mesh2Tess_151" unit="mm" x="-3038.243408203125" y="805.094482421875" z="-3.5"/>
-  <position name="Mesh2Tess_152" unit="mm" x="-3109.512451171875" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_153" unit="mm" x="-3110.509765625" y="798.5852661132812" z="2.0"/>
+  <position name="Mesh2Tess_0" unit="mm" x="-3116.512451171875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="-3116.512451171875" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="-3039.54248046875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="-3111.012451171875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="-2290.65478515625" y="123.9625015258789" z="-3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="-2290.65478515625" y="123.9625015258789" z="3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="-3111.012451171875" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="-3116.512451171875" y="519.7784423828125" z="-3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="-3116.512451171875" y="519.7784423828125" z="3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="-3111.012451171875" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="-3039.54248046875" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="-3017.741943359375" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="-3039.54248046875" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="-3039.54248046875" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="-3017.741943359375" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="-3111.012451171875" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_16" unit="mm" x="-2600.395263671875" y="123.9625015258789" z="-3.5" />
+  <position name="Mesh2Tess_17" unit="mm" x="-2600.395263671875" y="123.9625015258789" z="3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalTile12_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_152" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_152" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_152" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_152" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_152" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_153" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_153" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_153" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_153" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_153" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_153" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_16" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_17" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_17" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_17" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
         </tessellated>
   </solid>
 
   <solid name="OuterHCalChimneyTile09" material="PlasticScint" unit="mm" x="2118.192" y="645.632" z="0.0">
     <define>
-  <position name="Mesh2Tess_0" unit="mm" x="2221.36181640625" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_1" unit="mm" x="2220.25" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_2" unit="mm" x="2149.891845703125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_3" unit="mm" x="2222.810791015625" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_4" unit="mm" x="2222.422607421875" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_5" unit="mm" x="2221.36181640625" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_6" unit="mm" x="2219.4453125" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_7" unit="mm" x="2150.641845703125" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_8" unit="mm" x="2221.939208984375" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_9" unit="mm" x="2149.271728515625" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_10" unit="mm" x="2221.77587890625" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_11" unit="mm" x="2221.98193359375" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_12" unit="mm" x="2220.09912109375" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_13" unit="mm" x="2221.75" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_14" unit="mm" x="2219.86181640625" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_15" unit="mm" x="2222.11181640625" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_16" unit="mm" x="2149.723876953125" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_17" unit="mm" x="2222.810791015625" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_18" unit="mm" x="2222.86181640625" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_19" unit="mm" x="2221.647216796875" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_20" unit="mm" x="2149.891845703125" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_21" unit="mm" x="2149.244140625" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_22" unit="mm" x="2114.95849609375" y="477.66448974609375" z="3.5"/>
-  <position name="Mesh2Tess_23" unit="mm" x="2150.775634765625" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_24" unit="mm" x="2149.141845703125" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_25" unit="mm" x="2221.217529296875" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_26" unit="mm" x="2221.75" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_27" unit="mm" x="2148.391845703125" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_28" unit="mm" x="2221.36181640625" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_29" unit="mm" x="2148.5927734375" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_30" unit="mm" x="2222.810791015625" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_31" unit="mm" x="2221.858642578125" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_32" unit="mm" x="2222.422607421875" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_33" unit="mm" x="2149.271728515625" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_34" unit="mm" x="2221.160888671875" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_35" unit="mm" x="2220.09912109375" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_36" unit="mm" x="2151.50634765625" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_37" unit="mm" x="2149.891845703125" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_38" unit="mm" x="2220.922607421875" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_39" unit="mm" x="2221.75" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_40" unit="mm" x="2222.11181640625" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_41" unit="mm" x="2149.723876953125" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_42" unit="mm" x="2220.47802734375" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_43" unit="mm" x="2149.503662109375" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_44" unit="mm" x="2221.52978515625" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_45" unit="mm" x="2221.647216796875" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_46" unit="mm" x="2149.891845703125" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_47" unit="mm" x="2413.33154296875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_48" unit="mm" x="2150.775634765625" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_49" unit="mm" x="2148.831298828125" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_50" unit="mm" x="2151.003662109375" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_51" unit="mm" x="2150.39453125" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_52" unit="mm" x="2221.75" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_53" unit="mm" x="2151.154541015625" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_54" unit="mm" x="2220.25" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_55" unit="mm" x="2148.5927734375" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_56" unit="mm" x="2149.141845703125" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_57" unit="mm" x="2222.660888671875" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_58" unit="mm" x="2221.858642578125" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_59" unit="mm" x="2149.314453125" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_60" unit="mm" x="2151.391845703125" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_61" unit="mm" x="2151.80859375" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_62" unit="mm" x="1837.6192626953125" y="477.66448974609375" z="-3.5"/>
-  <position name="Mesh2Tess_63" unit="mm" x="2151.50634765625" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_64" unit="mm" x="2221.310791015625" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_65" unit="mm" x="2149.503662109375" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_66" unit="mm" x="2149.503662109375" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_67" unit="mm" x="2219.212890625" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_68" unit="mm" x="2221.52978515625" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_69" unit="mm" x="2149.395263671875" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_70" unit="mm" x="2222.11181640625" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_71" unit="mm" x="2149.94287109375" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_72" unit="mm" x="2150.331298828125" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_73" unit="mm" x="2221.36181640625" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_74" unit="mm" x="2148.831298828125" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_75" unit="mm" x="2219.4453125" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_76" unit="mm" x="2150.39453125" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_77" unit="mm" x="2222.009521484375" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_78" unit="mm" x="2151.154541015625" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_79" unit="mm" x="2221.939208984375" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_80" unit="mm" x="2150.0927734375" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_81" unit="mm" x="2149.141845703125" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_82" unit="mm" x="2220.61181640625" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_83" unit="mm" x="2222.660888671875" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_84" unit="mm" x="2149.314453125" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_85" unit="mm" x="2148.831298828125" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_86" unit="mm" x="2096.244384765625" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_87" unit="mm" x="2149.6064453125" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_88" unit="mm" x="2151.80859375" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_89" unit="mm" x="2148.44287109375" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_90" unit="mm" x="2149.244140625" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_91" unit="mm" x="2149.891845703125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_92" unit="mm" x="2221.160888671875" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_93" unit="mm" x="2148.5927734375" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_94" unit="mm" x="2220.859130859375" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_95" unit="mm" x="2149.891845703125" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_96" unit="mm" x="2219.212890625" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_97" unit="mm" x="2149.395263671875" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_98" unit="mm" x="2222.11181640625" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_99" unit="mm" x="2148.44287109375" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_100" unit="mm" x="2150.0361328125" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_101" unit="mm" x="2114.95849609375" y="477.66448974609375" z="-3.5"/>
-  <position name="Mesh2Tess_102" unit="mm" x="2221.36181640625" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_103" unit="mm" x="2221.36181640625" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_104" unit="mm" x="2221.36181640625" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_105" unit="mm" x="2222.009521484375" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_106" unit="mm" x="1837.6192626953125" y="477.66448974609375" z="3.5"/>
-  <position name="Mesh2Tess_107" unit="mm" x="2149.891845703125" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_108" unit="mm" x="2220.922607421875" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_109" unit="mm" x="2219.747314453125" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_110" unit="mm" x="2219.86181640625" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_111" unit="mm" x="2148.831298828125" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_112" unit="mm" x="2149.6064453125" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_113" unit="mm" x="2150.641845703125" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_114" unit="mm" x="2221.36181640625" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_115" unit="mm" x="2148.5927734375" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_116" unit="mm" x="2220.859130859375" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_117" unit="mm" x="2149.141845703125" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_118" unit="mm" x="2221.217529296875" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_119" unit="mm" x="2149.891845703125" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_120" unit="mm" x="2148.391845703125" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_121" unit="mm" x="2148.44287109375" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_122" unit="mm" x="2149.891845703125" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_123" unit="mm" x="2150.0361328125" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_124" unit="mm" x="2413.33154296875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_125" unit="mm" x="2096.244384765625" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_126" unit="mm" x="2149.47802734375" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_127" unit="mm" x="2150.331298828125" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_128" unit="mm" x="2151.391845703125" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_129" unit="mm" x="2222.660888671875" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_130" unit="mm" x="2152.041015625" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_131" unit="mm" x="2219.747314453125" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_132" unit="mm" x="2221.310791015625" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_133" unit="mm" x="2150.0927734375" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_134" unit="mm" x="2222.422607421875" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_135" unit="mm" x="2220.47802734375" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_136" unit="mm" x="2149.503662109375" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_137" unit="mm" x="2149.94287109375" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_138" unit="mm" x="2221.77587890625" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_139" unit="mm" x="2221.98193359375" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_140" unit="mm" x="2220.61181640625" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_141" unit="mm" x="2149.891845703125" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_142" unit="mm" x="2149.47802734375" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_143" unit="mm" x="2221.36181640625" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_144" unit="mm" x="2222.810791015625" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_145" unit="mm" x="2222.86181640625" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_146" unit="mm" x="2222.660888671875" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_147" unit="mm" x="2148.44287109375" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_148" unit="mm" x="2152.041015625" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_149" unit="mm" x="2221.36181640625" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_150" unit="mm" x="2222.422607421875" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_151" unit="mm" x="2151.003662109375" y="799.3455810546875" z="-2.0"/>
+  <position name="Mesh2Tess_0" unit="mm" x="2149.891845703125" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="2221.36181640625" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="2114.95849609375" y="477.66448974609375" z="3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="1837.6192626953125" y="477.66448974609375" z="-3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="1837.6192626953125" y="477.66448974609375" z="3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="2413.33154296875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="2096.244384765625" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="2096.244384765625" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="2149.891845703125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="2413.33154296875" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="2221.36181640625" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="2221.36181640625" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="2221.36181640625" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="2149.891845703125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="2114.95849609375" y="477.66448974609375" z="-3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="2149.891845703125" y="799.2944946289062" z="-3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalChimneyTile09_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
         </tessellated>
   </solid>
 
   <solid name="OuterHCalChimneyTile10" material="PlasticScint" unit="mm" x="2425.895" y="645.645" z="0.0">
-
   <define>
-  <position name="Mesh2Tess_0" unit="mm" x="2465.52392578125" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_1" unit="mm" x="2536.278076171875" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_2" unit="mm" x="2536.411865234375" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_3" unit="mm" x="2410.197021484375" y="477.6445007324219" z="3.5"/>
-  <position name="Mesh2Tess_4" unit="mm" x="2536.6591796875" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_5" unit="mm" x="2538.61083984375" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_6" unit="mm" x="2466.44189453125" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_7" unit="mm" x="2535.245361328125" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_8" unit="mm" x="2116.287353515625" y="477.6445007324219" z="3.5"/>
-  <position name="Mesh2Tess_9" unit="mm" x="2537.7392578125" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_10" unit="mm" x="2465.69189453125" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_11" unit="mm" x="2465.742919921875" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_12" unit="mm" x="2466.131103515625" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_13" unit="mm" x="2465.69189453125" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_14" unit="mm" x="2467.8408203125" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_15" unit="mm" x="2537.575927734375" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_16" unit="mm" x="2537.550048828125" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_17" unit="mm" x="2464.631103515625" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_18" unit="mm" x="2466.194580078125" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_19" unit="mm" x="2538.4609375" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_20" unit="mm" x="2537.447265625" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_21" unit="mm" x="2536.722412109375" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_22" unit="mm" x="2465.69189453125" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_23" unit="mm" x="2464.94189453125" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_24" unit="mm" x="2466.57568359375" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_25" unit="mm" x="2537.11083984375" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_26" unit="mm" x="2465.044189453125" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_27" unit="mm" x="2537.550048828125" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_28" unit="mm" x="2750.239501953125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_29" unit="mm" x="2537.161865234375" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_30" unit="mm" x="2465.892822265625" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_31" unit="mm" x="2464.392822265625" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_32" unit="mm" x="2465.52392578125" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_33" unit="mm" x="2536.278076171875" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_34" unit="mm" x="2537.161865234375" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_35" unit="mm" x="2536.9609375" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_36" unit="mm" x="2535.245361328125" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_37" unit="mm" x="2537.7392578125" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_38" unit="mm" x="2465.69189453125" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_39" unit="mm" x="2467.8408203125" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_40" unit="mm" x="2465.69189453125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_41" unit="mm" x="2538.61083984375" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_42" unit="mm" x="2537.550048828125" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_43" unit="mm" x="2464.631103515625" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_44" unit="mm" x="2538.222412109375" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_45" unit="mm" x="2466.8037109375" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_46" unit="mm" x="2537.329833984375" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_47" unit="mm" x="2536.050048828125" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_48" unit="mm" x="2537.447265625" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_49" unit="mm" x="2465.27783203125" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_50" unit="mm" x="2466.57568359375" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_51" unit="mm" x="2466.95458984375" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_52" unit="mm" x="2535.899169921875" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_53" unit="mm" x="2464.94189453125" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_54" unit="mm" x="2465.195068359375" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_55" unit="mm" x="2537.550048828125" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_56" unit="mm" x="2464.392822265625" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_57" unit="mm" x="2537.65869140625" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_58" unit="mm" x="2535.54736328125" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_59" unit="mm" x="2467.19189453125" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_60" unit="mm" x="2465.07177734375" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_61" unit="mm" x="2465.69189453125" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_62" unit="mm" x="2465.742919921875" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_63" unit="mm" x="2538.61083984375" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_64" unit="mm" x="2537.911865234375" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_65" unit="mm" x="2535.661865234375" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_66" unit="mm" x="2465.3037109375" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_67" unit="mm" x="2538.222412109375" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_68" unit="mm" x="2750.239501953125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_69" unit="mm" x="2535.012939453125" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_70" unit="mm" x="2537.329833984375" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_71" unit="mm" x="2465.27783203125" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_72" unit="mm" x="2465.114501953125" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_73" unit="mm" x="2536.411865234375" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_74" unit="mm" x="2465.406494140625" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_75" unit="mm" x="2535.899169921875" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_76" unit="mm" x="2538.222412109375" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_77" unit="mm" x="2466.131103515625" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_78" unit="mm" x="2465.195068359375" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_79" unit="mm" x="2465.69189453125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_80" unit="mm" x="2538.661865234375" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_81" unit="mm" x="2537.781982421875" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_82" unit="mm" x="2535.54736328125" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_83" unit="mm" x="2414.678466796875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_84" unit="mm" x="2465.07177734375" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_85" unit="mm" x="2116.287353515625" y="477.6445007324219" z="-3.5"/>
-  <position name="Mesh2Tess_86" unit="mm" x="2464.242919921875" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_87" unit="mm" x="2467.306396484375" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_88" unit="mm" x="2537.911865234375" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_89" unit="mm" x="2464.392822265625" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_90" unit="mm" x="2465.3037109375" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_91" unit="mm" x="2535.012939453125" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_92" unit="mm" x="2538.4609375" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_93" unit="mm" x="2465.114501953125" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_94" unit="mm" x="2464.242919921875" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_95" unit="mm" x="2537.161865234375" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_96" unit="mm" x="2465.3037109375" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_97" unit="mm" x="2537.161865234375" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_98" unit="mm" x="2465.406494140625" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_99" unit="mm" x="2538.222412109375" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_100" unit="mm" x="2538.661865234375" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_101" unit="mm" x="2466.8037109375" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_102" unit="mm" x="2537.781982421875" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_103" unit="mm" x="2467.19189453125" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_104" unit="mm" x="2464.242919921875" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_105" unit="mm" x="2537.8095703125" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_106" unit="mm" x="2466.95458984375" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_107" unit="mm" x="2466.44189453125" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_108" unit="mm" x="2537.161865234375" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_109" unit="mm" x="2464.392822265625" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_110" unit="mm" x="2464.94189453125" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_111" unit="mm" x="2465.69189453125" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_112" unit="mm" x="2537.911865234375" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_113" unit="mm" x="2535.661865234375" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_114" unit="mm" x="2464.19189453125" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_115" unit="mm" x="2537.017578125" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_116" unit="mm" x="2538.4609375" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_117" unit="mm" x="2464.242919921875" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_118" unit="mm" x="2465.892822265625" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_119" unit="mm" x="2465.3037109375" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_120" unit="mm" x="2414.678466796875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_121" unit="mm" x="2536.9609375" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_122" unit="mm" x="2410.197021484375" y="477.6445007324219" z="-3.5"/>
-  <position name="Mesh2Tess_123" unit="mm" x="2536.722412109375" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_124" unit="mm" x="2537.11083984375" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_125" unit="mm" x="2467.6083984375" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_126" unit="mm" x="2537.161865234375" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_127" unit="mm" x="2465.836181640625" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_128" unit="mm" x="2464.631103515625" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_129" unit="mm" x="2537.8095703125" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_130" unit="mm" x="2536.6591796875" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_131" unit="mm" x="2538.61083984375" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_132" unit="mm" x="2465.69189453125" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_133" unit="mm" x="2537.017578125" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_134" unit="mm" x="2537.911865234375" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_135" unit="mm" x="2464.19189453125" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_136" unit="mm" x="2537.575927734375" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_137" unit="mm" x="2537.65869140625" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_138" unit="mm" x="2466.194580078125" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_139" unit="mm" x="2538.4609375" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_140" unit="mm" x="2537.161865234375" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_141" unit="mm" x="2536.050048828125" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_142" unit="mm" x="2465.69189453125" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_143" unit="mm" x="2464.94189453125" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_144" unit="mm" x="2537.161865234375" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_145" unit="mm" x="2467.306396484375" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_146" unit="mm" x="2467.6083984375" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_147" unit="mm" x="2537.161865234375" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_148" unit="mm" x="2465.044189453125" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_149" unit="mm" x="2465.836181640625" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_150" unit="mm" x="2537.161865234375" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_151" unit="mm" x="2464.631103515625" y="803.2838134765625" z="-2.0"/>
+  <position name="Mesh2Tess_0" unit="mm" x="2414.678466796875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="2414.678466796875" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="2537.161865234375" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="2537.161865234375" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="2116.287353515625" y="477.6445007324219" z="-3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="2410.197021484375" y="477.6445007324219" z="3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="2750.239501953125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="2537.161865234375" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="2465.69189453125" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="2465.69189453125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="2410.197021484375" y="477.6445007324219" z="-3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="2750.239501953125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="2465.69189453125" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="2116.287353515625" y="477.6445007324219" z="3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="2537.161865234375" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="2465.69189453125" y="799.2944946289062" z="3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalChimneyTile10_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_58" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_122" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_15" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
         </tessellated>
   </solid>
 
   <solid name="OuterHCalChimneyTile11" material="PlasticScint" unit="mm" x="2711.635" y="642.964" z="0.0">
     <define>
-  <position name="Mesh2Tess_0" unit="mm" x="2845.780517578125" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_1" unit="mm" x="2845.9248046875" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_2" unit="mm" x="2772.954833984375" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_3" unit="mm" x="2846.210205078125" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_4" unit="mm" x="2774.89404296875" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_5" unit="mm" x="2845.1748046875" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_6" unit="mm" x="2773.704833984375" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_7" unit="mm" x="2775.338623046875" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_8" unit="mm" x="2845.9248046875" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_9" unit="mm" x="2774.286865234375" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_10" unit="mm" x="2846.31298828125" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_11" unit="mm" x="2845.041015625" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_12" unit="mm" x="2847.223876953125" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_13" unit="mm" x="2845.873779296875" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_14" unit="mm" x="2774.65576171875" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_15" unit="mm" x="2845.485595703125" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_16" unit="mm" x="2773.834716796875" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_17" unit="mm" x="2774.066650390625" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_18" unit="mm" x="2411.63134765625" y="477.6445007324219" z="-3.5"/>
-  <position name="Mesh2Tess_19" unit="mm" x="2844.00830078125" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_20" unit="mm" x="2664.947509765625" y="477.6445007324219" z="3.5"/>
-  <position name="Mesh2Tess_21" unit="mm" x="2846.502197265625" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_22" unit="mm" x="2846.985595703125" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_23" unit="mm" x="2776.0693359375" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_24" unit="mm" x="2776.371337890625" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_25" unit="mm" x="3016.282958984375" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_26" unit="mm" x="2773.39404296875" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_27" unit="mm" x="2773.15576171875" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_28" unit="mm" x="2845.780517578125" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_29" unit="mm" x="2774.59912109375" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_30" unit="mm" x="2845.9248046875" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_31" unit="mm" x="2772.954833984375" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_32" unit="mm" x="2846.985595703125" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_33" unit="mm" x="2846.210205078125" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_34" unit="mm" x="2751.673828125" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_35" unit="mm" x="2775.338623046875" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_36" unit="mm" x="2774.95751953125" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_37" unit="mm" x="2846.31298828125" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_38" unit="mm" x="2845.422119140625" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_39" unit="mm" x="2847.373779296875" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_40" unit="mm" x="2844.662109375" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_41" unit="mm" x="2845.9248046875" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_42" unit="mm" x="2844.81298828125" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_43" unit="mm" x="2774.286865234375" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_44" unit="mm" x="2846.31298828125" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_45" unit="mm" x="2845.041015625" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_46" unit="mm" x="2845.723876953125" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_47" unit="mm" x="2773.15576171875" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_48" unit="mm" x="2847.223876953125" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_49" unit="mm" x="2773.80712890625" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_50" unit="mm" x="2845.9248046875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_51" unit="mm" x="2845.9248046875" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_52" unit="mm" x="2774.454833984375" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_53" unit="mm" x="2776.0693359375" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_54" unit="mm" x="2776.371337890625" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_55" unit="mm" x="2846.6748046875" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_56" unit="mm" x="2774.59912109375" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_57" unit="mm" x="2846.985595703125" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_58" unit="mm" x="2411.63134765625" y="477.6445007324219" z="3.5"/>
-  <position name="Mesh2Tess_59" unit="mm" x="2846.31298828125" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_60" unit="mm" x="2774.95751953125" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_61" unit="mm" x="2845.1748046875" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_62" unit="mm" x="2847.373779296875" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_63" unit="mm" x="2844.662109375" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_64" unit="mm" x="2774.454833984375" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_65" unit="mm" x="2846.421630859375" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_66" unit="mm" x="2774.505859375" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_67" unit="mm" x="2774.454833984375" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_68" unit="mm" x="2846.0927734375" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_69" unit="mm" x="2847.223876953125" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_70" unit="mm" x="2845.873779296875" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_71" unit="mm" x="2775.717529296875" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_72" unit="mm" x="2773.80712890625" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_73" unit="mm" x="2846.544921875" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_74" unit="mm" x="2773.704833984375" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_75" unit="mm" x="2845.9248046875" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_76" unit="mm" x="2774.454833984375" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_77" unit="mm" x="2773.005859375" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_78" unit="mm" x="2846.6748046875" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_79" unit="mm" x="2773.005859375" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_80" unit="mm" x="2773.39404296875" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_81" unit="mm" x="2775.954833984375" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_82" unit="mm" x="2845.9248046875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_83" unit="mm" x="2774.454833984375" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_84" unit="mm" x="2846.421630859375" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_85" unit="mm" x="2844.81298828125" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_86" unit="mm" x="2846.0927734375" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_87" unit="mm" x="2774.454833984375" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_88" unit="mm" x="2847.373779296875" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_89" unit="mm" x="2775.717529296875" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_90" unit="mm" x="2775.566650390625" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_91" unit="mm" x="2773.15576171875" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_92" unit="mm" x="2773.9580078125" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_93" unit="mm" x="2773.704833984375" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_94" unit="mm" x="2846.544921875" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_95" unit="mm" x="2774.040771484375" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_96" unit="mm" x="2664.947509765625" y="477.6445007324219" z="-3.5"/>
-  <position name="Mesh2Tess_97" unit="mm" x="2844.4248046875" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_98" unit="mm" x="2773.005859375" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_99" unit="mm" x="2846.572509765625" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_100" unit="mm" x="2774.89404296875" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_101" unit="mm" x="2773.005859375" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_102" unit="mm" x="2775.204833984375" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_103" unit="mm" x="2845.422119140625" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_104" unit="mm" x="2846.6748046875" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_105" unit="mm" x="2776.603759765625" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_106" unit="mm" x="2751.673828125" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_107" unit="mm" x="2843.77587890625" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_108" unit="mm" x="2846.985595703125" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_109" unit="mm" x="2774.505859375" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_110" unit="mm" x="2774.454833984375" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_111" unit="mm" x="2847.373779296875" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_112" unit="mm" x="2773.87744140625" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_113" unit="mm" x="2774.066650390625" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_114" unit="mm" x="2773.9580078125" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_115" unit="mm" x="2774.040771484375" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_116" unit="mm" x="2774.65576171875" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_117" unit="mm" x="2845.485595703125" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_118" unit="mm" x="2774.454833984375" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_119" unit="mm" x="2846.572509765625" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_120" unit="mm" x="2844.310302734375" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_121" unit="mm" x="2774.16943359375" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_122" unit="mm" x="2846.6748046875" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_123" unit="mm" x="2774.454833984375" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_124" unit="mm" x="2847.4248046875" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_125" unit="mm" x="2776.603759765625" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_126" unit="mm" x="2846.3388671875" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_127" unit="mm" x="2773.15576171875" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_128" unit="mm" x="2845.723876953125" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_129" unit="mm" x="2843.77587890625" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_130" unit="mm" x="2773.704833984375" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_131" unit="mm" x="2773.87744140625" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_132" unit="mm" x="2845.9248046875" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_133" unit="mm" x="3016.282958984375" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_134" unit="mm" x="2845.9248046875" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_135" unit="mm" x="2774.066650390625" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_136" unit="mm" x="2775.566650390625" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_137" unit="mm" x="2847.223876953125" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_138" unit="mm" x="2774.454833984375" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_139" unit="mm" x="2775.954833984375" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_140" unit="mm" x="2844.4248046875" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_141" unit="mm" x="2773.39404296875" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_142" unit="mm" x="2774.066650390625" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_143" unit="mm" x="2773.834716796875" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_144" unit="mm" x="2844.310302734375" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_145" unit="mm" x="2774.16943359375" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_146" unit="mm" x="2844.00830078125" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_147" unit="mm" x="2775.204833984375" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_148" unit="mm" x="2846.502197265625" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_149" unit="mm" x="2847.4248046875" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_150" unit="mm" x="2846.3388671875" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_151" unit="mm" x="2773.39404296875" y="805.4051513671875" z="3.5"/>
+  <position name="Mesh2Tess_0" unit="mm" x="2845.9248046875" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="2774.454833984375" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="2774.454833984375" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="2774.454833984375" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="2845.9248046875" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="3016.282958984375" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="3016.282958984375" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="2845.9248046875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="2845.9248046875" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="2664.947509765625" y="477.6445007324219" z="-3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="2411.63134765625" y="477.6445007324219" z="-3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="2411.63134765625" y="477.6445007324219" z="3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="2774.454833984375" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="2664.947509765625" y="477.6445007324219" z="3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="2751.673828125" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="2751.673828125" y="808.344482421875" z="3.5" />
     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalChimneyTile11_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_90" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_61" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_105" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_4" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_72" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_116" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_35" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_66" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_89" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_54" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_91" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_75" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_62" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_78" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_150" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_97" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_28" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_147" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_85" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_70" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_25" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_29" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_143" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_24" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_132" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_37" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_82" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_38" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_123" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_4" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
          </tessellated>
   </solid>
 
   <solid name="OuterHCalChimneyTile12" material="PlasticScint" unit="mm" x="2957.924" y="607.790" z="0.0">
     <define>
-  <position name="Mesh2Tess_0" unit="mm" x="3039.54248046875" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_1" unit="mm" x="3039.128662109375" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_2" unit="mm" x="3112.512451171875" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_3" unit="mm" x="3112.3115234375" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_4" unit="mm" x="3111.762451171875" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_5" unit="mm" x="3038.79248046875" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_6" unit="mm" x="3039.0458984375" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_7" unit="mm" x="3017.741943359375" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_8" unit="mm" x="3109.900634765625" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_9" unit="mm" x="3039.37451171875" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_10" unit="mm" x="3110.128662109375" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_11" unit="mm" x="3039.54248046875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_12" unit="mm" x="3111.012451171875" y="801.2803955078125" z="-2.0"/>
-  <position name="Mesh2Tess_13" unit="mm" x="3112.46142578125" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_14" unit="mm" x="3111.012451171875" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_15" unit="mm" x="3038.093505859375" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_16" unit="mm" x="3110.96142578125" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_17" unit="mm" x="3109.512451171875" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_18" unit="mm" x="3112.512451171875" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_19" unit="mm" x="3112.0732421875" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_20" unit="mm" x="3038.79248046875" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_21" unit="mm" x="3110.262451171875" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_22" unit="mm" x="3040.654296875" y="799.3455810546875" z="-2.0"/>
-  <position name="Mesh2Tess_23" unit="mm" x="3040.29248046875" y="799.4954833984375" z="-2.0"/>
-  <position name="Mesh2Tess_24" unit="mm" x="3111.012451171875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_25" unit="mm" x="3039.54248046875" y="800.7944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_26" unit="mm" x="3110.8681640625" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_27" unit="mm" x="3038.894775390625" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_28" unit="mm" x="3116.512451171875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_29" unit="mm" x="3108.863525390625" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_30" unit="mm" x="3041.691650390625" y="799.2944946289062" z="3.5"/>
-  <position name="Mesh2Tess_31" unit="mm" x="3038.243408203125" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_32" unit="mm" x="3112.46142578125" y="803.956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_33" unit="mm" x="3111.762451171875" y="803.0454711914062" z="3.5"/>
-  <position name="Mesh2Tess_34" unit="mm" x="3039.98193359375" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_35" unit="mm" x="2666.427734375" y="477.66448974609375" z="3.5"/>
-  <position name="Mesh2Tess_36" unit="mm" x="3112.46142578125" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_37" unit="mm" x="3110.5732421875" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_38" unit="mm" x="3039.743408203125" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_39" unit="mm" x="3109.39794921875" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_40" unit="mm" x="3110.8115234375" y="800.0444946289062" z="-2.0"/>
-  <position name="Mesh2Tess_41" unit="mm" x="3039.686767578125" y="798.7208862304688" z="3.5"/>
-  <position name="Mesh2Tess_42" unit="mm" x="3039.257080078125" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_43" unit="mm" x="3112.0732421875" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_44" unit="mm" x="3038.92236328125" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_45" unit="mm" x="3111.66015625" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_46" unit="mm" x="3038.48193359375" y="803.2838134765625" z="3.5"/>
-  <position name="Mesh2Tess_47" unit="mm" x="3110.8681640625" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_48" unit="mm" x="3116.512451171875" y="519.7784423828125" z="3.5"/>
-  <position name="Mesh2Tess_49" unit="mm" x="3038.79248046875" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_50" unit="mm" x="3111.2978515625" y="801.0247192382812" z="3.5"/>
-  <position name="Mesh2Tess_51" unit="mm" x="3112.0732421875" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_52" unit="mm" x="3111.426513671875" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_53" unit="mm" x="3041.691650390625" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_54" unit="mm" x="3038.243408203125" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_55" unit="mm" x="3112.3115234375" y="805.094482421875" z="3.5"/>
-  <position name="Mesh2Tess_56" unit="mm" x="3061.598876953125" y="477.66448974609375" z="3.5"/>
-  <position name="Mesh2Tess_57" unit="mm" x="3040.80517578125" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_58" unit="mm" x="3041.04248046875" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_59" unit="mm" x="3111.012451171875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_60" unit="mm" x="3112.46142578125" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_61" unit="mm" x="3039.54248046875" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_62" unit="mm" x="3109.512451171875" y="799.2944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_63" unit="mm" x="3039.154296875" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_64" unit="mm" x="3109.39794921875" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_65" unit="mm" x="3039.686767578125" y="798.7208862304688" z="-2.0"/>
-  <position name="Mesh2Tess_66" unit="mm" x="3039.257080078125" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_67" unit="mm" x="3111.012451171875" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_68" unit="mm" x="3109.095947265625" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_69" unit="mm" x="3039.593505859375" y="800.40625" z="-3.5"/>
-  <position name="Mesh2Tess_70" unit="mm" x="3110.262451171875" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_71" unit="mm" x="3038.92236328125" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_72" unit="mm" x="3040.654296875" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_73" unit="mm" x="3038.48193359375" y="803.2838134765625" z="-2.0"/>
-  <position name="Mesh2Tess_74" unit="mm" x="3110.96142578125" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_75" unit="mm" x="3112.0732421875" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_76" unit="mm" x="3111.400634765625" y="805.7933959960938" z="3.5"/>
-  <position name="Mesh2Tess_77" unit="mm" x="3112.3115234375" y="805.094482421875" z="-2.0"/>
-  <position name="Mesh2Tess_78" unit="mm" x="3039.128662109375" y="799.2367553710938" z="3.5"/>
-  <position name="Mesh2Tess_79" unit="mm" x="3040.80517578125" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_80" unit="mm" x="3038.48193359375" y="805.4051513671875" z="3.5"/>
-  <position name="Mesh2Tess_81" unit="mm" x="3039.98193359375" y="799.7338256835938" z="-3.5"/>
-  <position name="Mesh2Tess_82" unit="mm" x="3038.093505859375" y="804.7327270507812" z="3.5"/>
-  <position name="Mesh2Tess_83" unit="mm" x="3039.154296875" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_84" unit="mm" x="3039.54248046875" y="808.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_85" unit="mm" x="3038.243408203125" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_86" unit="mm" x="3039.54248046875" y="802.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_87" unit="mm" x="3110.509765625" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_88" unit="mm" x="3039.743408203125" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_89" unit="mm" x="3039.154296875" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_90" unit="mm" x="3109.900634765625" y="799.3455810546875" z="-3.5"/>
-  <position name="Mesh2Tess_91" unit="mm" x="3039.54248046875" y="805.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_92" unit="mm" x="3110.8115234375" y="800.0444946289062" z="-3.5"/>
-  <position name="Mesh2Tess_93" unit="mm" x="3109.095947265625" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_94" unit="mm" x="3111.632568359375" y="800.34228515625" z="3.5"/>
-  <position name="Mesh2Tess_95" unit="mm" x="3108.863525390625" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_96" unit="mm" x="3040.42626953125" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_97" unit="mm" x="3038.965087890625" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_98" unit="mm" x="3111.50927734375" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_99" unit="mm" x="3041.156982421875" y="798.7539672851562" z="3.5"/>
-  <position name="Mesh2Tess_100" unit="mm" x="3111.762451171875" y="803.0454711914062" z="-2.0"/>
-  <position name="Mesh2Tess_101" unit="mm" x="3111.400634765625" y="802.8956298828125" z="3.5"/>
-  <position name="Mesh2Tess_102" unit="mm" x="3111.012451171875" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_103" unit="mm" x="3110.5732421875" y="799.7338256835938" z="-2.0"/>
-  <position name="Mesh2Tess_104" unit="mm" x="3111.400634765625" y="805.7933959960938" z="-2.0"/>
-  <position name="Mesh2Tess_105" unit="mm" x="3116.512451171875" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_106" unit="mm" x="3041.459228515625" y="798.9898071289062" z="3.5"/>
-  <position name="Mesh2Tess_107" unit="mm" x="3038.48193359375" y="805.4051513671875" z="-2.0"/>
-  <position name="Mesh2Tess_108" unit="mm" x="3111.180419921875" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_109" unit="mm" x="3109.749755859375" y="798.6023559570312" z="3.5"/>
-  <position name="Mesh2Tess_110" unit="mm" x="3038.093505859375" y="804.7327270507812" z="-2.0"/>
-  <position name="Mesh2Tess_111" unit="mm" x="3039.154296875" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_112" unit="mm" x="2666.427734375" y="477.66448974609375" z="-3.5"/>
-  <position name="Mesh2Tess_113" unit="mm" x="3111.66015625" y="799.9600830078125" z="-2.0"/>
-  <position name="Mesh2Tess_114" unit="mm" x="3038.243408203125" y="803.594482421875" z="-2.0"/>
-  <position name="Mesh2Tess_115" unit="mm" x="3110.509765625" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_116" unit="mm" x="3040.29248046875" y="799.4954833984375" z="-3.5"/>
-  <position name="Mesh2Tess_117" unit="mm" x="3040.045166015625" y="798.5852661132812" z="3.5"/>
-  <position name="Mesh2Tess_118" unit="mm" x="3017.741943359375" y="808.344482421875" z="-3.5"/>
-  <position name="Mesh2Tess_119" unit="mm" x="3038.79248046875" y="805.6435546875" z="-2.0"/>
-  <position name="Mesh2Tess_120" unit="mm" x="3039.54248046875" y="800.7944946289062" z="-3.5"/>
-  <position name="Mesh2Tess_121" unit="mm" x="3039.54248046875" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_122" unit="mm" x="3111.2978515625" y="801.0247192382812" z="-2.0"/>
-  <position name="Mesh2Tess_123" unit="mm" x="3038.04248046875" y="804.344482421875" z="3.5"/>
-  <position name="Mesh2Tess_124" unit="mm" x="3038.894775390625" y="799.9600830078125" z="3.5"/>
-  <position name="Mesh2Tess_125" unit="mm" x="3111.58984375" y="799.5833740234375" z="3.5"/>
-  <position name="Mesh2Tess_126" unit="mm" x="3111.012451171875" y="802.844482421875" z="3.5"/>
-  <position name="Mesh2Tess_127" unit="mm" x="3111.632568359375" y="800.34228515625" z="-2.0"/>
-  <position name="Mesh2Tess_128" unit="mm" x="3111.426513671875" y="799.2367553710938" z="-2.0"/>
-  <position name="Mesh2Tess_129" unit="mm" x="3038.965087890625" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_130" unit="mm" x="3040.42626953125" y="798.5448608398438" z="-2.0"/>
-  <position name="Mesh2Tess_131" unit="mm" x="3111.50927734375" y="800.705078125" z="-2.0"/>
-  <position name="Mesh2Tess_132" unit="mm" x="3039.54248046875" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_133" unit="mm" x="3041.156982421875" y="798.7539672851562" z="-2.0"/>
-  <position name="Mesh2Tess_134" unit="mm" x="3111.400634765625" y="802.8956298828125" z="-2.0"/>
-  <position name="Mesh2Tess_135" unit="mm" x="3041.04248046875" y="799.2944946289062" z="-2.0"/>
-  <position name="Mesh2Tess_136" unit="mm" x="3116.512451171875" y="519.7784423828125" z="-3.5"/>
-  <position name="Mesh2Tess_137" unit="mm" x="3112.3115234375" y="803.594482421875" z="3.5"/>
-  <position name="Mesh2Tess_138" unit="mm" x="3111.762451171875" y="805.6435546875" z="3.5"/>
-  <position name="Mesh2Tess_139" unit="mm" x="3039.0458984375" y="800.705078125" z="3.5"/>
-  <position name="Mesh2Tess_140" unit="mm" x="3041.459228515625" y="798.9898071289062" z="-2.0"/>
-  <position name="Mesh2Tess_141" unit="mm" x="3039.37451171875" y="798.94287109375" z="3.5"/>
-  <position name="Mesh2Tess_142" unit="mm" x="3110.128662109375" y="798.5448608398438" z="3.5"/>
-  <position name="Mesh2Tess_143" unit="mm" x="3061.598876953125" y="477.66448974609375" z="-3.5"/>
-  <position name="Mesh2Tess_144" unit="mm" x="3111.180419921875" y="798.94287109375" z="-2.0"/>
-  <position name="Mesh2Tess_145" unit="mm" x="3111.012451171875" y="805.844482421875" z="-2.0"/>
-  <position name="Mesh2Tess_146" unit="mm" x="3109.749755859375" y="798.6023559570312" z="-2.0"/>
-  <position name="Mesh2Tess_147" unit="mm" x="3039.593505859375" y="800.40625" z="-2.0"/>
-  <position name="Mesh2Tess_148" unit="mm" x="3111.012451171875" y="801.2803955078125" z="3.5"/>
-  <position name="Mesh2Tess_149" unit="mm" x="3040.045166015625" y="798.5852661132812" z="-2.0"/>
-  <position name="Mesh2Tess_150" unit="mm" x="3038.093505859375" y="803.956298828125" z="3.5"/>
-  <position name="Mesh2Tess_151" unit="mm" x="3111.58984375" y="799.5833740234375" z="-2.0"/>
-  <position name="Mesh2Tess_152" unit="mm" x="3038.04248046875" y="804.344482421875" z="-2.0"/>
-  <position name="Mesh2Tess_153" unit="mm" x="3111.012451171875" y="802.844482421875" z="-2.0"/>
-    </define>
+  <position name="Mesh2Tess_0" unit="mm" x="3039.54248046875" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_1" unit="mm" x="3039.54248046875" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_2" unit="mm" x="3116.512451171875" y="519.7784423828125" z="3.5" />
+  <position name="Mesh2Tess_3" unit="mm" x="3116.512451171875" y="519.7784423828125" z="-3.5" />
+  <position name="Mesh2Tess_4" unit="mm" x="3116.512451171875" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_5" unit="mm" x="3111.012451171875" y="799.2944946289062" z="-3.5" />
+  <position name="Mesh2Tess_6" unit="mm" x="3111.012451171875" y="799.2944946289062" z="3.5" />
+  <position name="Mesh2Tess_7" unit="mm" x="3017.741943359375" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_8" unit="mm" x="3111.012451171875" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_9" unit="mm" x="3111.012451171875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_10" unit="mm" x="3061.598876953125" y="477.66448974609375" z="-3.5" />
+  <position name="Mesh2Tess_11" unit="mm" x="2666.427734375" y="477.66448974609375" z="-3.5" />
+  <position name="Mesh2Tess_12" unit="mm" x="3116.512451171875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_13" unit="mm" x="3039.54248046875" y="808.344482421875" z="-3.5" />
+  <position name="Mesh2Tess_14" unit="mm" x="3061.598876953125" y="477.66448974609375" z="3.5" />
+  <position name="Mesh2Tess_15" unit="mm" x="2666.427734375" y="477.66448974609375" z="3.5" />
+  <position name="Mesh2Tess_16" unit="mm" x="3017.741943359375" y="808.344482421875" z="3.5" />
+  <position name="Mesh2Tess_17" unit="mm" x="3039.54248046875" y="808.344482421875" z="3.5" />
+     </define>
 
         <tessellated aunit="deg" lunit="mm" name="OuterHCalChimneyTile12_EJ200-SOL">
-      <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_22" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_81" vertex3="Mesh2Tess_23" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_88" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_69" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_53" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_135" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_95" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_95" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_53" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_74" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_103" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_21" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_8" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_17" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_59" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_153" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_126" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_153" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_153" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_12" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_102" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_30" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_30" vertex2="Mesh2Tess_140" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_106" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_99" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_133" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_133" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_79" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_130" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_96" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_149" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_117" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_65" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_41" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_141" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_129" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_44" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_27" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_71" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_139" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_42" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_66" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_9" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_34" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_9" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_149" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_65" vertex3="Mesh2Tess_149" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_23" vertex2="Mesh2Tess_34" vertex3="Mesh2Tess_65" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_129" vertex3="Mesh2Tess_1" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_129" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_38" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_34" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_130" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_22" vertex2="Mesh2Tess_23" vertex3="Mesh2Tess_130" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_71" vertex3="Mesh2Tess_27" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_71" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_147" vertex2="Mesh2Tess_27" vertex3="Mesh2Tess_38" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_6" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_147" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_79" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_135" vertex2="Mesh2Tess_22" vertex3="Mesh2Tess_79" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_140" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_133" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_66" vertex3="Mesh2Tess_25" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_53" vertex2="Mesh2Tess_135" vertex3="Mesh2Tess_140" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_111" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_111" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_83" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_20" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_5" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_73" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_114" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_152" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_152" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_110" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_54" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_80" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_49" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_63" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_119" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_89" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_86" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_111" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_107" vertex2="Mesh2Tess_54" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_73" vertex3="Mesh2Tess_20" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_114" vertex3="Mesh2Tess_73" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_114" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_152" vertex3="Mesh2Tess_15" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_110" vertex3="Mesh2Tess_152" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_119" vertex3="Mesh2Tess_107" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_89" vertex3="Mesh2Tess_119" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_107" vertex3="Mesh2Tess_110" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_20" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_145" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_67" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_67" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_76" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_104" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_138" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_75" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_51" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_77" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_55" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_36" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_77" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_60" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_32" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_13" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_32" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_43" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_33" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_43" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_19" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_100" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_101" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_134" vertex2="Mesh2Tess_153" vertex3="Mesh2Tess_126" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_43" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_18" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_32" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_104" vertex3="Mesh2Tess_145" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_104" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_60" vertex3="Mesh2Tess_77" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_18" vertex3="Mesh2Tess_60" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_134" vertex3="Mesh2Tess_100" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_153" vertex3="Mesh2Tess_134" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_145" vertex3="Mesh2Tess_153" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_100" vertex3="Mesh2Tess_3" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_75" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_18" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_12" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_148" vertex2="Mesh2Tess_122" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_50" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_131" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_98" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_127" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_94" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_113" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_45" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_125" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_151" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_128" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_144" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_144" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_108" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_87" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_47" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_26" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_115" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_142" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_39" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_146" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_109" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_64" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_29" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_93" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_64" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_93" vertex3="Mesh2Tess_64" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_95" vertex3="Mesh2Tess_93" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_146" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_146" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_115" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_10" vertex3="Mesh2Tess_115" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_21" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_10" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_47" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_103" vertex2="Mesh2Tess_21" vertex3="Mesh2Tess_47" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_128" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_144" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_40" vertex2="Mesh2Tess_103" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_151" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_128" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_40" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_113" vertex2="Mesh2Tess_40" vertex3="Mesh2Tess_151" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_127" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_113" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_74" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_131" vertex2="Mesh2Tess_74" vertex3="Mesh2Tess_127" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_14" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_122" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_131" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_25" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_132" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_61" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_86" vertex3="Mesh2Tess_0" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_91" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_121" vertex3="Mesh2Tess_86" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_121" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_84" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_120" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_121" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_112" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_88" vertex3="Mesh2Tess_81" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_81" vertex2="Mesh2Tess_116" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_143" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_116" vertex2="Mesh2Tess_72" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_69" vertex3="Mesh2Tess_88" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_120" vertex3="Mesh2Tess_69" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_72" vertex2="Mesh2Tess_58" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_118" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_120" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_58" vertex2="Mesh2Tess_62" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_62" vertex2="Mesh2Tess_90" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_90" vertex2="Mesh2Tess_70" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_70" vertex2="Mesh2Tess_37" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_37" vertex2="Mesh2Tess_92" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_24" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_102" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_102" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_16" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_92" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_92" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_28" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_105" vertex3="Mesh2Tess_24" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_78" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_141" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_41" vertex2="Mesh2Tess_141" vertex3="Mesh2Tess_7" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_97" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_78" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_117" vertex2="Mesh2Tess_41" vertex3="Mesh2Tess_56" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_124" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_97" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_96" vertex2="Mesh2Tess_117" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_57" vertex2="Mesh2Tess_96" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_46" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_46" vertex3="Mesh2Tess_139" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_139" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_44" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_85" vertex2="Mesh2Tess_44" vertex3="Mesh2Tess_46" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_42" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_83" vertex2="Mesh2Tess_42" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_124" vertex3="Mesh2Tess_85" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_150" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_124" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_61" vertex2="Mesh2Tess_83" vertex3="Mesh2Tess_132" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_123" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_150" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_82" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_123" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_31" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_82" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_31" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_31" vertex3="Mesh2Tess_80" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_80" vertex3="Mesh2Tess_49" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_49" vertex3="Mesh2Tess_63" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_84" vertex2="Mesh2Tess_63" vertex3="Mesh2Tess_91" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_68" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_106" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_39" vertex2="Mesh2Tess_68" vertex3="Mesh2Tess_106" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_29" vertex2="Mesh2Tess_30" vertex3="Mesh2Tess_68" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_99" vertex3="Mesh2Tess_57" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_39" vertex3="Mesh2Tess_99" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_109" vertex2="Mesh2Tess_57" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_142" vertex2="Mesh2Tess_109" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_87" vertex2="Mesh2Tess_142" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_26" vertex2="Mesh2Tess_87" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_108" vertex2="Mesh2Tess_26" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_52" vertex2="Mesh2Tess_108" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_126" vertex3="Mesh2Tess_148" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_101" vertex2="Mesh2Tess_148" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_50" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_33" vertex2="Mesh2Tess_101" vertex3="Mesh2Tess_50" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_98" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_19" vertex2="Mesh2Tess_33" vertex3="Mesh2Tess_98" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_94" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_137" vertex2="Mesh2Tess_19" vertex3="Mesh2Tess_94" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_67" vertex3="Mesh2Tess_76" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_76" vertex3="Mesh2Tess_138" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_59" vertex2="Mesh2Tess_138" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_52" vertex3="Mesh2Tess_48" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_51" vertex3="Mesh2Tess_55" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_55" vertex3="Mesh2Tess_36" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_36" vertex3="Mesh2Tess_2" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_13" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_137" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_45" vertex3="Mesh2Tess_125" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_125" vertex3="Mesh2Tess_52" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_59" vertex3="Mesh2Tess_51" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_137" vertex3="Mesh2Tess_45" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_112" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_56" vertex2="Mesh2Tess_35" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_118" vertex3="Mesh2Tess_112" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_35" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_84" vertex3="Mesh2Tess_11" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_118" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_136" vertex3="Mesh2Tess_105" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_28" vertex2="Mesh2Tess_48" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_136" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_143" type="ABSOLUTE"/>
-    <triangular vertex1="Mesh2Tess_48" vertex2="Mesh2Tess_56" vertex3="Mesh2Tess_136" type="ABSOLUTE"/>
+      <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_14" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_17" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_6" vertex2="Mesh2Tess_1" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_8" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_6" vertex3="Mesh2Tess_2" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_1" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_1" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_17" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_11" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_10" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_0" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_7" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_0" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_0" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_5" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_5" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_9" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_8" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_5" vertex3="Mesh2Tess_6" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_3" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_4" vertex2="Mesh2Tess_2" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_3" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_2" vertex2="Mesh2Tess_14" vertex3="Mesh2Tess_3" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_11" vertex3="Mesh2Tess_10" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_14" vertex2="Mesh2Tess_15" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_7" vertex3="Mesh2Tess_11" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_15" vertex2="Mesh2Tess_16" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_17" vertex3="Mesh2Tess_13" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_16" vertex2="Mesh2Tess_13" vertex3="Mesh2Tess_7" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_4" vertex3="Mesh2Tess_12" type="ABSOLUTE" />
+    <triangular vertex1="Mesh2Tess_8" vertex2="Mesh2Tess_12" vertex3="Mesh2Tess_9" type="ABSOLUTE" />
         </tessellated>
   </solid>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Simplified description of tile solid shapes for outer HCAL

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other: Optization

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No breaking changes found/expected

### Does this PR change default behavior?
The tile shapes have been reduced to about 10% of their original complexity.  Most of the complexity in terms of the facets describing the tiles was associated with small mounting holes in the tiles SiPM mount/light blocker. This is unnecessary for the description of the tiles in simulations and adds much more complexity, which increases the time required for G4 to decide where it is in a solid.  This should result in a reduced time in traversing the oHCAL geometry and simplify things like the overlap checks. 

Unfortunately, this does not affect at all the spurious overlap errors reported in G4 between disparate objects that are clearly not overlapping and nowhere near to each other.  In addition, the TGeo overlap checks also still fail with tons of bizzare messages. It was hoped that the simplified geometry would address this, but that does not seem to be the case, although the simplified geometry should make the debugging easier.  This would seem to indicate that the issue does not lie with the description of the solids themselves but with the internal handling in dd4hep/TGeo/G4.  

<img width="1620" alt="Holes" src="https://user-images.githubusercontent.com/3042746/199016505-cb442055-aefc-4474-8141-ae722c2b77c6.png">

