### PR TITLE
fix: set dd4hep compiler flags to suppress ABI warnings on arm

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -95,7 +95,7 @@ jobs:
         platform-release: "jug_xl:nightly"
         run: |
           CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-          cmake --build build -- -j 2 install
+          cmake --build build -- -k -j 2 install
     - uses: actions/upload-artifact@v3
       with:
         name: build-${{ matrix.CC }}-full-eic-shell

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ find_package(fmt REQUIRED)
 set(a_lib_name ${PROJECT_NAME})
 
 dd4hep_configure_output()
+dd4hep_set_compiler_flags()
 
 file(GLOB sources CONFIGURE_DEPENDS src/*.cpp)
 dd4hep_add_plugin(${a_lib_name}

--- a/src/B0Tracker_geo.cpp
+++ b/src/B0Tracker_geo.cpp
@@ -238,8 +238,8 @@ static Ref_t create_B0Tracker(Detector& description, xml_h e, SensitiveDetector 
           DetElement   comp_elt(module, sens_pv.volume().name(), mod_num);
           comp_elt.setPlacement(sens_pv);
           // std::cout << " adding ACTS extension" << "\n";
-          auto &params = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(comp_elt);
-          params.set("axis_definitions", "XZY");
+          auto &comp_elt_params = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(comp_elt);
+          comp_elt_params.set("axis_definitions", "XZY");
           volSurfaceList(comp_elt)->push_back(volplane_surfaces[m_nam][ic]);
         }
         //} else {

--- a/src/BarrelTrackerWithFrame_geo.cpp
+++ b/src/BarrelTrackerWithFrame_geo.cpp
@@ -297,8 +297,8 @@ static Ref_t create_BarrelTrackerWithFrame(Detector& description, xml_h e, Sensi
           DetElement   comp_de(mod_elt, std::string("de_") + sens_pv.volume().name(), module);
           comp_de.setPlacement(sens_pv);
 
-          auto &params = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(comp_de);
-          params.set<string>("axis_definitions", "XYZ");
+          auto &comp_de_params = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(comp_de);
+          comp_de_params.set<string>("axis_definitions", "XYZ");
           // comp_de.setAttributes(description, sens_pv.volume(), x_layer.regionStr(), x_layer.limitsStr(),
           //                       xml_det_t(xmleles[m_nam]).visStr());
           //

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -18,7 +18,7 @@
 
 namespace fs = std::filesystem;
 
-using namespace dd4hep;
+using dd4hep::printout;
 
 // Function to download files
 inline void EnsureFileFromURLExists(std::string url, std::string file, std::string cache_str = "",

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -19,6 +19,7 @@
 namespace fs = std::filesystem;
 
 using dd4hep::printout;
+using dd4hep::ERROR, dd4hep::WARNING, dd4hep::INFO;
 
 // Function to download files
 inline void EnsureFileFromURLExists(std::string url, std::string file, std::string cache_str = "",

--- a/src/TrapEndcapTracker_geo.cpp
+++ b/src/TrapEndcapTracker_geo.cpp
@@ -290,8 +290,8 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
           for (size_t ic = 0; ic < sensVols.size(); ++ic) {
             PlacedVolume sens_pv = sensVols[ic];
             DetElement   comp_elt(r_module, sens_pv.volume().name(), mod_num);
-            auto &params = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(comp_elt);
-            params.set<string>("axis_definitions", "XZY");
+            auto &comp_elt_params = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(comp_elt);
+            comp_elt_params.set<string>("axis_definitions", "XZY");
             comp_elt.setPlacement(sens_pv);
             volSurfaceList(comp_elt)->push_back(volplane_surfaces[m_nam][ic]);
           }

--- a/src/TrapEndcapTracker_geo.cpp
+++ b/src/TrapEndcapTracker_geo.cpp
@@ -276,8 +276,8 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
           for (size_t ic = 0; ic < sensVols.size(); ++ic) {
             PlacedVolume sens_pv = sensVols[ic];
             DetElement   comp_elt(module, sens_pv.volume().name(), mod_num);
-            auto &params = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(comp_elt);
-            params.set<string>("axis_definitions", "XZY");
+            auto &comp_elt_params = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(comp_elt);
+            comp_elt_params.set<string>("axis_definitions", "XZY");
             comp_elt.setPlacement(sens_pv);
             volSurfaceList(comp_elt)->push_back(volplane_surfaces[m_nam][ic]);
           }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
As of version 1.24, DD4hep exports `-Wno-psabi` in its compiler flags to suppress gcc ABI warnings in the DD4hep header Shapes.h. This PR has us pick up these upstream compiler flags to pick this up. This means:
`-Wshadow -Wformat-security -Wno-long-long -Wdeprecated -fdiagnostics-color=auto -Wall -Wextra -pedantic -Wno-psabi`

### What kind of change does this PR introduce?
- [x] Bug fix (issue: too much spurious output on arm)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.