### PR TITLE
Add direct lumi CAL to lumi.xml and relocate it further backward.

### DIFF
--- a/compact/far_backward/definitions.xml
+++ b/compact/far_backward/definitions.xml
@@ -293,7 +293,7 @@
     <constant name="LumiChamber2_Z2"      value="LumiSpecCAL_Z - LumiSpecCALTower_DZ"/>
 
     <!-- Lumi direct photon detector -->
-    <constant name="LumiDirect_Z"         value="-50*m"/>
+    <constant name="LumiDirect_Z"         value="-66*m"/>
     <constant name="LumiDirect_XY"        value="0.2*m"/>
     <constant name="LumiDirect_DZ"        value="0.2*m"/>
 

--- a/compact/far_backward/lumi.xml
+++ b/compact/far_backward/lumi.xml
@@ -10,5 +10,6 @@
    <include ref="lumi/spec_tracker.xml"/>
    <include ref="lumi/spec_homo_cal.xml"/>
    <include ref="lumi/photon_chamber.xml"/>
+   <include ref="lumi/directPC.xml"/>
 
 </lccdd>


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Activate the direct lumi photon CAL to the main lumi.xml and relocate it further backward, behind spectrometer CAL.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
