### PR TITLE
fix: labeler for RICHes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,7 @@
 "topic: backward":
   - "compact/**/backward_*"
+  - "compact/**/mrich*"
+  - "compact/**/pfrich*"
 
 "topic: barrel":
   - "compact/**/barrel_*"
@@ -31,7 +33,7 @@
 
 "topic: forward":
   - "compact/**/forward_*"
-  - "compact/**/*rich*"
+  - "compact/**/drich*"
   - "src/*Tracker*"
 
 "topic: infrastructure":


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Make sure `pfRICH` and `mRICH` get the backward label

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no