### PR TITLE
Sciglass backport to 22.11

### DIFF
--- a/.github/workflows/generate-weekly-meeting-slides.yml
+++ b/.github/workflows/generate-weekly-meeting-slides.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         since: ${{ inputs.since || '1 week ago' }}
         config: |
-          repos:  
+          repos:
             - name: ${{ github.repository }}
               do_stale: true
               stale_label: stale

--- a/compact/ecal/backward_PbWO4.xml
+++ b/compact/ecal/backward_PbWO4.xml
@@ -10,7 +10,7 @@
     <constant name="EcalEndcapN_structure_ring_length" value="EcalEndcapN_length"/>
     <constant name="EcalEndcapN_structure_ring_max" value="65.00*cm"/>
     <constant name="EcalEndcapN_structure_ring_min" value="EcalEndcapN_structure_ring_max - 0.9*cm"/>
-    
+
     <comment>FIXME currently unused</comment>
     <constant name="EcalEndcapN_IonCutout_dphi" value="30*degree"/>
 
@@ -35,7 +35,7 @@
             r12min="EcalEndcapN_structure_ring_min"
             r12max="EcalEndcapN_structure_ring_max"
             SFlength="EcalEndcapN_structure_ring_length"
-            CMlength="EcalEndcapN_CrystalModule_length + 2.*EcalEndcapN_CrystalModule_wrap_thickness" 
+            CMlength="EcalEndcapN_CrystalModule_length + 2.*EcalEndcapN_CrystalModule_wrap_thickness"
             envelope="true"
             vis_struc="RPVis"
             vis_steel_gap="AnlGray"
@@ -47,7 +47,7 @@
             gz="EcalEndcapN_CrystalModule_length"
             gdz="EcalEndcapN_CrystalModule_wrap_thickness"
             gmaterial="Vacuum"
-            vis="BlueVis"/>              
+            vis="BlueVis"/>
           <crystal
             sizex="EcalEndcapN_CrystalModule_width"
             sizey="EcalEndcapN_CrystalModule_width"
@@ -57,7 +57,7 @@
           <wrapper
             carbon_thickness="EcalEndcapN_CrystalModule_carbon_thickness"
             wrap_thickness="EcalEndcapN_CrystalModule_wrap_thickness"
-            length="EcalEndcapN_CrystalModule_carbon_length"  
+            length="EcalEndcapN_CrystalModule_carbon_length"
             material_carbon="CarbonFiber"
             material_wrap="VM2000"
             material_gap="Air"

--- a/compact/ecal/barrel_sciglass.xml
+++ b/compact/ecal/barrel_sciglass.xml
@@ -134,7 +134,7 @@
   <readouts>
     <readout name="EcalBarrelSciGlassHits">
       <segmentation type="NoSegmentation"/>
-      <id>system:8,sector:8,module:8,slice:-8</id>
+      <id>system:8,sector:8,row:8,tower:-8</id>
     </readout>
   </readouts>
 </lccdd>

--- a/compact/ecal/barrel_sciglass.xml
+++ b/compact/ecal/barrel_sciglass.xml
@@ -35,7 +35,7 @@
       An EM calorimeter with SciGlass blocks
     </comment>
 
-    <detector id="4" name="EcalBarrel" type="epic_SciGlassCalorimeter" readout="EcalBarrelSciGlassHits" vis="det_vis" calorimeterType="EM_BARREL">
+    <detector id="4" name="EcalBarrel" type="epic_EcalBarrelSciGlass" readout="EcalBarrelSciGlassHits" vis="det_vis" calorimeterType="EM_BARREL">
       <comment>
         Global detector dimensions from https://eic.jlab.org/Geometry/Detector/Detector-20220624102507.html
       </comment>

--- a/compact/ecal/barrel_sciglass.xml
+++ b/compact/ecal/barrel_sciglass.xml
@@ -44,6 +44,11 @@
                   zmax="EcalBarrelForward_zmax" zmin="-EcalBarrelBackward_zmax"
                   etamin="EcalBarrel_etamin" etamax="EcalBarrel_etamax"/>
 
+      <documentation>
+        Pick the material for the towers
+      </documentation>
+      <material name="SciGlass" />
+
       <comment>
 	The current implementation of the wedge box approximates flat inner
 	surfaces of individual wedge boxes with a single shared tube at a fixed
@@ -111,8 +116,8 @@
 
       <outer_supports>
         <comment>
-	  "EMCal Outer Surface" from the menagerie and tower support before it.
-	  Extra 1.5 cm is supposed to represent the aluminum tower support,
+          "EMCal Outer Surface" from the menagerie and tower support before it.
+          Extra 1.5 cm is supposed to represent the aluminum tower support,
           which is supposed to have a more complicated shape.
         </comment>
         <layer inner_r="129.0 * cm" thickness="(1 * cm) + (1.5 * cm)" material="Aluminum5083" vis="outer_support_aluminum" />

--- a/compact/ecal/forward_homogeneous.xml
+++ b/compact/ecal/forward_homogeneous.xml
@@ -89,4 +89,3 @@
   </plugins>
 
 </lccdd>
-

--- a/compact/ecal/forward_insert_homogeneous.xml
+++ b/compact/ecal/forward_insert_homogeneous.xml
@@ -67,7 +67,7 @@
         <slice material="Air" thickness="EcalEndcapPInsertAirThickness"/>
         <slice material="Fr4" thickness="EcalEndcapPInsertPCBThickness"/>
         <slice material="Plexiglass" thickness="EcalEndcapPInsertLightGuideThickness"/>
-        <slice material="AvgTungstenScFi" thickness="EcalEndcapPInsertScintillatorThickness" sensitive="true"/> 
+        <slice material="AvgTungstenScFi" thickness="EcalEndcapPInsertScintillatorThickness" sensitive="true"/>
       </layer>
       <documentation>
         initial_hole_radius: Hole radius at front of first layer

--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -422,7 +422,7 @@
     <fraction n="0.091" ref="H"/>
     <fraction n="0.822" ref="C"/>
     <fraction n="0.032" ref="N"/>
-    <fraction n="0.055" ref="O"/>   
+    <fraction n="0.055" ref="O"/>
   </material>
   <material name="SciFiPb_PbGlue">
     <D type="density" value="8.558" unit="g / cm3"/>

--- a/compact/optical_materials.xml
+++ b/compact/optical_materials.xml
@@ -830,7 +830,7 @@
       <property name="SCINTILLATIONYIELD1"  value="200.0/MeV"/>
       <property name="SCINTILLATIONTIMECONSTANT1"    value="6.0*ns"/>
       <property name="RESOLUTIONSCALE"     value="1.0"/>
-    </material>        
+    </material>
   </materials>
   <surfaces>
     <opticalsurface finish="polished" model="glisur" name="MirrorOpticalSurface" type="dielectric_metal" value="0">

--- a/configurations/bhcal.yml
+++ b/configurations/bhcal.yml
@@ -1,5 +1,5 @@
 features:
-  solenoid: 
+  solenoid:
   beampipe:
   hcal:
     barrel_gdml:

--- a/src/BarrelCalorimeterSciGlass_geo.cpp
+++ b/src/BarrelCalorimeterSciGlass_geo.cpp
@@ -279,8 +279,8 @@ static Ref_t create_detector(Detector &lcdd, xml_h handle,
                       Transform3D{RotationX{-M_PI / 2 + dir_sign * beta}} *
                       Transform3D{Position{0, dir_sign * y1, z}})
               .addPhysVolID("sector", sector)
-              .addPhysVolID("module", row)
-              .addPhysVolID("slice", tower_id)
+              .addPhysVolID("row", row)
+              .addPhysVolID("tower", tower_id)
               .volume()
               .setSensitiveDetector(sens)
               .setVisAttributes(lcdd.visAttributes(family_dim_handle.visStr()));

--- a/src/BarrelCalorimeterSciGlass_geo.cpp
+++ b/src/BarrelCalorimeterSciGlass_geo.cpp
@@ -35,6 +35,7 @@ static Ref_t create_detector(Detector &lcdd, xml_h handle,
   xml_dim_t sectors_handle = det_handle.child(_Unicode(sectors));
   xml_dim_t rows_handle = sectors_handle.child(_Unicode(rows));
   xml_dim_t dim_handle = rows_handle.dimensions();
+  Material tower_mat = lcdd.material(det_handle.materialStr());
   double row_rmin = dim_handle.inner_r();
   DetElement det_element{det_handle.nameStr(), det_handle.id()};
 
@@ -273,7 +274,7 @@ static Ref_t create_detector(Detector &lcdd, xml_h handle,
                   Volume{t_name,
                          Trap{z, theta, phi, y1, x1, x2, alpha1, y2, x3, x4,
                               alpha2},
-                         lcdd.material("SciGlass")},
+                         tower_mat},
                   Transform3D{RotationZ{-M_PI_2 + sector_phi + row_phi}} *
                       Transform3D{Position{0. * cm, row_rmin, dir_sign * dz}} *
                       Transform3D{RotationX{-M_PI / 2 + dir_sign * beta}} *

--- a/src/BarrelCalorimeterSciGlass_geo.cpp
+++ b/src/BarrelCalorimeterSciGlass_geo.cpp
@@ -412,4 +412,4 @@ static Ref_t create_detector(Detector &lcdd, xml_h handle,
   return det_element;
 }
 
-DECLARE_DETELEMENT(epic_SciGlassCalorimeter, create_detector)
+DECLARE_DETELEMENT(epic_EcalBarrelSciGlass, create_detector)

--- a/src/BarrelCalorimeterSciGlass_geo.cpp
+++ b/src/BarrelCalorimeterSciGlass_geo.cpp
@@ -140,6 +140,8 @@ static Ref_t create_detector(Detector &lcdd, xml_h handle,
     }
   }
 
