### PR TITLE
feat!: remove redundant `*RICH_RECON` constants

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -289,7 +289,7 @@ jobs:
         setup: install/setup.sh
         run: |
           mkdir -p doc
-          npdet_info dump ${DETECTOR_PATH}/epic_brycecanyon.xml | tee doc/constants.out
+          npdet_info dump ${DETECTOR_PATH}/epic.xml | tee doc/constants.out
     - uses: actions/upload-artifact@v3
       with:
         name: constants.out

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -289,7 +289,7 @@ jobs:
         setup: install/setup.sh
         run: |
           mkdir -p doc
-          npdet_info dump ${DETECTOR_PATH}/epic.xml | tee doc/constants.out
+          npdet_info dump ${DETECTOR_PATH}/epic_brycecanyon.xml | tee doc/constants.out
     - uses: actions/upload-artifact@v3
       with:
         name: constants.out

--- a/compact/pid/drich.xml
+++ b/compact/pid/drich.xml
@@ -5,24 +5,26 @@
 
 <define>
 <!-- vessel (=snout+tank) geometry -->
-<constant name="DRICH_Length"             value="ForwardRICHRegion_length"/>  <!-- overall vessel length -->
+<constant name="DRICH_length"             value="ForwardRICHRegion_length"/>  <!-- overall vessel length -->
 <constant name="DRICH_zmin"               value="ForwardRICHRegion_zmin"/>
-<constant name="DRICH_zmax"               value="DRICH_zmin + DRICH_Length"/>
+<constant name="DRICH_zmax"               value="DRICH_zmin + DRICH_length"/>
 <constant name="DRICH_rmin0"              value="DRICH_zmin * ForwardRICHRegion_tan1"/>  <!-- bore radius at dRICH entrance -->
 <constant name="DRICH_rmin1"              value="DRICH_zmax * ForwardRICHRegion_tan2"/>  <!-- bore radius at dRICH exit -->
+<constant name="DRICH_bore_slope"         value="(DRICH_rmin1 - DRICH_rmin0) / DRICH_length"/> <!-- slope of bore radius -->
 <constant name="DRICH_wall_thickness"     value="0.5*cm"/>  <!-- thickness of radial walls -->
 <constant name="DRICH_window_thickness"   value="0.1*cm"/>  <!-- thickness of entrance and exit walls -->
+<constant name="DRICH_num_sectors"        value="6"/>  <!-- number of azimuthal sectors -->
 <!-- snout geometry: cone with front radius rmax0 and back radius of rmax1 -->
 <constant name="DRICH_rmax0"              value="110.0*cm"/>
-<constant name="DRICH_SnoutLength"        value="20.0*cm"/>
-<constant name="DRICH_SnoutSlope"         value="DRICH_rmax0 / DRICH_zmin"/> <!-- TODO: increase slope to allow more space for aerogel cones ? -->
-<constant name="DRICH_rmax1"              value="DRICH_rmax0 + DRICH_SnoutLength * DRICH_SnoutSlope"/>
+<constant name="DRICH_snout_length"       value="20.0*cm"/>
+<constant name="DRICH_snout_slope"        value="DRICH_rmax0 / DRICH_zmin"/> <!-- TODO: increase slope to allow more space for aerogel cones ? -->
+<constant name="DRICH_rmax1"              value="DRICH_rmax0 + DRICH_snout_length * DRICH_snout_slope"/>
 <!-- tank geometry: cylinder, holding the majority of detector components -->
 <constant name="DRICH_rmax2"              value="ForwardPIDRegion_rmax"/>  <!-- cylinder radius -->
 <!-- aerogel+filter geometry -->
 <constant name="DRICH_aerogel_thickness"  value="4.0*cm"/>  <!-- aerogel thickness -->
+<constant name="DRICH_airgap_thickness"   value="0.01*mm"/> <!-- air gap between aerogel and filter -->
 <constant name="DRICH_filter_thickness"   value="0.3*mm"/>  <!-- filter thickness -->
