### PR TITLE
BarrelCalorimeterSciGlass: allow specifying azimuthal flaring angle for towers

### DIFF
--- a/doc/sciglass_tower_front_view.svg
+++ b/doc/sciglass_tower_front_view.svg
@@ -1,0 +1,383 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="58.162678mm"
+   height="44.769291mm"
+   viewBox="0 0 58.162678 44.769291"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
+   sodipodi:docname="sciglass_tower_front_view.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     showguides="false"
+     inkscape:lockguides="false"
+     inkscape:zoom="2.8241405"
+     inkscape:cx="91.355228"
+     inkscape:cy="80.555482"
+     inkscape:window-width="1309"
+     inkscape:window-height="845"
+     inkscape:window-x="77"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer5" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="shapes"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-57.156783,-86.766816)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.254;stroke-dasharray:none"
+       d="M 57.322404,89.783599 67.731176,128.62967 H 100.69518 L 111.06993,89.910599 Z"
+       id="path1361" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.254;stroke-dasharray:none"
+       d="M 65.748753,95.873742 72.89382,122.53948 H 95.521845 L 102.64356,95.960921 Z"
+       id="path1361-1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="grid"
+     transform="translate(-57.156783,-86.766816)">
+    <path
+       style="stroke:#999999;stroke-width:0.1524;stroke-dasharray:0.1524, 0.3048;stroke-dashoffset:0"
+       d="m 57.156788,109.13041 57.193672,-0.004"
+       id="path1610"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:0.1524, 0.3048;stroke-dashoffset:0"
+       d="M 84.28933,130.72618 V 87.558035"
+       id="path1819" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.155188;stroke-dasharray:0.155188, 0.310377;stroke-dashoffset:0"
+       d="M 72.897809,130.72618 V 111.42985"
+       id="path1819-0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:0.1524, 0.3048;stroke-dashoffset:0"
+       d="m 65.748753,99.575135 -0.121901,-12.0171"
+       id="path1819-6"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="stroke:#999999;stroke-width:0.1524;stroke-dasharray:0.1524, 0.3048;stroke-dashoffset:0"
+       d="m 84.272371,95.997531 30.078089,-0.0802 v 0 0"
+       id="path1610-6"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="stroke:#999999;stroke-width:0.1524;stroke-dasharray:0.1524, 0.3048;stroke-dashoffset:0"
+       d="m 84.272369,128.65853 25.066641,0.0981 v 0 0"
+       id="path1610-6-1"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:0.1524, 0.3048;stroke-dashoffset:0"
+       d="m 111.29629,92.981016 -0.1219,-5.422981"
+       id="path1819-6-2"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.155188;stroke-dasharray:0.155188, 0.310377;stroke-dashoffset:0"
+       d="m 100.61533,130.72618 v -6.25202"
+       id="path2693"
+       sodipodi:nodetypes="cc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer5"
+     inkscape:label="distances"
+     transform="translate(-57.156783,-86.766816)">
+    <path
+       style="fill:none;stroke:#4d4d4d;stroke-width:0.0762;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="M 65.848739,88.616369 H 84.079504"
+       id="path2140"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.82223px;fill:none;stroke:#4d4d4d;stroke-width:0.0762;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       x="71.944923"
+       y="87.557259"
+       id="text2146"><tspan
+         sodipodi:role="line"
+         id="tspan2144"
+         style="stroke-width:0.0762"
+         x="71.944923"
+         y="87.557259" /></text>
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;fill:#000000;stroke:none;stroke-width:0.0762;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       x="73.573662"
+       y="87.92437"
+       id="text2150"><tspan
+         sodipodi:role="line"
+         id="tspan2148"
+         style="font-size:2.11667px;stroke:none;stroke-width:0.0762"
+         x="73.573662"
+         y="87.92437">x<tspan
+   style="font-size:65%;baseline-shift:sub;stroke:none"
+   id="tspan2154">2</tspan></tspan></text>
+    <path
+       style="fill:#000000;stroke:#4d4d4d;stroke-width:0.0762;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="M 73.113048,129.66784 H 84.075714"
+       id="path2156"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;fill:#000000;stroke:none;stroke-width:0.0762;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       x="77.563271"
+       y="131.09329"
+       id="text2150-6"><tspan
+         sodipodi:role="line"
+         id="tspan2148-8"
+         style="font-size:2.11667px;stroke:none;stroke-width:0.0762"
+         x="77.563271"
+         y="131.09329">x<tspan
+   style="font-size:65%;baseline-shift:sub;stroke:none"
+   id="tspan2190">1</tspan></tspan></text>
+    <path
+       style="fill:none;stroke:#4d4d4d;stroke-width:0.0762;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="M 113.12774,96.130476 V 108.91216"
+       id="path2267"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;fill:#000000;stroke:none;stroke-width:0.0762;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       x="113.31844"
+       y="102.92061"
+       id="text2150-6-3"><tspan
+         sodipodi:role="line"
+         id="tspan2148-8-2"
+         style="font-size:2.11667px;stroke:none;stroke-width:0.0762"
+         x="113.31844"
+         y="102.92061">y<tspan
+   style="font-size:65%;baseline-shift:sub;stroke:none"
+   id="tspan2190-2">1</tspan></tspan></text>
+    <path
+       style="fill:none;stroke:#4d4d4d;stroke-width:0.077485;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 107.6733,109.34162 v 19.1987"
+       id="path2323"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 107.94714,128.47186 -0.27385,0.27382 -0.27382,-0.27382 z"
+       id="path3509-33-2" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;fill:#000000;stroke:none;stroke-width:0.0762;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       x="107.88313"
+       y="119.25311"
+       id="text2150-6-3-6"><tspan
+         sodipodi:role="line"
+         id="tspan2148-8-2-5"
+         style="font-size:2.11667px;stroke:none;stroke-width:0.0762"
+         x="107.88313"
+         y="119.25311">y<tspan
+   style="font-size:65%;baseline-shift:sub;stroke:none"
+   id="tspan2190-2-0">2</tspan></tspan></text>
+    <path
+       style="fill:none;stroke:#4d4d4d;stroke-width:0.0762;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="M 84.499156,88.616369 H 110.98614"
+       id="path2572"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;fill:#000000;stroke:none;stroke-width:0.0762;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       x="96.706253"
+       y="87.92437"
+       id="text2578"><tspan
+         sodipodi:role="line"
+         id="tspan2576"
+         style="font-size:2.11667px;stroke:none;stroke-width:0.0762"
+         x="96.706253"
+         y="87.92437">x<tspan
+   style="font-size:65%;baseline-shift:sub;stroke:none"
+   id="tspan2574">4</tspan></tspan></text>
+    <path
+       style="fill:#000000;stroke:#4d4d4d;stroke-width:0.0762;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 84.50295,129.66784 h 15.89788"
+       id="path2704"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;fill:#000000;stroke:none;stroke-width:0.0762;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       x="91.420631"
+       y="131.09329"
+       id="text2710"><tspan
+         sodipodi:role="line"
+         id="tspan2708"
+         style="font-size:2.11667px;stroke:none;stroke-width:0.0762"
+         x="91.420631"
+         y="131.09329">x<tspan
+   style="font-size:65%;baseline-shift:sub;stroke:none"
+   id="tspan2706">3</tspan></tspan></text>
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 65.917196,88.890197 -0.273828,-0.273828 0.273828,-0.273828 z"
+       id="path3509" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 84.567613,88.890197 -0.273828,-0.273828 0.273828,-0.273828 z"
+       id="path3509-0" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 84.011047,88.342541 0.273828,0.273828 -0.273828,0.273828 z"
+       id="path3509-8" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 110.91769,88.342539 0.27382,0.27384 -0.27382,0.27382 z"
+       id="path3509-7" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 73.181505,129.94167 -0.273828,-0.27382 0.273828,-0.27384 z"
+       id="path3509-6" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 84.571407,129.94167 -0.273828,-0.27382 0.273828,-0.27382 z"
+       id="path3509-3" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 84.007259,129.39401 0.27382,0.27384 -0.27382,0.27382 z"
+       id="path3509-1" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 100.33238,129.39401 0.27382,0.27382 -0.27382,0.27384 z"
+       id="path3509-2" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 112.8539,96.198931 0.27384,-0.27382 0.27382,0.27382 z"
+       id="path3509-33" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 113.40157,108.8437 -0.27384,0.27382 -0.27382,-0.27382 z"
+       id="path3509-33-0" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 107.39947,109.41008 0.27385,-0.27382 0.27382,0.27382 z"
+       id="path3509-33-9" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="angles"
+     transform="translate(-57.156783,-86.766816)">
+    <text
+       xml:space="preserve"
+       style="font-size:2.11667px;fill:#000000;stroke:none;stroke-width:0.1524;stroke-dasharray:0.1524, 0.3048;stroke-dashoffset:0"
+       x="70.634277"
+       y="114.13088"
+       id="text1977"><tspan
+         sodipodi:role="line"
+         id="tspan1975"
+         style="font-size:2.11667px;fill:#000000;stroke:none;stroke-width:0.1524"
+         x="70.634277"
+         y="114.13088">α<tspan
+   style="font-size:65%;baseline-shift:sub;fill:#000000;stroke:none"
+   id="tspan2038">f</tspan></tspan></text>
+    <path
+       style="fill:none;stroke:#4d4d4d;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 71.032843,115.59423 c 0.66103,-0.34956 1.287638,-0.48748 1.85838,-0.49795"
+       id="path2046"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#4d4d4d;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 73.890932,126.26076 c -0.310947,0.12892 -0.702844,0.25115 -1.071915,0.25115"
+       id="path2046-2"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#4d4d4d;stroke-width:0.1524;stroke-linecap:butt;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 64.546465,91.472944 c 0.310947,-0.128919 0.702844,-0.251149 1.071916,-0.251149"
+       id="path2046-2-6"
+       sodipodi:nodetypes="cc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="measures"
+     style="stroke:#4d4d4d"
+     transform="translate(-57.156783,-86.766816)">
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 72.893819,109.07456 v 19.55511"
+       id="path1389"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 72.893819,122.53948 1.63186,6.09019"
+       id="path1393" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="M 72.893819,122.53948 H 66.099313"
+       id="path1397" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 84.20783,122.53948 0.0053,6.09019"
+       id="path1401" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 69.321285,109.20661 -6.794495,2e-5"
+       id="path1403" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 83.762126,125.58458 h 0.896708 v 0 0"
+       id="path1405-8" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 65.670038,108.75827 v 0.8967 0 0"
+       id="path1405-7" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 66.178038,108.75827 v 0.8967 0 0"
+       id="path1405-7-4" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 69.242567,122.09113 v 0.8967 0 0"
+       id="path1405-7-8" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 69.750567,122.09113 v 0.8967 0 0"
+       id="path1405-7-4-0" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="M 65.748751,95.873741 65.583138,89.803118"
+       id="path1387"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="M 65.748751,95.873741 64.121206,89.799662"
+       id="path1391" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 65.748751,95.873741 h -6.7945"
+       id="path1395" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 84.196154,95.917331 1.1e-5,-6.070232"
+       id="path1399" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 83.747806,92.882215 h 0.896708 v 0 0"
+       id="path1405" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 62.097502,95.425391 v 0.8967 0 0"
+       id="path1405-7-5" />
+    <path
+       style="stroke:#4d4d4d;stroke-width:0.1524;stroke-dasharray:none"
+       d="m 62.605502,95.425391 v 0.8967 0 0"
+       id="path1405-7-4-8" />
+  </g>
+</svg>

