### PR TITLE
Change ECal insert's readout to 1x1 cm from 2x2 cm

### DIFF
--- a/compact/ecal/forward_insert_homogeneous.xml
+++ b/compact/ecal/forward_insert_homogeneous.xml
@@ -93,8 +93,8 @@
     <readout name="EcalEndcapPInsertHits">
       <segmentation
         type="CartesianGridXY"
-        grid_size_x="2.*cm"
-        grid_size_y="2.*cm"
+        grid_size_x="1.*cm"
+        grid_size_y="1.*cm"
       />
       <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>
     </readout>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This reduces the readout size of the ECal insert from 2x2 cm to 1x1 cm.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #399)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
None.
### Does this PR change default behavior?
No, just changes the readout size of the ECal insert.