### PR TITLE
dRICH: update sensor sphere positioning and re-focus

### DIFF
--- a/compact/pid/drich.xml
+++ b/compact/pid/drich.xml
@@ -162,8 +162,8 @@
   rmax="DRICH_rmax2 - DRICH_wall_thickness - 3.0*cm"
   phiw="59.5*degree"
   thickness="0.2*cm"
-  focus_tune_x="3.60*cm"
-  focus_tune_z="-2.00*cm"
+  focus_tune_x="-7.00*cm"
+  focus_tune_z="6.15*cm"
   />
 
 <!-- /detectors/detector/sensors -->
@@ -210,15 +210,15 @@
     - `zmin`: z-plane cut
 </documentation>
 <sphere
-  centerz="-50.0*cm"
-  centerx="180.0*cm"
+  centerz="138.4*cm - DRICH_zmin"
+  centerx="183.4*cm"
   radius="110.0*cm"
   />
 <sphericalpatch
-  phiw="18*degree"
+  phiw="30*degree"
   rmin="DRICH_rmax1 + 3.0*cm"
   rmax="DRICH_rmax2 - 3.0*cm"
-  zmin="DRICH_snout_length + 5.0*cm"
+  zmin="DRICH_snout_length + 3.0*cm"
   />
 
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- Update sensor sphere center following guidance from Luca and Marco; the radius remains fixed at 110 cm
- Set mirror focus tune z such that the mirror radius = 2x the sensor sphere radius
- Adjust mirror focus tune x to re-center the focal region on the sensors
- Disable the azimuthal limits of the sensor sphere (so more sensors than necessary will be placed); it is clear the true azimuthal limits of where the rings will appear are not quite aligned with these azimuthal cuts; we will re-think this later when implementing "sensor window boxes", where all the sensors will be contained in a `Box` filled with `AirOptical` (one per sector)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: dRICH optics tuning

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no

---
# Before/After Comparisons
### Mirror geometry
#### before
```
DRICH_mirror_radius       =      221.310
DRICH_mirror_center_x     =      118.878
DRICH_mirror_center_y     =        0.000
DRICH_mirror_center_z     =       92.590
```
#### after
```
DRICH_mirror_radius       =      220.006
DRICH_mirror_center_x     =      114.582
DRICH_mirror_center_y     =        0.000
DRICH_mirror_center_z     =       93.894
```

### Hits from Theta Scan
20 GeV pions fired at 4 different angles, 10 per angle:
```
theta = 2.8 deg   eta = 3.71
theta = 12.03 deg eta = 2.25
theta = 21.27 deg eta = 1.67
theta = 30.5 deg  eta = 1.30
```
#### before
![sim hits](https://user-images.githubusercontent.com/7843751/230512789-272c6ec2-643f-4d53-9b67-01ecaeab4f3e.png)
#### after
![sim hits](https://user-images.githubusercontent.com/7843751/230512910-1f7334ef-8677-4bd8-b4b7-967a999aa65d.png)

### Hits Azimuthal Scan
Same as theta test, with 24 azimuthal angles
#### before
![00000000](https://user-images.githubusercontent.com/7843751/230511953-d06e6d61-40a7-4ae5-9efe-f80d1143d1d5.png)
#### after
![00000000](https://user-images.githubusercontent.com/7843751/230514110-e3a8e455-349d-4f01-960a-f5b5be185a3a.png)

### Focal region
5 collimated beams of photons, to show the parallel-to-point focal region in comparison with the sensors
#### before
![2023-04-06-193230_796x861_scrot](https://user-images.githubusercontent.com/7843751/230512117-073802e8-7cb9-4680-95e5-94e3093a1b35.png)
#### after
![2023-04-06-195644_796x861_scrot](https://user-images.githubusercontent.com/7843751/230514217-bc9fc000-1f44-48ff-b399-09ca50f320fe.png)
