### PR TITLE
Uncomment settings for high-acceptance, comment out high-divergence.

### DIFF
--- a/compact/far_forward/roman_pots_eRD24_design.xml
+++ b/compact/far_forward/roman_pots_eRD24_design.xml
@@ -38,11 +38,11 @@
 
 
 
-	<constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
-    <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
+        <constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
+        <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
 
-	<constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
-    <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
+        <constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
+        <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
 
 
 
@@ -50,11 +50,11 @@
 
     	<!--
 
-	<constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
-    <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
+        <constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
+        <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
 
-    <constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
-    <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
+        <constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
+        <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
 
 	--!>
 

--- a/compact/far_forward/roman_pots_eRD24_design.xml
+++ b/compact/far_forward/roman_pots_eRD24_design.xml
@@ -36,7 +36,7 @@
 
 	<!-- HIGH ACCEPTANCE VALUES -->
 
-	
+
 
 	<constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
     <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
@@ -44,7 +44,7 @@
 	<constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
     <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
 
-	
+
 
 	<!-- HIGH DIVERGENCE VALUES -->
 

--- a/compact/far_forward/roman_pots_eRD24_design.xml
+++ b/compact/far_forward/roman_pots_eRD24_design.xml
@@ -36,17 +36,19 @@
 
 	<!-- HIGH ACCEPTANCE VALUES -->
 
-	<!--
+	
 
 	<constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
     <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
 
-	<constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.8*cm"/>
-    <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.8*cm"/>
+	<constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
+    <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
 
-	-->
+	
 
 	<!-- HIGH DIVERGENCE VALUES -->
+
+    	<!--
 
 	<constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
     <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
@@ -54,6 +56,7 @@
     <constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
     <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
 
+	--!>
 
 	<!-- Each module is a sandwich of 1mm aluminum, 0.3mm air, 0.3mm silicon, 0.3mm inactive silicon, 0.3mm copper, and 1mm aluminum -->
 	<!-- Vacuum is between each module -->


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This changes the location of portions of the Roman Pots planes to make them "high acceptance". It should be noted that it is obvious (now) that the arrangement of the planes needs to be re-shuffled in the next campaign to optimized the 10 sigma distance. Additionally, need to add functionality to adjust the 10sigma position at run-time. Will do later with a different PR.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Not a bug necessarily - just have everything set for high-divergence, switching to HA.

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

This PR makes a minimal change to the compact file, and only adjusts some constants for the placement of the detector planes.

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No.

### Does this PR change default behavior?

Yes, it will increase the overall acceptance of far-forward protons at low-Pt (in the Roman Pots, nowhere else).