### PR TITLE
fix: use consistent dd4hep cmake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,15 @@ list(TRANSFORM DD4hep_required_libraries PREPEND DD4hep::)
 
 # Dependencies
 find_package(DD4hep REQUIRED COMPONENTS ${DD4hep_required_components})
+include(${DD4hep_DIR}/cmake/DD4hep.cmake)
+include(${DD4hep_DIR}/cmake/DD4hepBuild.cmake)
+dd4hep_configure_output()
+dd4hep_set_compiler_flags()
 if(${DD4hep_VERSION} VERSION_LESS 1.21)
   message(WARNING "DD4hep before 1.21 does not write collections correctly \n"
                   "More info at https://github.com/AIDASoft/DD4hep/pull/922")
 endif()
+
 find_package(ActsDD4hep)
 if(ActsDD4hep_FOUND)
   add_compile_definitions(USE_ACTSDD4HEP)
@@ -59,21 +64,16 @@ else()
   find_package(Acts REQUIRED COMPONENTS Core PluginIdentification PluginTGeo PluginDD4hep)
   set(ActsDD4hep ActsCore ActsPluginDD4hep)
 endif()
+
 find_package(fmt REQUIRED)
 
 #-----------------------------------------------------------------------------------
-set(a_lib_name ${PROJECT_NAME})
-
-dd4hep_configure_output()
 
 file(GLOB sources CONFIGURE_DEPENDS src/*.cpp)
-dd4hep_add_plugin(${a_lib_name}
+dd4hep_add_plugin(${PROJECT_NAME}
   SOURCES ${sources}
-  USES ${ActsDD4hep} ROOT::Core ROOT::Gdml
-  )
-target_link_libraries(${a_lib_name}
-  PUBLIC ${DD4hep_required_libraries} fmt::fmt
-  )
+  USES ${ActsDD4hep} ${DD4hep_required_libraries} ROOT::Core ROOT::Gdml fmt::fmt
+)
 
 #-----------------------------------------------------------------------------------
 # Parse jinja templates: once by default, and once for all yml files

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -15,12 +15,13 @@
 
 namespace fs = std::filesystem;
 
-using namespace dd4hep;
-
 // Function to download files
 inline void EnsureFileFromURLExists(std::string url, std::string file, std::string cache_str = "",
                                     std::string cmd = "curl --retry 5 -f {0} -o {1}")
 {
+  using dd4hep::ERROR;
+  using dd4hep::INFO;
+
   // parse cache for environment variables
   auto pos = std::string::npos;
   while ((pos = cache_str.find('$')) != std::string::npos) {
@@ -40,10 +41,10 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
   }
 
   // tokenize cache on regex
-  std::regex cache_sep(":");
+  std::regex                 cache_sep(":");
   std::sregex_token_iterator cache_iter(cache_str.begin(), cache_str.end(), cache_sep, -1);
   std::sregex_token_iterator cache_end;
-  std::vector<std::string> cache_vec(cache_iter, cache_end);
+  std::vector<std::string>   cache_vec(cache_iter, cache_end);
 
   // create file path
   fs::path file_path(file);
@@ -84,7 +85,8 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
           fs::path cache_hash_path = cache_dir_path / hash;
           if (fs::exists(cache_hash_path)) {
             // symlink hash to cache/.../hash
-            printout(INFO, "FileLoader", "File " + file + " with hash " + hash + " found in " + cache_hash_path.string());
+            printout(INFO, "FileLoader",
+                     "File " + file + " with hash " + hash + " found in " + cache_hash_path.string());
             try {
               fs::create_symlink(cache_hash_path, hash_path);
               success = true;
@@ -98,7 +100,8 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
           }
         }
       }
-      if (success) break;
+      if (success)
+        break;
     }
   }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The recent upgrade of some underlying dependency (not sure which one...) has surfaced an issue in how we use the DD4hep cmake helper macros. This has resulted in cases with duplicate library entries in `ldd` where only one is resolved, e.g.
```
        libTree.so.6.26 => not found
        libRIO.so.6.26 => not found
        libTree.so.6.26 => /opt/software/linux-debian-x86_64/gcc-12.2.0/root-6.26.06-vjvesxyjadhyrz3darz6wlyqhz4visgv/lib/root/libTree.so.6.26 (0x00007f5884aa7000)
        libRIO.so.6.26 => /opt/software/linux-debian-x86_64/gcc-12.2.0/root-6.26.06-vjvesxyjadhyrz3darz6wlyqhz4visgv/lib/root/libRIO.so.6.26 (0x00007f5884190000)
```
This PR fixes the macro calling by properly including the correct DD4hep cmake files and calling the required macros.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: build failures on updated containers)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.