-<constant name="DRICH_aerogel_filter_gap" value="0.01*mm"/> <!-- air gap between aerogel and filter FIXME: currently a gas gap -->
 <!-- sensor geometry; model = S13361-3050NE-08 SiPM -->
 <constant name="DRICH_sensor_size"           value="25.8*mm"/> <!-- full length of the sensor side FIXME: resin base should be this size -->
 <constant name="DRICH_pixel_gap"             value="0.2*mm"/> <!-- size of gaps between adjacent pixels AND gaps between edge pixels and sensor side -->
@@ -84,14 +86,14 @@
 </documentation>
 <dimensions
   zmin="DRICH_zmin"
-  length="DRICH_Length"
-  snout_length="DRICH_SnoutLength"
+  length="DRICH_length"
+  snout_length="DRICH_snout_length"
   rmin0="DRICH_rmin0"
   rmin1="DRICH_rmin1"
   rmax0="DRICH_rmax0"
   rmax1="DRICH_rmax1"
   rmax2="DRICH_rmax2"
-  nsectors="6"
+  nsectors="DRICH_num_sectors"
   wall_thickness="DRICH_wall_thickness"
   window_thickness="DRICH_window_thickness"
   />
@@ -123,7 +125,7 @@
   <airgap
     material="AirOptical"
     vis="DRICH_gas_vis"
-    thickness="DRICH_aerogel_filter_gap"
+    thickness="DRICH_airgap_thickness"
     />
   <filter
     material="Acrylic_DRICH"
@@ -215,7 +217,7 @@
   phiw="18*degree"
   rmin="DRICH_rmax1 + 2.0*cm"
   rmax="DRICH_rmax2 - 5.0*cm"
-  zmin="DRICH_SnoutLength + 5.0*cm"
+  zmin="DRICH_snout_length + 5.0*cm"
   />
 
 

--- a/compact/pid/pfrich.xml
+++ b/compact/pid/pfrich.xml
@@ -10,7 +10,8 @@
 <constant name="PFRICH_zmin"               value="PFRICH_zmax + PFRICH_length"/>      <!-- vessel back -->
 <constant name="PFRICH_rmin0"              value="-PFRICH_zmin * Eta3_9_tan * 0.95"/> <!-- bore radius at vessel frontplane -->
 <constant name="PFRICH_rmin1"              value="-PFRICH_zmax * Eta3_9_tan * 0.85"/> <!-- bore radius at vessel backplane -->
-<constant name="PFRICH_rmax"               value="BackwardPIDRegion_rmax"/>           <!-- vessel backplane radius -->
+<constant name="PFRICH_rmax"               value="BackwardPIDRegion_rmax"/>           <!-- vessel radius -->
+<constant name="PFRICH_bore_slope"         value="(PFRICH_rmin1 - PFRICH_rmin0) / PFRICH_length"/> <!-- slope of bore radius -->
 <constant name="PFRICH_proximity_gap"      value="35*cm"/>                            <!-- distance between aerogel exit plane and sensor entrance plane -->
 <constant name="PFRICH_services_length"    value="15*cm"/>                            <!-- span of service materials behind the sensors -->
 <constant name="PFRICH_wall_thickness"     value="0.5*cm"/>                           <!-- thickness of radial walls -->

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -150,21 +150,6 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
     return enc;
   };
 
