### PR TITLE
feat(dRICH): add test setting `DRICH_debug_sector` to draw only one sector

### DIFF
--- a/compact/pid/drich.xml
+++ b/compact/pid/drich.xml
@@ -38,10 +38,12 @@
                            2 = all components become vacuum, except for mirrors and `gasvol`, test charged particles from IP
                            3 = all components become vacuum, except for mirrors and sensors, test reflected trajectories' hits
                            0 = off
+- `DRICH_debug_sector`:    1 = only include one sector (will be set automatically when `DRICH_debug_optics>0`)
 - `DRICH_debug_mirror`:    1 = draw full mirror shape for single sector; 0 = off
 - `DRICH_debug_sensors`:   1 = draw full sensor sphere for a single sector; 0 = off
 </comment>
 <constant name="DRICH_debug_optics"    value="0"/>
+<constant name="DRICH_debug_sector"    value="0"/>
 <constant name="DRICH_debug_mirror"    value="0"/>
 <constant name="DRICH_debug_sensors"   value="0"/>
 </define>

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -107,6 +107,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   double sensorSphPatchZmin = sensorSphPatchElem.attr<double>(_Unicode(zmin));
   // - settings and switches
   long debugOpticsMode = desc.constantAsLong("DRICH_debug_optics");
+  bool debugSector     = desc.constantAsLong("DRICH_debug_sector") == 1;
   bool debugMirror     = desc.constantAsLong("DRICH_debug_mirror") == 1;
   bool debugSensors    = desc.constantAsLong("DRICH_debug_sensors") == 1;
 
@@ -128,9 +129,13 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
       printout(FATAL, "DRICH_geo", "UNKNOWN debugOpticsMode");
       return det;
     }
-    aerogelVis = sensorVis = mirrorVis;
-    gasvolVis = vesselVis = desc.invisible();
   }
+
+  // if debugging anything, draw only one sector and adjust visibility
+  if (debugOptics || debugMirror || debugSensors)
+    debugSector = true;
+  if (debugSector)
+    gasvolVis = vesselVis = desc.invisible();
 
   // readout coder <-> unique sensor ID
   /* - `sensorIDfields` is a list of readout fields used to specify a unique sensor ID
@@ -321,7 +326,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   for (int isec = 0; isec < nSectors; isec++) {
 
     // debugging filters, limiting the number of sectors
-    if ((debugMirror || debugSensors || debugOptics) && isec != 0)
+    if (debugSector && isec != 0)
       continue;
 
     // sector rotation about z axis


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Add a new "debugging" mode for the dRICH to draw only one sector (makes event displays easier to see).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no