### PR TITLE
fix: define Birks constants in materials definition

### DIFF
--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -39,6 +39,7 @@
     <D value="1.032" unit="g/cm3"/>
     <composite n="19" ref="C"/>
     <composite n="21" ref="H"/>
+    <constant name="BirksConstant" value="0.126*mm/MeV"/>
   </material>
   <material name="Water">
     <D value="1.00" unit="g/cm3"/>
@@ -140,6 +141,7 @@
     <fraction n="0.2146" ref="Gd"/>
     <fraction n="0.1369" ref="Si"/>
     <fraction n="0.2610" ref="O"/>
+    <constant name="BirksConstant" value="0.0333*mm/MeV"/>
   </material>
   <documentation level="3">
     #### Material for TOF
@@ -287,12 +289,14 @@
     <D type="density" unit="g/cm3" value="1.032"/>
     <composite n="9" ref="C"/>
     <composite n="10" ref="H"/>
+    <constant name="BirksConstant" value="0.126*mm/MeV"/>
   </material>
   <material name="PbWO4">
     <D type="density" value="8.3" unit="g / cm3"/>
     <composite n="1" ref="Pb"/>
     <composite n="1" ref="W"/>
     <composite n="4" ref="O"/>
+    <constant name="BirksConstant" value="0.0333*mm/MeV"/>
   </material>
   <material name="Ar10CO2">
     <D type="density" value="1.802" unit="mg / cm3"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Until now we were relying on a local [patch](https://github.com/eic/eic-spack/blob/v0.18/packages/geant4/birks.patch) to geant4 to define Birks constants. That's error-prone and makes the geometry dependent on external patches in a non-obvious way. This introduces the Birks constants for those materials that are used in our geometry, set to the values in the patch that has been in use:
- PbWO4: 0.0333*mm/MeV
- PlasticScint: 0.126*mm/MeV
- Polystyrene: 0.126*mm/MeV 
- SciGlass: 0.0333*mm/MeV

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators: @veprbl @mariakzurek @lkosarz @johnlajoie @johnny8266 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.