-  // define reconstruction geometry constants `DRICH_RECON_*`
-  /* - these are the numbers needed to rebuild the geometry in the
-   *   reconstruction, in particular, the optical surfaces encountered by the
-   *   Cherenkov photons
-   * - positions are w.r.t. the IP
-   * - check the values of all of the `DRICH_RECON_*` constants after any change
-   *   to the geometry
-   * - some `DRICH_RECON_*` constants are redundant, but are defined to make
-   *   it clear that the reconstruction code depends on them
-   */
-  desc.add(Constant("DRICH_RECON_nSectors", std::to_string(nSectors)));
-  desc.add(Constant("DRICH_RECON_zmin", std::to_string(vesselZmin)));
-  desc.add(Constant("DRICH_RECON_gasvolMaterial", gasvolMat.ptr()->GetName(), "string"));
-  desc.add(Constant("DRICH_RECON_cellMask", std::to_string(cellMask)));
-
   // BUILD VESSEL ====================================================================
   /* - `vessel`: aluminum enclosure, the mother volume of the dRICH
    * - `gasvol`: gas volume, which fills `vessel`; all other volumes defined below
@@ -251,6 +236,22 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   PlacedVolume vesselPV  = motherVol.placeVolume(vesselVol, vesselPos);
   vesselPV.addPhysVolID("system", detID);
   det.setPlacement(vesselPV);
+
+  // define reconstruction geometry constants `DRICH_RECON_*`
+  /* - these are the numbers needed to rebuild the geometry in the
+   *   reconstruction, in particular, the optical surfaces encountered by the
+   *   Cherenkov photons
+   * - positions are w.r.t. the IP
+   * - check the values of all of the `DRICH_RECON_*` constants after any change
+   *   to the geometry
+   * - some `DRICH_RECON_*` constants are redundant, but are defined to make
+   *   it clear that the reconstruction code depends on them
+   */
+  desc.add(Constant("DRICH_RECON_nSectors", std::to_string(nSectors)));
+  desc.add(Constant("DRICH_RECON_zmin", std::to_string(vesselZmin)));
+  desc.add(Constant("DRICH_RECON_zmax", std::to_string(vesselZmax)));
+  desc.add(Constant("DRICH_RECON_gasvolMaterial", gasvolMat.ptr()->GetName(), "string"));
+  desc.add(Constant("DRICH_RECON_cellMask", std::to_string(cellMask)));
 
   // BUILD RADIATOR ====================================================================
 

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -250,6 +250,12 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   desc.add(Constant("DRICH_RECON_nSectors", std::to_string(nSectors)));
   desc.add(Constant("DRICH_RECON_zmin", std::to_string(vesselZmin)));
   desc.add(Constant("DRICH_RECON_zmax", std::to_string(vesselZmax)));
+  desc.add(Constant("DRICH_RECON_rmin0", std::to_string(vesselRmin0)));
+  desc.add(Constant("DRICH_RECON_rmin1", std::to_string(vesselRmin1)));
+  desc.add(Constant("DRICH_RECON_rmax0", std::to_string(vesselRmax0)));
+  desc.add(Constant("DRICH_RECON_rmax1", std::to_string(vesselRmax1)));
+  desc.add(Constant("DRICH_RECON_rmax2", std::to_string(vesselRmax2)));
+  desc.add(Constant("DRICH_RECON_snoutLength", std::to_string(snoutLength)));
   desc.add(Constant("DRICH_RECON_gasvolMaterial", gasvolMat.ptr()->GetName(), "string"));
   desc.add(Constant("DRICH_RECON_cellMask", std::to_string(cellMask)));
 

--- a/src/PFRICH_geo.cpp
+++ b/src/PFRICH_geo.cpp
@@ -119,21 +119,6 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
     return enc;
   };
 
