### PR TITLE
fix for endcap TOF coordinate conversion

### DIFF
--- a/src/EndcapTOF_geo.cpp
+++ b/src/EndcapTOF_geo.cpp
@@ -176,12 +176,12 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   int layer_id = 0;
   Assembly layer_assembly("layer_assembly" + _toString(layer_id, "_%d"));
 
-  DetElement layer_detEl(ttl_detEl, _toString(layer_id, "layer_%d"), x_det.id());
+  DetElement layer_detEl(ttl_detEl, _toString(layer_id, "layer_%d"), layer_id);
 
 
   // NOTE: ACTS extension for the disk layer of the TTL
   // also defining the coordinate system that differs between ACTS and Geant4 (zyx vs xyz)
-  Acts::ActsExtension* detlayer = new Acts::ActsExtension("zyx");
+  Acts::ActsExtension* detlayer = new Acts::ActsExtension();
   detlayer->addValue(-80. * mm, "r_min", "envelope");
   detlayer->addValue(670. * mm, "r_max", "envelope");
   detlayer->addValue(10. * mm, "z_min", "envelope");
@@ -338,11 +338,11 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
         pv.addPhysVolID("module", layer_id).addPhysVolID("sensor", isensor);
 
 
-        DetElement sensor_detEl_front(layer_detEl, sens_name_front, x_det.id());
+        DetElement sensor_detEl_front(layer_detEl, sens_name_front, isensor);
         sensor_detEl_front.setPlacement(pv);
         volSurfaceList(sensor_detEl_front)->push_back(surf_front);
 
-        Acts::ActsExtension* sensorExtension_front = new Acts::ActsExtension();
+        Acts::ActsExtension* sensorExtension_front = new Acts::ActsExtension("XZY");
         sensor_detEl_front.addExtension<Acts::ActsExtension>(sensorExtension_front);
 
         isensor++;
@@ -402,11 +402,11 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
         pv.addPhysVolID("module", layer_id).addPhysVolID("sensor", isensor);
 
 
-        DetElement sensor_detEl_back(layer_detEl, sens_name_back, x_det.id());
+        DetElement sensor_detEl_back(layer_detEl, sens_name_back, isensor);
         sensor_detEl_back.setPlacement(pv);
         volSurfaceList(sensor_detEl_back)->push_back(surf_back);
 
-        Acts::ActsExtension* sensorExtension_back = new Acts::ActsExtension();
+        Acts::ActsExtension* sensorExtension_back = new Acts::ActsExtension("XZY");
         sensor_detEl_back.addExtension<Acts::ActsExtension>(sensorExtension_back);
 
         isensor++;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
It appears, that the wrong coordinate system was used for the TOF ACTS implementation. One needs to use "xzy" instead of "zyx". 
With this change, no more surface errors appear and the endcap hits are available.

```
[2022-11-11 11:02:35.749] [tof_efficiency] [trace] TOF barrel hits:
[2022-11-11 11:02:35.749] [tof_efficiency] [trace]           [x]        [y]        [z]     [time]
[2022-11-11 11:02:35.750] [tof_efficiency] [trace] TOF endcap hits:
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]           [x]        [y]        [z]     [time]
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]        523.00     -95.19    1914.95     6.6580
[2022-11-11 11:02:35.750] [tof_efficiency] [trace] Going over tracks:
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]           [x]        [y]        [z]   [length]
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]  Track trajectory
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]        369.34     -62.38    1349.86    1400.88
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]        369.33     -62.38    1349.84    1400.86
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]        273.97     -44.43    1000.16    1037.96
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]        273.91     -44.39     999.86    1037.66
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]        273.90     -44.39     999.84    1037.63
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]        191.98     -29.96     700.16     726.62
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]        191.91     -29.93     699.86     726.31
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]        191.90     -29.93     699.84     726.29
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]        123.53     -18.63     450.16     467.17
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]        123.45     -18.64     449.86     466.86
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]        123.45     -18.64     449.84     466.84
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]         68.58     -10.00     249.87     259.30
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]         68.58     -10.00     249.84     259.28
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]         35.64      -5.10     129.79     134.69
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]         34.65      -4.95     126.18     130.95
[2022-11-11 11:02:35.750] [tof_efficiency] [trace]         27.97      -3.98     101.85     105.70
```
HOWEVER, i don't know why the track trajectory does not reach the endcap. In the exaple above, there should be a track state also for the tof region. @DraTeots maybe can provide a hint for what i could check in this regard?

### What kind of change does this PR introduce?
- [x] Bug fix (issue #286 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
