### PR TITLE
feat: move benchmark trigger to workflow_run

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -25,6 +25,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  meta:
+    steps:
+    - name: Save metadata
+      run: |
+        echo "GITHUB_SERVER_URL=${{ github.server_url }}" >> meta.env
+        echo "GITHUB_REPOSITORY=${{ github.repository }}" >> meta.env
+        echo "GITHUB_REF=${{ github.ref }}" >> meta.env
+        echo "GITHUB_REF_NAME=${{ github.event.pull_request.head.ref || github.ref_name }}" >> meta.env
+        echo "GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}" >> meta.env
+    - uses: actions/upload-artifact@v2
+      with:
+        name: meta
+        path: meta.env
+
   xmllint-before-build:
     runs-on: ubuntu-latest
     steps:
@@ -479,38 +493,6 @@ jobs:
           python scripts/checkOverlaps.py -c ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml | tee doc/overlap_check_geant4.out
           noverlaps="$(grep -c GeomVol1002 doc/overlap_check_geant4.out || true)"
           if [[ "${noverlaps}" -gt "0" ]] ; then echo "${noverlaps} overlaps found!" && false ; fi
-
-  trigger-detector-benchmarks:
-    runs-on: ubuntu-latest
-    needs: [check-overlap-tgeo, check-overlap-geant4-fast]
-    strategy:
-      matrix:
-        detector_config: [epic_arches, epic_brycecanyon]
-    steps:
-    - uses: eic/trigger-gitlab-ci@v2
-      id: trigger
-      with:
-        url: https://eicweb.phy.anl.gov
-        project_id: 399
-        token: ${{ secrets.EICWEB_DETECTOR_BENCHMARK_TRIGGER }}
-        ref_name: master
-        variables: |
-          DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
-          DETECTOR_VERSION=${{ github.event.pull_request.head.ref || github.ref_name }}
-          DETECTOR_CONFIG=${{ matrix.detector_config }}
-          GITHUB_REPOSITORY=${{ inputs.github_repository || github.repository }}
-          GITHUB_SHA=${{ inputs.github_sha || github.event.pull_request.head.sha || github.sha }}
-    - run: |
-        gh api \
-           --method POST \
-          -H "Accept: application/vnd.github+json" \
-          /repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha || github.sha }} \
-          -f state="pending" \
-          -f target_url="${{ steps.trigger.outputs.web_url }}" \
-          -f description="Triggered... $(TZ=America/New_York date)" \
-          -f context="eicweb/detector_benchmarks (${{ matrix.detector_config }})"
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   generate-prim-file:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-benchmarks.yml
+++ b/.github/workflows/trigger-benchmarks.yml
@@ -1,0 +1,65 @@
+name: trigger-benchmarks
+
+on:
+  workflow_run:
+    workflows:
+      - linux-eic-shell
+    types:
+      - completed
+
+jobs:
+  trigger-detector-benchmarks:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    strategy:
+      matrix:
+        detector_config: [epic_arches, epic_brycecanyon]
+    steps:
+    - name: 'Download artifact'
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          var artifacts = await github.actions.listWorkflowRunArtifacts({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             run_id: ${{github.event.workflow_run.id }},
+          });
+          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "meta"
+          })[0];
+          var download = await github.actions.downloadArtifact({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             artifact_id: matchArtifact.id,
+             archive_format: 'zip',
+          });
+          var fs = require('fs');
+          fs.writeFileSync('${{github.workspace}}/meta.zip', Buffer.from(download.data));
+    - run: unzip meta.zip
+    - run: cat meta.env >> ${GITHUB_ENV}
+    - uses: eic/trigger-gitlab-ci@v2
+      id: trigger
+      with:
+        url: https://eicweb.phy.anl.gov
+        project_id: 399
+        token: ${{ secrets.EICWEB_DETECTOR_BENCHMARK_TRIGGER }}
+        ref_name: master
+        variables: |
+          DETECTOR_REPOSITORYURL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY
+          DETECTOR_VERSION=$GITHUB_REF_NAME
+          DETECTOR_CONFIG=${{ matrix.detector_config }}
+          GITHUB_REPOSITORY=$GITHUB_REPOSITORY
+          GITHUB_SHA=$GITHUB_SHA
+    - run: |
+        gh api \
+           --method POST \
+          -H "Accept: application/vnd.github+json" \
+          /repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha || github.sha }} \
+          -f state="pending" \
+          -f target_url="${{ steps.trigger.outputs.web_url }}" \
+          -f description="Triggered... $(TZ=America/New_York date)" \
+          -f context="eicweb/detector_benchmarks (${{ matrix.detector_config }})"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Because triggers to eicweb rely on repository secrets, they cannot be succesfully triggered by forked repositories. This moves the triggers to a workflow_run, which is triggered with repository permissions after a successful workflow run. This would allow also pull requests from forked repositories to trigger benchmarks.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #63)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.