+  double sector_rmin = envelope_handle.rmin();
+
   if (det_handle.hasChild(_Unicode(wedge_box))) {
     xml_comp_t wedge_box_handle = det_handle.child(_Unicode(wedge_box));
     Material wedge_box_mat = lcdd.material(wedge_box_handle.materialStr());
@@ -175,6 +177,8 @@ static Ref_t create_detector(Detector &lcdd, xml_h handle,
       side_rmax_default
       );
 
+    sector_rmin = side_rmin;
+
     Box wedge_box_side_box_shape{
       (side_rmax - side_rmin) / 2,
       // It would make sense for a shared side to have double thickness, but we seemingly don't have space for that
@@ -208,204 +212,227 @@ static Ref_t create_detector(Detector &lcdd, xml_h handle,
     // TODO: The endcap sides of the box are not implemented
   }
 
-  int sector = 0;
-  double sector_phi = sectors_handle.phi0();
-  for (; sector < sectors_handle.number();
-       sector++, sector_phi += sectors_handle.deltaphi()) {
-    int row = 0;
-    double row_phi = -rows_handle.deltaphi() / 2 * (rows_handle.number() - 1);
-    for (; row < rows_handle.number();
-         row++, row_phi += rows_handle.deltaphi()) {
+  int row = 0;
+  double row_phi = -rows_handle.deltaphi() / 2 * (rows_handle.number() - 1);
 
-      const double tower_gap_longitudinal = dim_handle.gap();
+  Tube sector_tube_shape {
+    sector_rmin,
+    std::min(support_inner_r, envelope_handle.rmax()),
+    (envelope_handle.zmax() - envelope_handle.zmin()) / 2,
+    -rows_handle.deltaphi() / 2 * rows_handle.number(),
+    rows_handle.deltaphi() / 2 * rows_handle.number()
+  };
+  IntersectionSolid sector_shape{
+    envelope_shape,
+    sector_tube_shape,
+    Position{0., 0., (envelope_handle.zmax() + envelope_handle.zmin()) / 2}
+  };
 
-      // negative rapidity towers will be counted backwards from -1
-      std::array<int, 2> tower_ids = {-1, 0};
-      std::array<double, 2> betas = {0., 0.};
-      std::array<double, 2> beta_prevs = {0., 0.};
-      std::array<double, 2> dzs = {0., 0.};
-      std::array<double, 2> flare_angle_polar_prevs = {0., 0.};
+  Volume sector_v{"sector", sector_shape, lcdd.material("Air")};
+  sector_v.setVisAttributes(lcdd.visAttributes(det_handle.visStr()));
 
-      for (xml_coll_t family_handle{rows_handle, _Unicode(family)};
-           family_handle; ++family_handle) {
-        const int dir_sign = family_handle.attr<double>(_Unicode(dir_sign));
-        int &tower_id = tower_ids[(dir_sign > 0) ? 1 : 0];
-        double &beta = betas[(dir_sign > 0) ? 1 : 0];
-        double &beta_prev = beta_prevs[(dir_sign > 0) ? 1 : 0];
-        double &dz = dzs[(dir_sign > 0) ? 1 : 0];
-        double &flare_angle_polar_prev =
-            flare_angle_polar_prevs[(dir_sign > 0) ? 1 : 0];
+  for (; row < rows_handle.number();
+       row++, row_phi += rows_handle.deltaphi()) {
 
-        xml_dim_t family_dim_handle = family_handle;
-        const double length = family_dim_handle.z_length();
-        const auto flare_angle_polar =
-            family_dim_handle.attr<double>(_Unicode(flare_angle_polar));
-        const unsigned int number = family_dim_handle.number();
-        const auto flare_angle_at_face =
-            family_dim_handle.attr<double>(_Unicode(flare_angle_at_face));
+    const double tower_gap_longitudinal = dim_handle.gap();
 
-        const double z = length / 2;
-        const double y1 = family_dim_handle.y1();
-        const double y2 = y1 + length * tan(flare_angle_polar);
-        const double x1 =
-            family_dim_handle.x1() +
-            (dir_sign < 0) * (2 * y1) * tan(flare_angle_at_face);
-        const double x2 =
-            family_dim_handle.x1() +
-            (dir_sign > 0) * (2 * y1) * tan(flare_angle_at_face);
-        const double x3 = x1 * (y2 / y1);
-        const double x4 = x2 * (y2 / y1);
-        const double theta = 0.;
-        const double phi = 0.;
-        const double alpha1 = 0.;
-        const double alpha2 = 0.;
+    // negative rapidity towers will be counted backwards from -1
+    std::array<int, 2> tower_ids = {-1, 0};
+    std::array<double, 2> betas = {0., 0.};
+    std::array<double, 2> beta_prevs = {0., 0.};
+    std::array<double, 2> dzs = {0., 0.};
+    std::array<double, 2> flare_angle_polar_prevs = {0., 0.};
 
-        for (unsigned int tower = 0; tower < number; tower++, tower_id += dir_sign) {
-          // see https://github.com/eic/epic/blob/main/doc/sciglass_tower_stacking.svg
-          beta += flare_angle_polar_prev + flare_angle_polar;
-          const double gamma = M_PI_2 - flare_angle_polar_prev - beta_prev;
+    for (xml_coll_t family_handle{rows_handle, _Unicode(family)};
+         family_handle; ++family_handle) {
+      const int dir_sign = family_handle.attr<double>(_Unicode(dir_sign));
+      int &tower_id = tower_ids[(dir_sign > 0) ? 1 : 0];
+      double &beta = betas[(dir_sign > 0) ? 1 : 0];
+      double &beta_prev = beta_prevs[(dir_sign > 0) ? 1 : 0];
+      double &dz = dzs[(dir_sign > 0) ? 1 : 0];
+      double &flare_angle_polar_prev =
+          flare_angle_polar_prevs[(dir_sign > 0) ? 1 : 0];
 
-          const double dz_prev = dz;
-          dz += (tower_gap_longitudinal / cos(flare_angle_polar) + 2 * y1) *
-                sin(M_PI - gamma - beta) / sin(gamma);
-          const string t_name = _toString(sector, "sector%d") + _toString(row, "_row%d") + _toString(tower_id, "_tower%d");
-          envelope_v
-              .placeVolume(
-                  Volume{t_name,
-                         Trap{z, theta, phi, y1, x1, x2, alpha1, y2, x3, x4,
-                              alpha2},
-                         tower_mat},
-                  Transform3D{RotationZ{-M_PI_2 + sector_phi + row_phi}} *
-                      Transform3D{Position{0. * cm, row_rmin, dir_sign * dz}} *
-                      Transform3D{RotationX{-M_PI / 2 + dir_sign * beta}} *
-                      Transform3D{Position{0, dir_sign * y1, z}})
-              .addPhysVolID("sector", sector)
-              .addPhysVolID("row", row)
-              .addPhysVolID("tower", tower_id)
-              .volume()
-              .setSensitiveDetector(sens)
-              .setVisAttributes(lcdd.visAttributes(family_dim_handle.visStr()));
+      xml_dim_t family_dim_handle = family_handle;
+      const double length = family_dim_handle.z_length();
+      const auto flare_angle_polar =
+          family_dim_handle.attr<double>(_Unicode(flare_angle_polar));
+      const unsigned int number = family_dim_handle.number();
+      const auto flare_angle_at_face =
+          family_dim_handle.attr<double>(_Unicode(flare_angle_at_face));
 
-          if (sectors_handle.hasChild(_Unicode(carbon_fiber_support))) {
-            xml_comp_t carbon_fiber_support_handle = sectors_handle.child(_Unicode(carbon_fiber_support));
-            xml_comp_t cut_out_handle = carbon_fiber_support_handle.child(_Unicode(cut_out));
-            Material carbon_fiber_support_mat = lcdd.material(carbon_fiber_support_handle.materialStr());
+      const double z = length / 2;
+      const double y1 = family_dim_handle.y1();
+      const double y2 = y1 + length * tan(flare_angle_polar);
+      const double x1 =
+          family_dim_handle.x1() +
+          (dir_sign < 0) * (2 * y1) * tan(flare_angle_at_face);
+      const double x2 =
+          family_dim_handle.x1() +
+          (dir_sign > 0) * (2 * y1) * tan(flare_angle_at_face);
+      const double x3 = x1 * (y2 / y1);
+      const double x4 = x2 * (y2 / y1);
+      const double theta = 0.;
+      const double phi = 0.;
+      const double alpha1 = 0.;
+      const double alpha2 = 0.;
 
-            const double margin_horizontal = cut_out_handle.attr<double>(_Unicode(margin_horizontal));
-            const double margin_top = cut_out_handle.attr<double>(_Unicode(margin_top));
-            const double margin_bottom = cut_out_handle.attr<double>(_Unicode(margin_bottom));
-            const double overhang_top = carbon_fiber_support_handle.attr<double>(_Unicode(overhang_top));
-            const double overhang_bottom = carbon_fiber_support_handle.attr<double>(_Unicode(overhang_bottom));
+      for (unsigned int tower = 0; tower < number; tower++, tower_id += dir_sign) {
+        // see https://github.com/eic/epic/blob/main/doc/sciglass_tower_stacking.svg
+        beta += flare_angle_polar_prev + flare_angle_polar;
+        const double gamma = M_PI_2 - flare_angle_polar_prev - beta_prev;
 
-            const double y1_long =
-              y1 + tower_gap_longitudinal / 2 / cos(flare_angle_polar) - overhang_bottom * tan(flare_angle_polar);
-            const double y2_long =
-              y2 + tower_gap_longitudinal / 2 / cos(flare_angle_polar) + overhang_top * tan(flare_angle_polar);
+        const double dz_prev = dz;
+        dz += (tower_gap_longitudinal / cos(flare_angle_polar) + 2 * y1) *
+              sin(M_PI - gamma - beta) / sin(gamma);
+        const string t_name = _toString(row, "_row%d") + _toString(tower_id, "_tower%d");
+        sector_v
+            .placeVolume(
+                Volume{t_name,
+                       Trap{z, theta, phi, y1, x1, x2, alpha1, y2, x3, x4,
+                            alpha2},
+                       tower_mat},
+                Transform3D{RotationZ{-M_PI_2 + row_phi}} *
+                    Transform3D{Position{0. * cm, row_rmin, dir_sign * dz}} *
+                    Transform3D{RotationX{-M_PI / 2 + dir_sign * beta}} *
+                    Transform3D{Position{0, dir_sign * y1, z}})
+            .addPhysVolID("row", row)
+            .addPhysVolID("tower", tower_id)
+            .volume()
+            .setSensitiveDetector(sens)
+            .setVisAttributes(lcdd.visAttributes(family_dim_handle.visStr()));
 
-            Trap trap_long_1{
-              z + (overhang_top + overhang_bottom) / 2,
-              theta,
-              phi,
-              y1_long,
-              carbon_fiber_support_handle.thickness() / 2,
-              carbon_fiber_support_handle.thickness() / 2,
-              alpha1,
-              y2_long,
-              carbon_fiber_support_handle.thickness() / 2,
-              carbon_fiber_support_handle.thickness() / 2,
-              alpha2
-            };
-            Trap trap_long_2{
-              z - (margin_top + margin_bottom) / 2,
-              theta,
-              phi,
-              y1_long - margin_horizontal / 2, // FIXME: y1_long/y2_long do not account for reduction of z by the vertical margins
-              carbon_fiber_support_handle.thickness(), // no division by 2 to ensure subtrahend volume is thicker than the minuend
-              carbon_fiber_support_handle.thickness(),
-              alpha1,
-              y2_long - margin_horizontal / 2,
-              carbon_fiber_support_handle.thickness(),
-              carbon_fiber_support_handle.thickness(),
-              alpha2
-            };
-            SubtractionSolid trap_long{
-              trap_long_1, trap_long_2,
-              Position{0., 0., (margin_bottom - margin_top) / 2}
-            };
+        if (sectors_handle.hasChild(_Unicode(carbon_fiber_support))) {
+          xml_comp_t carbon_fiber_support_handle = sectors_handle.child(_Unicode(carbon_fiber_support));
+          xml_comp_t cut_out_handle = carbon_fiber_support_handle.child(_Unicode(cut_out));
+          Material carbon_fiber_support_mat = lcdd.material(carbon_fiber_support_handle.materialStr());
 
-            for (int side = (row == 0) ? 0 : 1; side <= 1; side++) {
-              envelope_v
-                  .placeVolume(
-                      Volume{"fiber_structure_longitudinal", trap_long, carbon_fiber_support_mat},
-                      Transform3D{RotationZ{-M_PI_2 + sector_phi + row_phi + (2 * side - 1) * rows_handle.deltaphi() / 2}} *
-                      Transform3D{Position{0. * cm, row_rmin, dir_sign * dz}} *
-                      Transform3D{RotationX{-M_PI / 2 + dir_sign * beta}} *
-                      Transform3D{Position{0, dir_sign * y1, z + (overhang_top - overhang_bottom) / 2}})
-                  .volume()
-                  .setVisAttributes(lcdd.visAttributes(carbon_fiber_support_handle.visStr()));
-            }
+          const double margin_horizontal = cut_out_handle.attr<double>(_Unicode(margin_horizontal));
+          const double margin_top = cut_out_handle.attr<double>(_Unicode(margin_top));
+          const double margin_bottom = cut_out_handle.attr<double>(_Unicode(margin_bottom));
+          const double overhang_top = carbon_fiber_support_handle.attr<double>(_Unicode(overhang_top));
+          const double overhang_bottom = carbon_fiber_support_handle.attr<double>(_Unicode(overhang_bottom));
 
-            const double dz_trans = dz_prev
-              + (tower_gap_longitudinal / 2 + carbon_fiber_support_handle.thickness() / 2) / cos(flare_angle_polar)
-              * sin(M_PI - gamma - beta) / sin(gamma);
+          const double y1_long =
+            y1 + tower_gap_longitudinal / 2 / cos(flare_angle_polar) - overhang_bottom * tan(flare_angle_polar);
+          const double y2_long =
+            y2 + tower_gap_longitudinal / 2 / cos(flare_angle_polar) + overhang_top * tan(flare_angle_polar);
 
-            const double non_overlap_long = sin(beta) * (tower_gap_longitudinal / cos(flare_angle_polar) + 2 * y1) / sin(gamma);
+          Trap trap_long_1{
+            z + (overhang_top + overhang_bottom) / 2,
+            theta,
+            phi,
+            y1_long,
+            carbon_fiber_support_handle.thickness() / 4,
+            carbon_fiber_support_handle.thickness() / 4,
+            alpha1,
+            y2_long,
+            carbon_fiber_support_handle.thickness() / 4,
+            carbon_fiber_support_handle.thickness() / 4,
+            alpha2
+          };
+          Trap trap_long_2{
+            z - (margin_top + margin_bottom) / 2,
+            theta,
+            phi,
+            y1_long - margin_horizontal / 2, // FIXME: y1_long/y2_long do not account for reduction of z by the vertical margins
+            carbon_fiber_support_handle.thickness(), // no division by 2 to ensure subtrahend volume is thicker than the minuend
+            carbon_fiber_support_handle.thickness(),
+            alpha1,
+            y2_long - margin_horizontal / 2,
+            carbon_fiber_support_handle.thickness(),
+            carbon_fiber_support_handle.thickness(),
+            alpha2
+          };
+          SubtractionSolid trap_long{
+            trap_long_1, trap_long_2,
+            Position{0., 0., (margin_bottom - margin_top) / 2}
+          };
 
-            const double beta_trans = beta_prev + flare_angle_polar_prev;
-            const double x1_trans =
-              tan(rows_handle.deltaphi() / 2) * (row_rmin - overhang_bottom * cos(beta_trans))
-              - carbon_fiber_support_handle.thickness() / 2 / cos(rows_handle.deltaphi() / 2);
-            const double x2_trans =
-              tan(rows_handle.deltaphi() / 2) * (row_rmin + (2 * z + overhang_top + non_overlap_long) * cos(beta_trans))
-              - carbon_fiber_support_handle.thickness() / 2 / cos(rows_handle.deltaphi() / 2);
-
-            Trap trap_trans_1 {
-              z + (overhang_top + non_overlap_long + overhang_bottom) / 2,
-              theta,
-              phi,
-              carbon_fiber_support_handle.thickness() / 2,
-              x1_trans,
-              x1_trans,
-              alpha1,
-              carbon_fiber_support_handle.thickness() / 2,
-              x2_trans,
-              x2_trans,
-              alpha2
-            };
-            Trap trap_trans_2{
-              z - (margin_top + non_overlap_long + margin_bottom) / 2,
-              theta,
-              phi,
-              carbon_fiber_support_handle.thickness(), // no division by 2 to ensure subtrahend volume is thicker than the minuend
-              x1_trans - margin_horizontal / 2, // FIXME: x1_trans/x2_trans do not account for reduction of z by the vertical margins
-              x1_trans - margin_horizontal / 2,
-              alpha1,
-              carbon_fiber_support_handle.thickness(),
-              x2_trans - margin_horizontal / 2,
-              x2_trans - margin_horizontal / 2,
-              alpha2
-            };
-            SubtractionSolid trap_trans{
-              trap_trans_1, trap_trans_2,
-              Position{0., 0., (margin_bottom - margin_top) / 2 + (overhang_bottom - overhang_top) / 2}
-            };
-
-            envelope_v
+          for (int side = -1; side <= 1; side += 2) {
+            sector_v
                 .placeVolume(
-                    Volume{"fiber_structure_transverse" + t_name, trap_trans, carbon_fiber_support_mat},
-                    Transform3D{RotationZ{-M_PI_2 + sector_phi + row_phi}} *
-                    Transform3D{Position{0. * cm, row_rmin, dir_sign * dz_trans}} *
-                    Transform3D{RotationX{-M_PI / 2 + dir_sign * beta_trans}} *
-                    Transform3D{Position{0, dir_sign * carbon_fiber_support_handle.thickness() / 2, z + (overhang_top + non_overlap_long - overhang_bottom) / 2}})
+                    Volume{"fiber_structure_longitudinal", trap_long, carbon_fiber_support_mat},
+                    Transform3D{RotationZ{-M_PI_2 + row_phi + side * rows_handle.deltaphi() / 2}} *
+                    Transform3D{Position{0. * cm, row_rmin, dir_sign * dz}} *
+                    Transform3D{RotationX{-M_PI / 2 + dir_sign * beta}} *
+                    Transform3D{Position{side * carbon_fiber_support_handle.thickness() / 4, dir_sign * y1, z + (overhang_top - overhang_bottom) / 2}})
                 .volume()
                 .setVisAttributes(lcdd.visAttributes(carbon_fiber_support_handle.visStr()));
           }
 
-          beta_prev = beta;
-          flare_angle_polar_prev = flare_angle_polar;
+          const double dz_trans = dz_prev
+            + (tower_gap_longitudinal / 2 + carbon_fiber_support_handle.thickness() / 2) / cos(flare_angle_polar)
+            * sin(M_PI - gamma - beta) / sin(gamma);
+
+          const double non_overlap_long = sin(beta) * (tower_gap_longitudinal / cos(flare_angle_polar) + 2 * y1) / sin(gamma);
+
+          const double beta_trans = beta_prev + flare_angle_polar_prev;
+          const double x1_trans =
+            tan(rows_handle.deltaphi() / 2) * (row_rmin - overhang_bottom * cos(beta_trans))
+            - carbon_fiber_support_handle.thickness() / 2 / cos(rows_handle.deltaphi() / 2);
+          const double x2_trans =
+            tan(rows_handle.deltaphi() / 2) * (row_rmin + (2 * z + overhang_top + non_overlap_long) * cos(beta_trans))
+            - carbon_fiber_support_handle.thickness() / 2 / cos(rows_handle.deltaphi() / 2);
+
+          Trap trap_trans_1 {
+            z + (overhang_top + non_overlap_long + overhang_bottom) / 2,
+            theta,
+            phi,
+            carbon_fiber_support_handle.thickness() / 2,
+            x1_trans,
+            x1_trans,
+            alpha1,
+            carbon_fiber_support_handle.thickness() / 2,
+            x2_trans,
+            x2_trans,
+            alpha2
+          };
+          Trap trap_trans_2{
+            z - (margin_top + non_overlap_long + margin_bottom) / 2,
+            theta,
+            phi,
+            carbon_fiber_support_handle.thickness(), // no division by 2 to ensure subtrahend volume is thicker than the minuend
+            x1_trans - margin_horizontal / 2, // FIXME: x1_trans/x2_trans do not account for reduction of z by the vertical margins
+            x1_trans - margin_horizontal / 2,
+            alpha1,
+            carbon_fiber_support_handle.thickness(),
+            x2_trans - margin_horizontal / 2,
+            x2_trans - margin_horizontal / 2,
+            alpha2
+          };
+          SubtractionSolid trap_trans{
+            trap_trans_1, trap_trans_2,
+            Position{0., 0., (margin_bottom - margin_top) / 2 + (overhang_bottom - overhang_top) / 2}
+          };
+
+          sector_v
+              .placeVolume(
+                  Volume{"fiber_structure_transverse" + t_name, trap_trans, carbon_fiber_support_mat},
+                  Transform3D{RotationZ{-M_PI_2 + row_phi}} *
+                  Transform3D{Position{0. * cm, row_rmin, dir_sign * dz_trans}} *
+                  Transform3D{RotationX{-M_PI / 2 + dir_sign * beta_trans}} *
+                  Transform3D{Position{0, dir_sign * carbon_fiber_support_handle.thickness() / 2, z + (overhang_top + non_overlap_long - overhang_bottom) / 2}})
+              .volume()
+              .setVisAttributes(lcdd.visAttributes(carbon_fiber_support_handle.visStr()));
         }
+
+        beta_prev = beta;
+        flare_angle_polar_prev = flare_angle_polar;
       }
     }
+  }
+
+  int sector = 0;
+  double sector_phi = sectors_handle.phi0();
+  for (; sector < sectors_handle.number();
+       sector++, sector_phi += sectors_handle.deltaphi()) {
+    envelope_v
+        .placeVolume(
+          sector_v,
+          Transform3D{RotationZ{sector_phi}}
+          )
+        .addPhysVolID("sector", sector);
   }
 
   envelope_v.setVisAttributes(lcdd.visAttributes(det_handle.visStr()));

--- a/src/BarrelHCalCalorimeter_geo.cpp
+++ b/src/BarrelHCalCalorimeter_geo.cpp
@@ -35,22 +35,22 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   Material      air               = description.air();
 
   // get the solids section for this detector
-  xml_comp_t    x_solids         = x_det.child("solids"); 
+  xml_comp_t    x_solids         = x_det.child("solids");
 
   DetElement       sdet(det_name, det_id);
   Volume           motherVol = description.pickMotherVolume(sdet);
 
-  // Create envelope to hold HCAL barrel 
+  // Create envelope to hold HCAL barrel
 
-  double rmin1 = x_det.rmin1(); 
-  double rmin2 = x_det.rmin2(); 
-  double rmax = x_det.rmax(); 
-  double length1 = x_det.z1(); 
+  double rmin1 = x_det.rmin1();
+  double rmin2 = x_det.rmin2();
+  double rmax = x_det.rmax();
+  double length1 = x_det.z1();
   double length2 = x_det.z2();
-  
-  std::vector<double> rmins = {rmin2,rmin2,rmin1,rmin1,rmin2,rmin2}; 
-  std::vector<double> rmaxs = {rmax,rmax,rmax,rmax,rmax,rmax};  
-  std::vector<double> zs = {-length2/2.,-length1/2.,-length1/2.,length1/2.,length1/2.,length2/2.};  
+
+  std::vector<double> rmins = {rmin2,rmin2,rmin1,rmin1,rmin2,rmin2};
+  std::vector<double> rmaxs = {rmax,rmax,rmax,rmax,rmax,rmax};
+  std::vector<double> zs = {-length2/2.,-length1/2.,-length1/2.,length1/2.,length1/2.,length2/2.};
 
   //printout(WARNING, "BarrelHCalCalorimeter", "%f %f %f %f %f", rmin1, rmin2, rmax, length1/2., length2/2.);
 
@@ -64,33 +64,33 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   sdet.setPlacement(env_phv);
 
   // Storage for sectors and tile assemblies
-  Assembly      ChimneySector("ChimneySector"); 
-  Assembly      Sector("Sector"); 
-  Assembly      ChimneyTower[4]; 
-  Assembly      Tower[24]; 
+  Assembly      ChimneySector("ChimneySector");
+  Assembly      Sector("Sector");
+  Assembly      ChimneyTower[4];
+  Assembly      Tower[24];
 
   xml_comp_t    det_define           = x_det.child("define");
 
   // Pick up the constants
 
-  double ctilePlaneRotate = 0.0; 
-  double tilePlaneRotate = 0.0; 
-  double csectorRotate = 0.0; 
-  double sectorRotate = 0.0; 
+  double ctilePlaneRotate = 0.0;
+  double tilePlaneRotate = 0.0;
+  double csectorRotate = 0.0;
+  double sectorRotate = 0.0;
 
-  double tile_tolerance = 0.2; // Tile tolerance in mm to avoid overlaps 
+  double tile_tolerance = 0.2; // Tile tolerance in mm to avoid overlaps
 
   // Tile rotation starting points to align with sector plates
   double ctileRotateStart  = 5.4420*(360.0/320.0)*dd4hep::deg;
   double octileRotateStart = 5.4420*(360.0/320.0)*dd4hep::deg;
-  //double tileRotateStart  = 20.38875*(360.0/320.0)*dd4hep::deg + ctileRotateStart; 
-  double tileRotateStart  = 20.38675*(360.0/320.0)*dd4hep::deg + ctileRotateStart; 
+  //double tileRotateStart  = 20.38875*(360.0/320.0)*dd4hep::deg + ctileRotateStart;
+  double tileRotateStart  = 20.38675*(360.0/320.0)*dd4hep::deg + ctileRotateStart;
 
   for(xml_coll_t i(det_define, _Unicode(constant)); i; ++i){
-    xml_comp_t  x_const = i; 
+    xml_comp_t  x_const = i;
 
-    std::string   const_name      = getAttrOrDefault<std::string>(x_const, _Unicode(name), " "); 
-    std::string   const_value     = getAttrOrDefault<std::string>(x_const, _Unicode(value), " "); 
+    std::string   const_name      = getAttrOrDefault<std::string>(x_const, _Unicode(name), " ");
+    std::string   const_value     = getAttrOrDefault<std::string>(x_const, _Unicode(value), " ");
 
     if(const_name == "ctilePlaneRotate")
       ctilePlaneRotate = atof(const_value.c_str());
@@ -108,108 +108,108 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
   // Loop over the defines section and pick up the tile offsets
 
-  std::vector<double> xposOuter; 
-  std::vector<double> yposOuter; 
+  std::vector<double> xposOuter;
+  std::vector<double> yposOuter;
 
-  std::vector<double> xposTileS; 
-  std::vector<double> yposTileS; 
-  std::vector<double> zposTileS; 
+  std::vector<double> xposTileS;
+  std::vector<double> yposTileS;
+  std::vector<double> zposTileS;
 
-  std::vector<double> xposTileN; 
-  std::vector<double> yposTileN; 
-  std::vector<double> zposTileN; 
+  std::vector<double> xposTileN;
+  std::vector<double> yposTileN;
+  std::vector<double> zposTileN;
 
-  std::vector<double> xposChimneyTileS; 
-  std::vector<double> yposChimneyTileS; 
-  std::vector<double> zposChimneyTileS; 
+  std::vector<double> xposChimneyTileS;
+  std::vector<double> yposChimneyTileS;
+  std::vector<double> zposChimneyTileS;
 
-  std::vector<double> plates_x; 
-  std::vector<double> plates_y; 
-  std::vector<double> plates_z; 
+  std::vector<double> plates_x;
+  std::vector<double> plates_y;
+  std::vector<double> plates_z;
 
-  std::vector<double> tweak_tiles; 
-  std::vector<double> tweak_chimney_tiles; 
-  std::vector<double> tweak_sectors; 
+  std::vector<double> tweak_tiles;
+  std::vector<double> tweak_chimney_tiles;
+  std::vector<double> tweak_sectors;
 
   for(xml_coll_t i(det_define, _Unicode(matrix)); i; ++i){
-    xml_comp_t  x_mtrx = i; 
+    xml_comp_t  x_mtrx = i;
 
-    std::string   mtrx_name       = getAttrOrDefault<std::string>(x_mtrx, _Unicode(name), " "); 
-    std::string   mtrx_values     = getAttrOrDefault<std::string>(x_mtrx, _Unicode(values), " "); 
+    std::string   mtrx_name       = getAttrOrDefault<std::string>(x_mtrx, _Unicode(name), " ");
+    std::string   mtrx_values     = getAttrOrDefault<std::string>(x_mtrx, _Unicode(values), " ");
 
-    std::vector<double> *aptr = NULL; 
+    std::vector<double> *aptr = NULL;
 
-    if(mtrx_name == "xposOuter") 
-      aptr = &xposOuter; 
-    else if(mtrx_name == "yposOuter") 
+    if(mtrx_name == "xposOuter")
+      aptr = &xposOuter;
+    else if(mtrx_name == "yposOuter")
       aptr = &yposOuter;
-    else if(mtrx_name == "xposTileS") 
+    else if(mtrx_name == "xposTileS")
       aptr = &xposTileS;
-    else if(mtrx_name == "yposTileS") 
+    else if(mtrx_name == "yposTileS")
       aptr = &yposTileS;
-    else if(mtrx_name == "zposTileS") 
+    else if(mtrx_name == "zposTileS")
       aptr = &zposTileS;
-    else if(mtrx_name == "xposTileN") 
+    else if(mtrx_name == "xposTileN")
       aptr = &xposTileN;
-    else if(mtrx_name == "yposTileN") 
+    else if(mtrx_name == "yposTileN")
       aptr = &yposTileN;
-    else if(mtrx_name == "zposTileN") 
+    else if(mtrx_name == "zposTileN")
       aptr = &zposTileN;
-    else if(mtrx_name == "xposChimneyTileS") 
+    else if(mtrx_name == "xposChimneyTileS")
       aptr = &xposChimneyTileS;
-    else if(mtrx_name == "yposChimneyTileS") 
+    else if(mtrx_name == "yposChimneyTileS")
       aptr = &yposChimneyTileS;
-    else if(mtrx_name == "zposChimneyTileS") 
+    else if(mtrx_name == "zposChimneyTileS")
       aptr = &zposChimneyTileS;
-    else if(mtrx_name == "plates_x") 
+    else if(mtrx_name == "plates_x")
       aptr = &plates_x;
-    else if(mtrx_name == "plates_y") 
+    else if(mtrx_name == "plates_y")
       aptr = &plates_y;
-    else if(mtrx_name == "plates_z") 
+    else if(mtrx_name == "plates_z")
       aptr = &plates_z;
-    else if(mtrx_name == "tweak_tiles") 
+    else if(mtrx_name == "tweak_tiles")
       aptr = &tweak_tiles;
-    else if(mtrx_name == "tweak_chimney_tiles") 
+    else if(mtrx_name == "tweak_chimney_tiles")
       aptr = &tweak_chimney_tiles;
-    else if(mtrx_name == "tweak_sectors") 
+    else if(mtrx_name == "tweak_sectors")
       aptr = &tweak_sectors;
     else{
       printout(WARNING, "BarrelHCalCalorimeter", "unknown <matrix> data!");
       continue;
     }
-      
-    std::string delimiter = " "; 
+
+    std::string delimiter = " ";
     size_t pos = 0;
     std::string token;
     while ((pos = mtrx_values.find(delimiter)) != std::string::npos) {
       token = mtrx_values.substr(0, pos);
-      aptr->push_back(atof(token.c_str())); 
+      aptr->push_back(atof(token.c_str()));
       mtrx_values.erase(0, pos + delimiter.length());
     }
-    aptr->push_back(atof(mtrx_values.c_str())); 
+    aptr->push_back(atof(mtrx_values.c_str()));
 
   }
 
   // Loop over the solids, create them and add them to the detector volume
 
   for(xml_coll_t k(x_solids, _Unicode(solid)); k; ++k){
-    
-    xml_comp_t    x_solid = k; 
+
+    xml_comp_t    x_solid = k;
 
     // get the sector solid definitions
     xml_comp_t    define           = x_solid.child("define");
-    xml_comp_t    tessellated      = x_solid.child("tessellated"); 
+    xml_comp_t    tessellated      = x_solid.child("tessellated");
 
-    std::string   solid_name       = getAttrOrDefault<std::string>(x_solid, _Unicode(name), " "); 
-    std::string   solidMatString   = getAttrOrDefault<std::string>(x_solid, _Unicode(material), " "); 
-    Material      solid_material   = description.material(solidMatString); 
+    std::string   solid_name       = getAttrOrDefault<std::string>(x_solid, _Unicode(name), " ");
+    std::string   solidMatString   = getAttrOrDefault<std::string>(x_solid, _Unicode(material), " ");
+    Material      solid_material   = description.material(solidMatString);
 
-    double offset_x = atof(getAttrOrDefault<std::string>(x_solid, _Unicode(x), "0").c_str())*dd4hep::mm; 
-    double offset_y = atof(getAttrOrDefault<std::string>(x_solid, _Unicode(y), "0").c_str())*dd4hep::mm; 
-    double offset_z = atof(getAttrOrDefault<std::string>(x_solid, _Unicode(z), "0").c_str())*dd4hep::mm; 
+    double offset_x = atof(getAttrOrDefault<std::string>(x_solid, _Unicode(x), "0").c_str())*dd4hep::mm;
+    double offset_y = atof(getAttrOrDefault<std::string>(x_solid, _Unicode(y), "0").c_str())*dd4hep::mm;
+    double offset_z = atof(getAttrOrDefault<std::string>(x_solid, _Unicode(z), "0").c_str())*dd4hep::mm;
 
     // Get the vertices
-    std::vector<Tessellated::Vertex_t> vertices; 
+    std::vector<Tessellated::Vertex_t> vertices;
     for(xml_coll_t j(define, _Unicode(position)); j; ++j){
       xml_comp_t pos = j;
 
@@ -217,51 +217,51 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
       double xp = atof(getAttrOrDefault<std::string>(pos, _Unicode(x), "0").c_str())*dd4hep::mm - offset_x;
       double yp = atof(getAttrOrDefault<std::string>(pos, _Unicode(y), "0").c_str())*dd4hep::mm - offset_y;
-      double zp = atof(getAttrOrDefault<std::string>(pos, _Unicode(z), "0").c_str())*dd4hep::mm - offset_z; 
+      double zp = atof(getAttrOrDefault<std::string>(pos, _Unicode(z), "0").c_str())*dd4hep::mm - offset_z;
 
-      // for the sector plates  we perform a rotation around y - the chimney cutout should be in the 
-      // electron arm 
+      // for the sector plates  we perform a rotation around y - the chimney cutout should be in the
+      // electron arm
 
       if( (solid_name == "HCAL_Chimney_Sector_Half_Plate") ||
 	  (solid_name == "HCAL_Chimney_Sector_Plate") ||
 	  (solid_name == "HCAL_Sector_Half_Plate") ||
 	  (solid_name == "HCAL_Sector_Plate") ){
 	xp = -xp;
-	zp = -zp; 
+	zp = -zp;
       }
-       
-      Tessellated::Vertex_t thisPoint(xp,yp,zp); 
-    
+
+      Tessellated::Vertex_t thisPoint(xp,yp,zp);
+
       vertices.push_back(thisPoint);
 
     }
-    
+
     TessellatedSolid solid(solid_name.c_str(),vertices);
 
     for(xml_coll_t i(tessellated, _Unicode(triangular)); i; ++i){
-      xml_comp_t triang = i; 
+      xml_comp_t triang = i;
 
-      int vtx1 = -1; 
-      int vtx2 = -1; 
-      int vtx3 = -1; 
+      int vtx1 = -1;
+      int vtx2 = -1;
+      int vtx3 = -1;
 
-      std::string facetName1 = getAttrOrDefault<std::string>(triang, _Unicode(vertex1), " "); 
-      std::string facetName2 = getAttrOrDefault<std::string>(triang, _Unicode(vertex2), " "); 
-      std::string facetName3 = getAttrOrDefault<std::string>(triang, _Unicode(vertex3), " "); 
-      
+      std::string facetName1 = getAttrOrDefault<std::string>(triang, _Unicode(vertex1), " ");
+      std::string facetName2 = getAttrOrDefault<std::string>(triang, _Unicode(vertex2), " ");
+      std::string facetName3 = getAttrOrDefault<std::string>(triang, _Unicode(vertex3), " ");
+
       // Search the define collection to match things up
-      int idx = 0; 
+      int idx = 0;
       for(xml_coll_t j(define, _Unicode(position)); j; ++j){
 	xml_comp_t pos = j;
-	std::string posName = getAttrOrDefault<std::string>(pos, _Unicode(name), " "); 
+	std::string posName = getAttrOrDefault<std::string>(pos, _Unicode(name), " ");
 
-	if( posName == facetName1 ) vtx1 = idx; 
-	if( posName == facetName2 ) vtx2 = idx; 
-	if( posName == facetName3 ) vtx3 = idx; 
-      
-	if( (vtx1>=0) && (vtx2>=0) && (vtx3>=0) ) break; 
+	if( posName == facetName1 ) vtx1 = idx;
+	if( posName == facetName2 ) vtx2 = idx;
+	if( posName == facetName3 ) vtx3 = idx;
 
-	idx++; 
+	if( (vtx1>=0) && (vtx2>=0) && (vtx3>=0) ) break;
+
+	idx++;
 
       }
 
@@ -269,8 +269,8 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
       if( (vtx1>=0) && (vtx2>=0) && (vtx3>=0) && (vtx1!=vtx2) && (vtx1!=vtx3) && (vtx2!=vtx3) ){
 
-	solid->AddFacet(vtx1,vtx2,vtx3); 
-	
+	solid->AddFacet(vtx1,vtx2,vtx3);
+
       }
       else
 	printout(WARNING, "BarrelHCalCalorimeter", "bad facet! %d %d %d", vtx1, vtx2, vtx3);
@@ -278,7 +278,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
     }
 
     // Complete the shape
-    solid->CloseShape(true,true,true); 
+    solid->CloseShape(true,true,true);
 
     Volume           solidVolume(solid_name, solid, solid_material);
     solidVolume.setVisAttributes(description, x_det.visStr());
@@ -287,40 +287,40 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
     if(solid_name == "HCAL_Chimney_Sector_Half_Plate"){
 
-      ChimneySector.placeVolume(solidVolume, 0, 
+      ChimneySector.placeVolume(solidVolume, 0,
       			RotationZ(csectorRotate*dd4hep::deg)*Transform3D(RotationZ(0.0), Translation3D(plates_x[0]*dd4hep::mm, plates_y[0]*dd4hep::mm, plates_z[0]*dd4hep::mm) ));
- 
-      ChimneySector.placeVolume(solidVolume, 1, 
+
+      ChimneySector.placeVolume(solidVolume, 1,
       				RotationZ((9.60*2*M_PI / 320) + csectorRotate*dd4hep::deg)*Transform3D(RotationZ(0.0), Translation3D(plates_x[0]*dd4hep::mm, plates_y[0]*dd4hep::mm, plates_z[0]*dd4hep::mm) ));
- 
+
     }
     else if(solid_name == "HCAL_Chimney_Sector_Plate"){
 
       for(int i=0; i<9; i++)
-        ChimneySector.placeVolume(solidVolume, i, 
+        ChimneySector.placeVolume(solidVolume, i,
       			  RotationZ((i*2*M_PI / 320) + csectorRotate*dd4hep::deg)*Transform3D(RotationZ(0.0), Translation3D(plates_x[1]*dd4hep::mm, plates_y[1]*dd4hep::mm, plates_z[1]*dd4hep::mm) ));
-    
+
     }
     else if(solid_name == "HCAL_Sector_Half_Plate"){
 
-      Sector.placeVolume(solidVolume, 0, 
+      Sector.placeVolume(solidVolume, 0,
 			 RotationZ(sectorRotate*dd4hep::deg)*Transform3D(RotationZ(0.4*dd4hep::deg), Translation3D(plates_x[2]*dd4hep::mm, plates_y[2]*dd4hep::mm, plates_z[2]*dd4hep::mm) ));
- 
-      Sector.placeVolume(solidVolume, 1, 
+
+      Sector.placeVolume(solidVolume, 1,
       	 RotationZ((9.60*2*M_PI / 320) + sectorRotate*dd4hep::deg)*Transform3D(RotationZ(0.4*dd4hep::deg), Translation3D(plates_x[2]*dd4hep::mm, plates_y[2]*dd4hep::mm, plates_z[2]*dd4hep::mm) ));
 
     }
     else if(solid_name == "HCAL_Sector_Plate"){
 
       for(int i=0; i<9; i++)
-        Sector.placeVolume(solidVolume, i, 
+        Sector.placeVolume(solidVolume, i,
            RotationZ((i*2*M_PI / 320) + sectorRotate*dd4hep::deg)*Transform3D(RotationZ(0.4*dd4hep::deg), Translation3D(plates_x[3]*dd4hep::mm, plates_y[3]*dd4hep::mm, plates_z[3]*dd4hep::mm) ));
 
     }
     else{
 
       // If it's not sectors then it's a tile - for these we build an assembly to get the full array of tiles
-      // Offsets and rotation are to properly orient the tiles in the assembly. 
+      // Offsets and rotation are to properly orient the tiles in the assembly.
 
       if(solid_name.size()>0){
 
@@ -329,42 +329,42 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 	if( type=="OuterHCalTile" || type=="OuterHCalChimneyTile" ){
 
 	  std::string stnum = solid_name.substr(solid_name.size()-2,solid_name.size());
-	  int tnum = atoi(stnum.c_str())-1; 
-	  
-	  Assembly TempTower1(_toString(11-tnum,"Tower%i")); 
+	  int tnum = atoi(stnum.c_str())-1;
+
+	  Assembly TempTower1(_toString(11-tnum,"Tower%i"));
 	  Assembly TempTower2(_toString(12+tnum,"Tower%i"));
 
-	  solidVolume.setSensitiveDetector(sens); 
+	  solidVolume.setSensitiveDetector(sens);
 
 	  DetElement tile_det("tile0", det_id);
 
 	  if(type=="OuterHCalTile"){
 
-	    Tower[11-tnum] = TempTower1; 
-	    Tower[12+tnum] = TempTower2; 
+	    Tower[11-tnum] = TempTower1;
+	    Tower[12+tnum] = TempTower2;
 
-	    for(int i=0; i<5; i++){ 
- 
+	    for(int i=0; i<5; i++){
+
 	      if(tnum<8){
 
 		PlacedVolume phv0 = Tower[11-tnum].placeVolume(solidVolume,i,RotationZ(octileRotateStart + i*(360.0/320.0)*dd4hep::deg)*
 							       Transform3D(RotationY(90.0*dd4hep::deg), Translation3D(xposOuter[0]*dd4hep::mm, yposOuter[0]*dd4hep::mm, 0.0))*
-							       RotationX(-tilePlaneRotate*dd4hep::deg)*Transform3D(RotationY(0.0), 
-														   Translation3D((xposTileS[tnum]+(tnum+1)*tile_tolerance)*dd4hep::mm, 
+							       RotationX(-tilePlaneRotate*dd4hep::deg)*Transform3D(RotationY(0.0),
+														   Translation3D((xposTileS[tnum]+(tnum+1)*tile_tolerance)*dd4hep::mm,
 																 yposTileS[tnum]*dd4hep::mm, zposTileS[tnum]*dd4hep::mm) ));
 
 		phv0.addPhysVolID("tile", i + (11-tnum)*10);
-		DetElement sd0 = tile_det.clone(_toString(i + (11-tnum)*10, "tile%d")); 
+		DetElement sd0 = tile_det.clone(_toString(i + (11-tnum)*10, "tile%d"));
 		sd0.setPlacement(phv0);
 		sdet.add(sd0);
 
 		PlacedVolume phv1 = Tower[12+tnum].placeVolume(solidVolume,i+5,RotationZ(octileRotateStart + i*(360.0/320.0)*dd4hep::deg)*
 							       Transform3D(RotationY(90.0*dd4hep::deg), Translation3D(xposOuter[0]*dd4hep::mm, yposOuter[0]*dd4hep::mm, 0.0))*
-							       RotationX(-tilePlaneRotate*dd4hep::deg)*Transform3D(RotationY(180.0*dd4hep::deg), 
-														   Translation3D((xposTileN[tnum]-(tnum+1)*tile_tolerance)*dd4hep::mm, 
+							       RotationX(-tilePlaneRotate*dd4hep::deg)*Transform3D(RotationY(180.0*dd4hep::deg),
+														   Translation3D((xposTileN[tnum]-(tnum+1)*tile_tolerance)*dd4hep::mm,
 																 yposTileN[tnum]*dd4hep::mm, zposTileN[tnum]*dd4hep::mm) ));
 		phv1.addPhysVolID("tile", i+5 + (12+tnum)*10);
-		DetElement sd1 = tile_det.clone(_toString(i+5+(12+tnum)*10, "tile%d")); 
+		DetElement sd1 = tile_det.clone(_toString(i+5+(12+tnum)*10, "tile%d"));
 		sd1.setPlacement(phv1);
 		sdet.add(sd1);
 
@@ -374,27 +374,27 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
 		PlacedVolume phv0 = Tower[11-tnum].placeVolume(solidVolume,i,RotationZ(octileRotateStart + i*(360.0/320.0)*dd4hep::deg)*
 							       Transform3D(RotationY(90.0*dd4hep::deg), Translation3D(xposOuter[0]*dd4hep::mm, yposOuter[0]*dd4hep::mm, 0.0))*
-							       RotationX(-tilePlaneRotate*dd4hep::deg)*Transform3D(RotationY(180.0*dd4hep::deg), 
-														   Translation3D((xposTileS[tnum]+(tnum+1)*tile_tolerance)*dd4hep::mm, 
+							       RotationX(-tilePlaneRotate*dd4hep::deg)*Transform3D(RotationY(180.0*dd4hep::deg),
+														   Translation3D((xposTileS[tnum]+(tnum+1)*tile_tolerance)*dd4hep::mm,
 																 yposTileS[tnum]*dd4hep::mm, zposTileS[tnum]*dd4hep::mm) ));
 
 		phv0.addPhysVolID("tile", i + (11-tnum)*10);
-		DetElement sd0 = tile_det.clone(_toString(i + (11-tnum)*10, "tile%d")); 
+		DetElement sd0 = tile_det.clone(_toString(i + (11-tnum)*10, "tile%d"));
 		sd0.setPlacement(phv0);
 		sdet.add(sd0);
 
 		PlacedVolume phv1 = Tower[12+tnum].placeVolume(solidVolume,i+5,RotationZ(octileRotateStart + i*(360.0/320.0)*dd4hep::deg)*
 							       Transform3D(RotationY(90.0*dd4hep::deg), Translation3D(xposOuter[0]*dd4hep::mm, yposOuter[0]*dd4hep::mm, 0.0))*
-							       RotationX(-tilePlaneRotate*dd4hep::deg)*Transform3D(RotationY(0.0), 
-														   Translation3D((xposTileN[tnum]-(tnum+1)*tile_tolerance)*dd4hep::mm, 
+							       RotationX(-tilePlaneRotate*dd4hep::deg)*Transform3D(RotationY(0.0),
+														   Translation3D((xposTileN[tnum]-(tnum+1)*tile_tolerance)*dd4hep::mm,
 																 yposTileN[tnum]*dd4hep::mm, zposTileN[tnum]*dd4hep::mm) ));
 		phv1.addPhysVolID("tile", i+5 + (12+tnum)*10);
-		DetElement sd1 = tile_det.clone(_toString(i+5+(12+tnum)*10, "tile%d")); 
+		DetElement sd1 = tile_det.clone(_toString(i+5+(12+tnum)*10, "tile%d"));
 		sd1.setPlacement(phv1);
 		sdet.add(sd1);
 
 	      }
-	      
+
 
 	    }
 
@@ -402,19 +402,19 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
 	  if((tnum>7) && (type=="OuterHCalChimneyTile") ){
 
-	    Assembly TempChimneyTower1(_toString(11-tnum,"ChimneyTower%i")); 
+	    Assembly TempChimneyTower1(_toString(11-tnum,"ChimneyTower%i"));
 	    ChimneyTower[11-tnum] = TempChimneyTower1;
 
-	    for(int i=0; i<5; i++){ 
+	    for(int i=0; i<5; i++){
 
 	      PlacedVolume phv = ChimneyTower[11-tnum].placeVolume(solidVolume,i,RotationZ(ctileRotateStart + i*(360.0/320.0)*dd4hep::deg)*
 						Transform3D(RotationY(90.0*dd4hep::deg), Translation3D(xposOuter[0]*dd4hep::mm, yposOuter[0]*dd4hep::mm, 0.0))*
-						RotationX(-ctilePlaneRotate*dd4hep::deg)*Transform3D(RotationY(0.0), 
-												     Translation3D((xposChimneyTileS[tnum-8]+(tnum+1)*tile_tolerance)*dd4hep::mm, 
-														   yposChimneyTileS[tnum-8]*dd4hep::mm, 
+						RotationX(-ctilePlaneRotate*dd4hep::deg)*Transform3D(RotationY(0.0),
+												     Translation3D((xposChimneyTileS[tnum-8]+(tnum+1)*tile_tolerance)*dd4hep::mm,
+														   yposChimneyTileS[tnum-8]*dd4hep::mm,
 														   zposChimneyTileS[tnum-8]*dd4hep::mm) ));
 	      phv.addPhysVolID("tile", i+ (11-tnum)*10 + 480);
-	      DetElement sd = tile_det.clone(_toString(i + (11-tnum)*10 + 480, "tile%d")); 
+	      DetElement sd = tile_det.clone(_toString(i + (11-tnum)*10 + 480, "tile%d"));
 	      sd.setPlacement(phv);
 	      sdet.add(sd);
 
@@ -423,7 +423,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 	  }
 
 	}
-	else	 
+	else
           printout(WARNING, "BarrelHCalCalorimeter", "invalid solid_name, not a tile type?");
 
       }
@@ -442,67 +442,67 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   DetElement tower_det("tower0", det_id);
 
   // special chimney sector towers
-  for(int i=0; i<4; i++){ 
+  for(int i=0; i<4; i++){
 
     PlacedVolume     tower_phv0 = ChimneySector.placeVolume(ChimneyTower[i], i, Transform3D(RotationZ(tweak_chimney_tiles[i]), Translation3D(0.0,0.0,0.0)) );
     tower_phv0.addPhysVolID("tower", i);
-    DetElement sd0 = tower_det.clone(_toString(i, "tower%d")); 
+    DetElement sd0 = tower_det.clone(_toString(i, "tower%d"));
     sd0.setPlacement(tower_phv0);
     sdet.add(sd0);
 
     PlacedVolume     tower_phv1 = ChimneySector.placeVolume(ChimneyTower[i], i+24, Transform3D(RotationZ(5*(360.0/320.0)*dd4hep::deg + tweak_chimney_tiles[i]), Translation3D(0.0,0.0,0.0)) );
     tower_phv1.addPhysVolID("tower", i+24);
-    DetElement sd1 = tower_det.clone(_toString(i+24, "tower%d")); 
+    DetElement sd1 = tower_det.clone(_toString(i+24, "tower%d"));
     sd1.setPlacement(tower_phv1);
     sdet.add(sd1);
 
   }
 
   // ordinary towers in chimney sectors
-  for(int i=4; i<24; i++){ 
+  for(int i=4; i<24; i++){
 
     PlacedVolume     tower_phv0 = ChimneySector.placeVolume(Tower[i], i, Transform3D(RotationZ(tweak_chimney_tiles[i]), Translation3D(0.0,0.0,0.0)) );
     tower_phv0.addPhysVolID("tower", i);
-    DetElement sd0 = tower_det.clone(_toString(i, "tower%d")); 
+    DetElement sd0 = tower_det.clone(_toString(i, "tower%d"));
     sd0.setPlacement(tower_phv0);
     sdet.add(sd0);
 
     PlacedVolume     tower_phv1 = ChimneySector.placeVolume(Tower[i], i+24, Transform3D(RotationZ(5*(360.0/320.0)*dd4hep::deg + tweak_chimney_tiles[i]), Translation3D(0.0,0.0,0.0)) );
     tower_phv1.addPhysVolID("tower", i+24);
-    DetElement sd1 = tower_det.clone(_toString(i+24, "tower%d")); 
+    DetElement sd1 = tower_det.clone(_toString(i+24, "tower%d"));
     sd1.setPlacement(tower_phv1);
     sdet.add(sd1);
 
   }
 
   // ordinary sectors
-  for(int i=0; i<24; i++){ 
+  for(int i=0; i<24; i++){
 
     PlacedVolume     tower_phv0 = Sector.placeVolume(Tower[i], i+24, Transform3D(RotationZ(tileRotateStart - octileRotateStart + tweak_tiles[i]), Translation3D(0.0,0.0,0.0)) );
     tower_phv0.addPhysVolID("tower", i+48);
-    DetElement sd0 = tower_det.clone(_toString(i+48, "tower%d")); 
+    DetElement sd0 = tower_det.clone(_toString(i+48, "tower%d"));
     sd0.setPlacement(tower_phv0);
     sdet.add(sd0);
 
     PlacedVolume     tower_phv1 = Sector.placeVolume(Tower[i], i+48, Transform3D(RotationZ(tileRotateStart - octileRotateStart + 5*(360.0/320.0)*dd4hep::deg + tweak_tiles[i]), Translation3D(0.0,0.0,0.0)) );
     tower_phv1.addPhysVolID("tower", i+72);
-    DetElement sd1 = tower_det.clone(_toString(i+72, "tower%d")); 
+    DetElement sd1 = tower_det.clone(_toString(i+72, "tower%d"));
     sd1.setPlacement(tower_phv1);
     sdet.add(sd1);
 
   }
-  
+
   // Place the sectors into the envelope
 
   DetElement sector_det("sector0", det_id);
- 
+
   // Chimney sectors
   for(int i=-1; i<2; i++){
     PlacedVolume     sect_phv = envelope.placeVolume(ChimneySector, i+1, Transform3D(RotationZ(((i-1)*2*M_PI/32) + tweak_sectors[i+1]), Translation3D(0, 0, 0) ));
     sect_phv.addPhysVolID("system", det_id);
     sect_phv.addPhysVolID("barrel", 0);
     sect_phv.addPhysVolID("sector", i+1);
-    DetElement sd = sector_det.clone(_toString(i+1, "sector%d")); 
+    DetElement sd = sector_det.clone(_toString(i+1, "sector%d"));
     sd.setPlacement(sect_phv);
     sdet.add(sd);
   }
@@ -514,16 +514,15 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
     sect_phv.addPhysVolID("system", det_id);
     sect_phv.addPhysVolID("barrel", 0);
     sect_phv.addPhysVolID("sector", i);
-    DetElement sd = sector_det.clone(_toString(i, "sector%d")); 
+    DetElement sd = sector_det.clone(_toString(i, "sector%d"));
     sd.setPlacement(sect_phv);
     sdet.add(sd);
   }
 
-  std::string   env_vis = getAttrOrDefault<std::string>(x_det, _Unicode(env_vis), "HcalBarrelEnvelopeVis"); 
+  std::string   env_vis = getAttrOrDefault<std::string>(x_det, _Unicode(env_vis), "HcalBarrelEnvelopeVis");
   envelope.setAttributes(description, x_det.regionStr(), x_det.limitsStr(), env_vis);
   return sdet;
 
 }
 
 DECLARE_DETELEMENT(epic_HcalBarrelGDML, create_detector)
-

--- a/src/EndcapTOF_geo.cpp
+++ b/src/EndcapTOF_geo.cpp
@@ -179,7 +179,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   DetElement layer_detEl(ttl_detEl, _toString(layer_id, "layer_%d"), x_det.id());
 
 
-  // NOTE: ACTS extension for the disk layer of the TTL 
+  // NOTE: ACTS extension for the disk layer of the TTL
   // also defining the coordinate system that differs between ACTS and Geant4 (zyx vs xyz)
   Acts::ActsExtension* detlayer = new Acts::ActsExtension("zyx");
   detlayer->addValue(-80. * mm, "r_min", "envelope");

--- a/src/InsertCalorimeter_geo.cpp
+++ b/src/InsertCalorimeter_geo.cpp
@@ -50,11 +50,11 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
 
   // Getting thickness of backplate
   /*
-    The hole radius & position is determined by liner interpolation 
+    The hole radius & position is determined by liner interpolation
     The HCal insert has multiple layers; interpolation goes from front of insert to front of final layer
     So need final layer thickness (backplate thickness) for interpolation
-    
-    For the ECal insert, the hole radius & position is constant 
+
+    For the ECal insert, the hole radius & position is constant
     Also has only one layer so don't have a backplate_thickness there (so set to 0)
   */
   auto backplate_thickness = detElem.hasChild(_Unicode(backplate))? detElem.child(_Unicode(backplate)).attr<double>(_Unicode(thickness)) : 0.;

--- a/src/MPGDDIRC_geo.cpp
+++ b/src/MPGDDIRC_geo.cpp
@@ -143,9 +143,9 @@ static Ref_t create_MPGDDIRC_geo(Detector& description, xml_h e, SensitiveDetect
       c_vol.setVisAttributes(description, x_comp.visStr());
 
       pv = m_vol.placeVolume(c_vol, Position(0, 0, thickness_sum + x_comp.thickness() / 2.0));
-      
+
       if (x_comp.isSensitive()) {
-	pv.addPhysVolID("sensor",sensor_number++);      
+	pv.addPhysVolID("sensor",sensor_number++);
         c_vol.setSensitiveDetector(sens);
         sensitives[m_nam].push_back(pv);
         module_thicknesses[m_nam] = {thickness_so_far + x_comp.thickness() / 2.0,
@@ -244,7 +244,7 @@ static Ref_t create_MPGDDIRC_geo(Detector& description, xml_h e, SensitiveDetect
         DetElement mod_elt(lay_elt, module_name, module);
         double mod_z = 0.5 * dimensions.length();
         double z_placement = mod_z - j * nz * mod_z;          //z location for module placement
-	double z_offset = z_placement > 0 ? -z0/2.0 : z0/2.0; // determine the amount of overlap in z the z nz modules have 
+	double z_offset = z_placement > 0 ? -z0/2.0 : z0/2.0; // determine the amount of overlap in z the z nz modules have
 
         Transform3D tr(RotationZYX(0.0, ((M_PI / 2) - phic - phi_tilt), -M_PI / 2),
                        Position(xc, yc, mpgd_dirc_pos.z() + z_placement + z_offset)); // in x-y plane,
@@ -256,7 +256,7 @@ static Ref_t create_MPGDDIRC_geo(Detector& description, xml_h e, SensitiveDetect
           DetElement  comp_de(mod_elt, std::string("de_") + sens_pv.volume().name(),module);
           comp_de.setPlacement(sens_pv);
         }
-        //increas module counter	
+        //increas module counter
         module++;
 	//adjust x and y coordinates
 	xc += dx;

--- a/src/SciGlassCalorimeter_geo.cpp
+++ b/src/SciGlassCalorimeter_geo.cpp
@@ -180,14 +180,17 @@ static Ref_t create_detector(Detector &lcdd, xml_h handle,
       wedge_box_handle.thickness() / 2,
       (envelope_handle.zmax() - envelope_handle.zmin()) / 2
     };
-    IntersectionSolid wedge_box_side_shape{
-      envelope_shape,
-      wedge_box_side_box_shape,
-      Position{(side_rmax + side_rmin) / 2, 0, (envelope_handle.zmax() + envelope_handle.zmin()) / 2}
-    };
+    Volume wedge_box_side_v[2];
+    for (int side = -1; side <= 1; side += 2) {
+      IntersectionSolid wedge_box_side_shape{
+        envelope_shape,
+        wedge_box_side_box_shape,
+        Position{(side_rmax + side_rmin) / 2, side * wedge_box_handle.gap() / 2, (envelope_handle.zmax() + envelope_handle.zmin()) / 2}
+      };
 
-    Volume wedge_box_side_v {"wedge_box_side", wedge_box_side_shape, wedge_box_mat};
-    wedge_box_side_v.setVisAttributes(lcdd.visAttributes(wedge_box_handle.visStr()));
+      wedge_box_side_v[(side + 1) / 2] = Volume({"wedge_box_side", wedge_box_side_shape, wedge_box_mat});
+      wedge_box_side_v[(side + 1) / 2].setVisAttributes(lcdd.visAttributes(wedge_box_handle.visStr()));
+    }
 
     int sector = 0;
     double sector_phi = sectors_handle.phi0();
@@ -195,9 +198,8 @@ static Ref_t create_detector(Detector &lcdd, xml_h handle,
          sector++, sector_phi += sectors_handle.deltaphi()) {
       for (int side = -1; side <= 1; side += 2) {
         envelope_v.placeVolume(
-          wedge_box_side_v,
-          Transform3D{RotationZ{sector_phi + side * sectors_handle.deltaphi() / 2}} *
-          Transform3D{Position{0., - side * wedge_box_handle.gap() / 2, 0.}}
+          wedge_box_side_v[(side + 1) / 2],
+          Transform3D{RotationZ{sector_phi + side * sectors_handle.deltaphi() / 2}}
           );
       }
     }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Cherry-pick of f06a7d8 and 9dfcdb0 into 22.11 to reduce memory use.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: memory use is over 2GB, which imposes operational constraints on campaign)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators:
  - @veprbl: do we expect any actual changes due to f06a7d8 and 9dfcdb0 ?

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.