### PR TITLE
feat: explicitly define a world volume and material

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -2,14 +2,17 @@
 <!-- Copyright (C) 2022 Whitney Armstrong, Sylvester Joosten, Wouter Deconinck, Zhenyu Ye -->
 
   <define>
-    <constant name="world_side" value="30*m"/>
-    <constant name="world_x" value="world_side"/>
-    <constant name="world_y" value="world_side"/>
-    <constant name="world_z" value="100*m"/>
-
     <constant name="Pi" value="3.14159265359"/>
     <constant name="mil" value="0.0254*mm"/>
     <constant name="inch" value="2.54*cm"/>
+
+    <documentation>
+      ## World volume
+    </documentation>
+    <constant name="world_side" value="30*m"/>
+    <constant name="world_dx" value="world_side"/>
+    <constant name="world_dy" value="world_side"/>
+    <constant name="world_dz" value="100*m"/>
 
     <documentation>
       ## Detector IDs

--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -53,8 +53,8 @@
   <includes>
     <gdmlFile ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
     <gdmlFile ref="${DETECTOR_PATH}/compact/materials.xml"/>
-    <file     ref="${DETECTOR_PATH}/compact/optical_materials.xml"/>
   </includes>
+  <include ref="${DETECTOR_PATH}/compact/optical_materials.xml"/>
 
   <limits>
     <limitset name="EICBeamlineLimits">
@@ -73,6 +73,15 @@
     <include ref="${DETECTOR_PATH}/compact/{{colors | default("colors.xml", true) }}"/>
     <include ref="${DETECTOR_PATH}/compact/{{display | default("display.xml", true) }}"/>
   </display>
+
+  <documentation level="0">
+    ## World Volume
+
+    The world is a simple box, but could be a union of multiple regions.
+  </documentation>
+  <world material="Air">
+    <shape type="Box" dx="world_dx" dy="world_dy" dz="world_dz"/>
+  </world>
 
   <documentation level="0">
     ## Detector Subsystems


### PR DESCRIPTION
### Briefly, what does this PR introduce?
By defining our own world volume, we gain some flexibility in defining differently shaped world volumes, e.g. a central detector hall with far forward and far backward tunnels. It also may allow us to treat the world as a geant4 region with association user limit setters.

@c-dilks This has required moving the `optical_materials.xml` inclusion outside the `<includes>` tag. When the file is included inside the `<includes>` tag, it requires that the world is created at that time since it is treated as a new translation unit. When the file is included with a simple `<include>` tag, it includes the contents in-place in the current translation unit. Can you please double-check that the change to the optical_materials include line does not affect optical properties, in particular your optical surface definitions?

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @c-dilks 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.