### PR TITLE
feat: use asymmetry tracker region in secondary particle handler

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -611,6 +611,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     </comment>
 
     <constant name="tracker_region_rmax"   value="EcalBarrel_rmin"/>
-    <constant name="tracker_region_zmax"   value="EcalEndcapN_zmin"/>
+    <constant name="tracker_region_zmax"   value="EcalEndcapP_zmin"/>
+    <constant name="tracker_region_zmin"   value="EcalEndcapN_zmin"/>
 
   </define>

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -611,7 +611,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     </comment>
 
     <constant name="tracker_region_rmax"   value="EcalBarrel_rmin"/>
-    <constant name="tracker_region_zmax"   value="EcalEndcapP_zmin"/>
-    <constant name="tracker_region_zmin"   value="EcalEndcapN_zmin"/>
+    <constant name="tracker_region_zmax"   value="+EcalEndcapP_zmin"/>
+    <constant name="tracker_region_zmin"   value="-EcalEndcapN_zmin"/>
 
   </define>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Due to limitations in DD4hep we were using symmetric limits here, but DD4hep 1.24 allows asymmetric regions. This defines the "tracker region" which is the region where created secondaries will be stored in the MCParticles collection. This setting is backwards compatible in that `tracker_region_zmax` will be used as the symmetric limit for older DD4hep versions.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.