### PR TITLE
fix: require DD4hep 1.21 in CMakeLists.txt

### DIFF
--- a/.github/workflows/linux-lcg.yml
+++ b/.github/workflows/linux-lcg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build-lcg-ubuntu-2004:
     runs-on: ubuntu-20.04
+    if: ${{ false }}  # Note: disabled until LCG has at least DD4hep 1.21 (LCG_103 or beyond)
     strategy:
       fail-fast: false
       matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,19 +35,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 include(GNUInstallDirs)
 
 # Dependencies
-find_package(DD4hep REQUIRED COMPONENTS DDCore DDG4 DDRec)
-if(${DD4hep_VERSION} VERSION_LESS 1.21)
-  message(WARNING "DD4hep before 1.21 does not write collections correctly \n"
-                  "More info at https://github.com/AIDASoft/DD4hep/pull/922")
-endif()
-find_package(ActsDD4hep)
-if(ActsDD4hep_FOUND)
-  add_compile_definitions(USE_ACTSDD4HEP)
-  set(ActsDD4hep ActsDD4hep::ActsDD4hep)
-else()
-  find_package(Acts REQUIRED COMPONENTS Core PluginIdentification PluginTGeo PluginDD4hep)
-  set(ActsDD4hep ActsCore ActsPluginDD4hep)
-endif()
+find_package(DD4hep 1.21 REQUIRED COMPONENTS DDCore DDG4 DDRec)
 find_package(fmt REQUIRED)
 
 #-----------------------------------------------------------------------------------
@@ -58,7 +46,7 @@ dd4hep_configure_output()
 file(GLOB sources CONFIGURE_DEPENDS src/*.cpp)
 dd4hep_add_plugin(${a_lib_name}
   SOURCES ${sources}
-  USES ${ActsDD4hep} ROOT::Core ROOT::Gdml
+  USES ROOT::Core ROOT::Gdml
   )
 target_link_libraries(${a_lib_name}
   PUBLIC DD4hep::DDCore DD4hep::DDRec fmt::fmt


### PR DESCRIPTION
### Briefly, what does this PR introduce?
DD4hep 1.21 is required for its VariantParameter support. This enforces this at the cmake stage, rather than failing compilation later on. Because LCG_101 does not container DD4hep 1.21, the LCG workflow is disabled.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: fails to build on LCG_101)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @rahmans1 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.