--- a/src/BarrelCalorimeterSciGlass_geo.cpp
+++ b/src/BarrelCalorimeterSciGlass_geo.cpp
@@ -208,12 +208,11 @@ static Ref_t create_detector(Detector& lcdd, xml_h handle, SensitiveDetector sen
       double&   dz                     = dzs[(dir_sign > 0) ? 1 : 0];
       double&   flare_angle_polar_prev = flare_angle_polar_prevs[(dir_sign > 0) ? 1 : 0];
 
-      xml_dim_t          family_dim_handle     = family_handle;
-      const double       length                = family_dim_handle.z_length();
-      const auto         flare_angle_azimuthal = family_dim_handle.attr<double>(_Unicode(flare_angle_azimuthal), NAN);
-      const auto         flare_angle_polar     = family_dim_handle.attr<double>(_Unicode(flare_angle_polar));
-      const unsigned int number                = family_dim_handle.number();
-      const auto         flare_angle_at_face   = family_dim_handle.attr<double>(_Unicode(flare_angle_at_face));
+      xml_dim_t          family_dim_handle   = family_handle;
+      const double       length              = family_dim_handle.z_length();
+      const auto         flare_angle_polar   = family_dim_handle.attr<double>(_Unicode(flare_angle_polar));
+      const unsigned int number              = family_dim_handle.number();
+      const auto         flare_angle_at_face = family_dim_handle.attr<double>(_Unicode(flare_angle_at_face));
 
       const double z  = length / 2;
       // Face parameters (see doc/sciglass_tower_front_view.svg for definitions)
@@ -222,8 +221,9 @@ static Ref_t create_detector(Detector& lcdd, xml_h handle, SensitiveDetector sen
       double       x1 = family_dim_handle.x1();
       double       x2 = family_dim_handle.x1() + (2 * y1) * tan(flare_angle_at_face);
       double       x3, x4;
-      if (!std::isnan(flare_angle_azimuthal)) {
-        // Azimuthal flaring defined
+      if (family_dim_handle.hasAttr(_Unicode(flare_angle_azimuthal))) {
+        // Azimuthal flaring independently defined
+        const auto flare_angle_azimuthal = family_dim_handle.attr<double>(_Unicode(flare_angle_azimuthal));
         x3 = x1 + length * (tan(flare_angle_azimuthal) - tan(flare_angle_polar) * tan(flare_angle_at_face));
         x4 = x2 + length * (tan(flare_angle_azimuthal) + tan(flare_angle_polar) * tan(flare_angle_at_face));
       } else {

--- a/src/BarrelCalorimeterSciGlass_geo.cpp
+++ b/src/BarrelCalorimeterSciGlass_geo.cpp
@@ -216,13 +216,14 @@ static Ref_t create_detector(Detector& lcdd, xml_h handle, SensitiveDetector sen
       const auto         flare_angle_at_face   = family_dim_handle.attr<double>(_Unicode(flare_angle_at_face));
 
       const double z  = length / 2;
+      // Face parameters (see doc/sciglass_tower_front_view.svg for definitions)
       const double y1 = family_dim_handle.y1();
       const double y2 = y1 + length * tan(flare_angle_polar);
       double       x1 = family_dim_handle.x1();
       double       x2 = family_dim_handle.x1() + (2 * y1) * tan(flare_angle_at_face);
       double       x3, x4;
       if (!std::isnan(flare_angle_azimuthal)) {
-        //  Azimuthal flaring defined
+        // Azimuthal flaring defined
         x3 = x1 + length * (tan(flare_angle_azimuthal) - tan(flare_angle_polar) * tan(flare_angle_at_face));
         x4 = x2 + length * (tan(flare_angle_azimuthal) + tan(flare_angle_polar) * tan(flare_angle_at_face));
       } else {


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Allow specifying azimuthal flaring angle for towers using a new `flare_angle_azimuthal` parameter.

This parameter is not used in the current engineering geometry, and is implicitly calculated for it assuming a truncated pyramid tower shape. For AI/ML optimizations we need to relax this constraint.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No