### PR TITLE
barrel_sciglass.xml: shorten family 1 and 2 towers to 40 cm

### DIFF
--- a/compact/ecal/barrel_sciglass.xml
+++ b/compact/ecal/barrel_sciglass.xml
@@ -75,13 +75,13 @@
             The front and rear faces are similar isosceles trapezoids only slightly deviating from a rectangular shape by an amount parametrized with `flare_angle_at_face`.
           </comment>
 
-          <family dir_sign="+1" x1="1.925 * cm" y1="2 * cm" z_length="45.5 * cm" number="10" flare_angle_polar="1.16 * degree"  flare_angle_at_face="0.3059 * degree" vis="family1" />
-          <family dir_sign="+1" x1="1.925 * cm" y1="2 * cm" z_length="45.5 * cm" number="6"  flare_angle_polar="1.045 * degree" flare_angle_at_face="0.7058 * degree" vis="family2" />
+          <family dir_sign="+1" x1="1.925 * cm" y1="2 * cm" z_length="40.0 * cm" number="10" flare_angle_polar="1.16 * degree"  flare_angle_at_face="0.3059 * degree" vis="family1" />
+          <family dir_sign="+1" x1="1.925 * cm" y1="2 * cm" z_length="40.0 * cm" number="6"  flare_angle_polar="1.045 * degree" flare_angle_at_face="0.7058 * degree" vis="family2" />
           <family dir_sign="+1" x1="1.925 * cm" y1="2 * cm" z_length="45.5 * cm" number="5"  flare_angle_polar="0.929 * degree" flare_angle_at_face="0.8892 * degree" vis="family3" />
           <family dir_sign="+1" x1="1.925 * cm" y1="2 * cm" z_length="45.5 * cm" number="5"  flare_angle_polar="0.82 * degree"  flare_angle_at_face="1.0258 * degree" vis="family4" />
           <family dir_sign="+1" x1="1.925 * cm" y1="2 * cm" z_length="45.5 * cm" number="3"  flare_angle_polar="0.70 * degree"  flare_angle_at_face="1.126 * degree"  vis="family5" />
-          <family dir_sign="-1" x1="1.925 * cm" y1="2 * cm" z_length="45.5 * cm" number="10" flare_angle_polar="1.16 * degree"  flare_angle_at_face="0.3059 * degree" vis="family1" />
-          <family dir_sign="-1" x1="1.925 * cm" y1="2 * cm" z_length="45.5 * cm" number="6"  flare_angle_polar="1.045 * degree" flare_angle_at_face="0.7058 * degree" vis="family2" />
+          <family dir_sign="-1" x1="1.925 * cm" y1="2 * cm" z_length="40.0 * cm" number="10" flare_angle_polar="1.16 * degree"  flare_angle_at_face="0.3059 * degree" vis="family1" />
+          <family dir_sign="-1" x1="1.925 * cm" y1="2 * cm" z_length="40.0 * cm" number="6"  flare_angle_polar="1.045 * degree" flare_angle_at_face="0.7058 * degree" vis="family2" />
           <family dir_sign="-1" x1="1.925 * cm" y1="2 * cm" z_length="45.5 * cm" number="5"  flare_angle_polar="0.929 * degree" flare_angle_at_face="0.8892 * degree" vis="family3" />
           <family dir_sign="-1" x1="1.925 * cm" y1="2 * cm" z_length="45.5 * cm" number="5"  flare_angle_polar="0.82 * degree"  flare_angle_at_face="1.0258 * degree" vis="family4" />
           <family dir_sign="-1" x1="1.925 * cm" y1="2 * cm" z_length="45.5 * cm" number="5"  flare_angle_polar="0.70 * degree"  flare_angle_at_face="1.126 * degree"  vis="family5" />


### PR DESCRIPTION
### Briefly, what does this PR introduce?

A design update. Towers at mid-rapidity will now be shorter:
<img width="709" alt="image" src="https://user-images.githubusercontent.com/245573/213577446-980d4efb-9e12-48af-a49f-13d62c42b64b.png">

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators: Confirmed with Joshua

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes