### PR TITLE
dRICH large sensor for focal point region studies

### DIFF
--- a/compact/pid/drich.xml
+++ b/compact/pid/drich.xml
@@ -44,7 +44,7 @@
 - `DRICH_debug_mirror`:    1 = draw full mirror shape for single sector; 0 = off
 - `DRICH_debug_sensors`:   1 = draw full sensor sphere for a single sector; 0 = off
 </comment>
-<constant name="DRICH_debug_optics"    value="5"/>
+<constant name="DRICH_debug_optics"    value="0"/>
 <constant name="DRICH_debug_mirror"    value="0"/>
 <constant name="DRICH_debug_sensors"   value="0"/>
 </define>

--- a/compact/pid/drich.xml
+++ b/compact/pid/drich.xml
@@ -38,11 +38,13 @@
 - `DRICH_debug_optics`:    1 = all components become vacuum, except for mirrors; test opticalphotons from IP
                            2 = all components become vacuum, except for mirrors and `gasvol`, test charged particles from IP
                            3 = all components become vacuum, except for mirrors and sensors, test reflected trajectories' hits
+			   4 = all components become vacuum, except for mirrors and sensors, oversized sensor created to catch all photons
+                           5 = all components created normally, calculated focal points from mode 4 drawn if environment variable set
                            0 = off
 - `DRICH_debug_mirror`:    1 = draw full mirror shape for single sector; 0 = off
 - `DRICH_debug_sensors`:   1 = draw full sensor sphere for a single sector; 0 = off
 </comment>
-<constant name="DRICH_debug_optics"    value="0"/>
+<constant name="DRICH_debug_optics"    value="5"/>
 <constant name="DRICH_debug_mirror"    value="0"/>
 <constant name="DRICH_debug_sensors"   value="0"/>
 </define>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Adds two new optics debugging mode for dRICH:
   4 - creates large photosensor instead of default dRICH sensors, designed to catch all possible reflected photons. This is currently used with test 12 / 14 in drich-devs, throwing parallel beams of photons in order to determine the focal region of the dRICH optics.
   5 - from a local text file, creates representations of the calculated focal points from mode 4 and a script in drich-devs, and also creates default dRICH sensors to visually compare calculated focal point to sensor position.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [x] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No. 
### Does this PR change default behavior?
No.