### PR TITLE
SciGlassCalorimeter: place towers in a sector volume

### DIFF
--- a/src/BarrelCalorimeterSciGlass_geo.cpp
+++ b/src/BarrelCalorimeterSciGlass_geo.cpp
@@ -229,6 +229,7 @@ static Ref_t create_detector(Detector &lcdd, xml_h handle,
   };
 
   Volume sector_v{"sector", sector_shape, lcdd.material("Air")};
+  sector_v.setVisAttributes(lcdd.visAttributes(det_handle.visStr()));
 
   for (; row < rows_handle.number();
        row++, row_phi += rows_handle.deltaphi()) {


### PR DESCRIPTION
This places towers inside a sector volume instead of placing them directly in the envelope.

### TODO
 - [x] See if there is a performance improvement
 - [ ] ~~(optional) Avoid doubling the number of longitudinal carbon fibers~~