-  // define reconstruction geometry constants `PFRICH_RECON_*`
-  /* - these are the numbers needed to rebuild the geometry in the
-   *   reconstruction, in particular, the optical surfaces encountered by the
-   *   Cherenkov photons
-   * - positions are w.r.t. the IP
-   * - check the values of all of the `PFRICH_RECON_*` constants after any change
-   *   to the geometry
-   * - some `PFRICH_RECON_*` constants are redundant, but are defined to make
-   *   it clear that the reconstruction code depends on them
-   */
-  desc.add(Constant("PFRICH_RECON_zmin", std::to_string(vesselZmin)));
-  desc.add(Constant("PFRICH_RECON_gasvolMaterial", gasvolMat.ptr()->GetName(), "string"));
-  desc.add(Constant("PFRICH_RECON_cellMask", std::to_string(cellMask)));
-  desc.add(Constant("PFRICH_RECON_sensorThickness", std::to_string(sensorThickness)));
-
   // BUILD VESSEL //////////////////////////////////////
   /* - `vessel`: aluminum enclosure, the mother volume of the pfRICH
    * - `gasvol`: gas volume, which fills `vessel`; all other volumes defined below
@@ -183,6 +168,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   auto originFront = Position(0., 0., vesselLength / 2.0);
   // auto originBack = Position(0., 0., -vesselLength / 2.0);
   auto vesselPos = Position(0, 0, vesselZmin) - originFront;
+  double vesselZmax = vesselZmin - vesselLength;
 
   // place gas volume
   PlacedVolume gasvolPV = vesselVol.placeVolume(gasvolVol, Position(0, 0, 0));
@@ -194,6 +180,22 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   PlacedVolume vesselPV  = motherVol.placeVolume(vesselVol, vesselPos);
   vesselPV.addPhysVolID("system", detID);
   det.setPlacement(vesselPV);
+
+  // define reconstruction geometry constants `PFRICH_RECON_*`
+  /* - these are the numbers needed to rebuild the geometry in the
+   *   reconstruction, in particular, the optical surfaces encountered by the
+   *   Cherenkov photons
+   * - positions are w.r.t. the IP
+   * - check the values of all of the `PFRICH_RECON_*` constants after any change
+   *   to the geometry
+   * - some `PFRICH_RECON_*` constants are redundant, but are defined to make
+   *   it clear that the reconstruction code depends on them
+   */
+  desc.add(Constant("PFRICH_RECON_zmin", std::to_string(vesselZmin)));
+  desc.add(Constant("PFRICH_RECON_zmax", std::to_string(vesselZmax)));
+  desc.add(Constant("PFRICH_RECON_gasvolMaterial", gasvolMat.ptr()->GetName(), "string"));
+  desc.add(Constant("PFRICH_RECON_cellMask", std::to_string(cellMask)));
+  desc.add(Constant("PFRICH_RECON_sensorThickness", std::to_string(sensorThickness)));
 
   // BUILD RADIATOR //////////////////////////////////////
 

--- a/src/PFRICH_geo.cpp
+++ b/src/PFRICH_geo.cpp
@@ -193,6 +193,10 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
    */
   desc.add(Constant("PFRICH_RECON_zmin", std::to_string(vesselZmin)));
   desc.add(Constant("PFRICH_RECON_zmax", std::to_string(vesselZmax)));
+  desc.add(Constant("PFRICH_RECON_rmin0", std::to_string(vesselRmin0)));
+  desc.add(Constant("PFRICH_RECON_rmin1", std::to_string(vesselRmin1)));
+  desc.add(Constant("PFRICH_RECON_rmax0", std::to_string(vesselRmax0)));
+  desc.add(Constant("PFRICH_RECON_rmax1", std::to_string(vesselRmax1)));
   desc.add(Constant("PFRICH_RECON_gasvolMaterial", gasvolMat.ptr()->GetName(), "string"));
   desc.add(Constant("PFRICH_RECON_cellMask", std::to_string(cellMask)));
   desc.add(Constant("PFRICH_RECON_sensorThickness", std::to_string(sensorThickness)));

--- a/src/PFRICH_geo.cpp
+++ b/src/PFRICH_geo.cpp
@@ -111,6 +111,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   uint64_t cellMask = 0;
   for (const auto& idField : sensorIDfields)
     cellMask |= readoutCoder[idField].mask();
