### PR TITLE
ci: upgrade LCG from 101 to 102 for DD4hep-1.20

### DIFF
--- a/.github/workflows/linux-lcg.yml
+++ b/.github/workflows/linux-lcg.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["LCG_101/x86_64-ubuntu2004-gcc9-opt"]
+        LCG: ["LCG_102/x86_64-ubuntu2004-gcc9-opt"]
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3


### PR DESCRIPTION
### Briefly, what does this PR introduce?
LCG_101 only contains DD4hep 1.18. That does not have the required VariantParameters functionality that we need for Acts-20. This upgrades the LCG build to LCG_102 with DD4hep 1.20.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: currently failing to build on LCG_101)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @rahmans1 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.