### PR TITLE
hotfix: synchronize IP6 ID numbers again

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -284,19 +284,17 @@ The unused IDs below are saved for future use.
     <documentation>
       #### (190-199) Far Backward Beamline Detectors
 
-      - Low-Q2 Tagger 1 Tracker      ID: 195
-      - Low-Q2 Tagger 1 Calorimeter  ID: 196
-      - Low-Q2 Tagger 2 Tracker      ID: 198
-      - Low-Q2 Tagger 2 Calorimeter  ID: 199
+      - Low-Q2 Tagger 1       ID: 195
+      - Low-Q2 Tagger 2       ID: 196
+      - Low-Q2 Tagger Vacuum  ID: 199
 
       TODO: A lot of the repeated ID's below should be pushed into a single detector
     </documentation>
     <constant name="LumiCollimator_ID"       value="190"/>
     <constant name="LumiDipole_ID"           value="191"/>
-    <constant name="TaggerTracker_1_ID"      value="195"/>
-    <constant name="TaggerCalorimeter_1_ID"  value="196"/>
-    <constant name="TaggerTracker_2_ID"      value="198"/>
-    <constant name="TaggerCalorimeter_2_ID"  value="199"/>
+    <constant name="Tagger1_ID"              value="195"/>
+    <constant name="Tagger2_ID"              value="196"/>
+    <constant name="TaggerVacuum_ID"         value="199"/>
 
     <documentation>
       #### (200-219) Far Backward Beamline Magnets


### PR DESCRIPTION
### Briefly, what does this PR introduce?
IP6 merged a hard-coded ID number into master, which needed to be replaced by a defined ID number and added here.

### What kind of change does this PR introduce?
- [X] Bug fix (issue: IP6 integration in EPIC is currently broken)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.