+  desc.add(Constant("PFRICH_cell_mask", std::to_string(cellMask)));
   // create a unique sensor ID from a sensor's PlacedVolume::volIDs
   auto encodeSensorID = [&readoutCoder](auto ids) {
     uint64_t enc = 0;
@@ -168,7 +169,6 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   auto originFront = Position(0., 0., vesselLength / 2.0);
   // auto originBack = Position(0., 0., -vesselLength / 2.0);
   auto vesselPos = Position(0, 0, vesselZmin) - originFront;
-  double vesselZmax = vesselZmin - vesselLength;
 
   // place gas volume
   PlacedVolume gasvolPV = vesselVol.placeVolume(gasvolVol, Position(0, 0, 0));
@@ -180,26 +180,6 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   PlacedVolume vesselPV  = motherVol.placeVolume(vesselVol, vesselPos);
   vesselPV.addPhysVolID("system", detID);
   det.setPlacement(vesselPV);
-
-  // define reconstruction geometry constants `PFRICH_RECON_*`
-  /* - these are the numbers needed to rebuild the geometry in the
-   *   reconstruction, in particular, the optical surfaces encountered by the
-   *   Cherenkov photons
-   * - positions are w.r.t. the IP
-   * - check the values of all of the `PFRICH_RECON_*` constants after any change
-   *   to the geometry
-   * - some `PFRICH_RECON_*` constants are redundant, but are defined to make
-   *   it clear that the reconstruction code depends on them
-   */
-  desc.add(Constant("PFRICH_RECON_zmin", std::to_string(vesselZmin)));
-  desc.add(Constant("PFRICH_RECON_zmax", std::to_string(vesselZmax)));
-  desc.add(Constant("PFRICH_RECON_rmin0", std::to_string(vesselRmin0)));
-  desc.add(Constant("PFRICH_RECON_rmin1", std::to_string(vesselRmin1)));
-  desc.add(Constant("PFRICH_RECON_rmax0", std::to_string(vesselRmax0)));
-  desc.add(Constant("PFRICH_RECON_rmax1", std::to_string(vesselRmax1)));
-  desc.add(Constant("PFRICH_RECON_gasvolMaterial", gasvolMat.ptr()->GetName(), "string"));
-  desc.add(Constant("PFRICH_RECON_cellMask", std::to_string(cellMask)));
-  desc.add(Constant("PFRICH_RECON_sensorThickness", std::to_string(sensorThickness)));
 
   // BUILD RADIATOR //////////////////////////////////////
 
@@ -245,15 +225,16 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
     // filterSkin.isValid();
   };
 
-  // reconstruction constants (w.r.t. IP)
+  // radiator z-positions (w.r.t. IP)
   double aerogelZpos = vesselPos.z() + aerogelPV.position().z();
   double filterZpos  = vesselPos.z() + filterPV.position().z();
-  desc.add(Constant("PFRICH_RECON_aerogelZpos", std::to_string(aerogelZpos)));
-  desc.add(Constant("PFRICH_RECON_aerogelThickness", std::to_string(aerogelThickness)));
-  desc.add(Constant("PFRICH_RECON_aerogelMaterial", aerogelMat.ptr()->GetName(), "string"));
-  desc.add(Constant("PFRICH_RECON_filterZpos", std::to_string(filterZpos)));
-  desc.add(Constant("PFRICH_RECON_filterThickness", std::to_string(filterThickness)));
-  desc.add(Constant("PFRICH_RECON_filterMaterial", filterMat.ptr()->GetName(), "string"));
+  desc.add(Constant("PFRICH_aerogel_zpos", std::to_string(aerogelZpos)));
+  desc.add(Constant("PFRICH_filter_zpos", std::to_string(filterZpos)));
+
+  // radiator material names
+  desc.add(Constant("PFRICH_aerogel_material", aerogelMat.ptr()->GetName(), "string"));
+  desc.add(Constant("PFRICH_filter_material", filterMat.ptr()->GetName(), "string"));
+  desc.add(Constant("PFRICH_gasvol_material", gasvolMat.ptr()->GetName(), "string"));
 
   // BUILD SENSORS ///////////////////////
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- Remove redundant extra `*RICH_RECON_*` constants
- All `*RICH_` constants to snake case

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
yes, but only to downstream code, namely `eicrecon` and `drich-dev`

### Does this PR change default behavior?
no