### PR TITLE
fix: mRICH aerogel sum components to 1

### DIFF
--- a/compact/optical_materials.xml
+++ b/compact/optical_materials.xml
@@ -733,7 +733,7 @@
       <D value="0.2" unit="g / cm3"/>
       <fraction n="0.625" ref="SiliconOxide"/>
       <fraction n="0.374" ref="SiliconOxide"/>
-      <fraction n="0.1"   ref="C"/>
+      <fraction n="0.001" ref="C"/>
       <property name="RINDEX" ref="RINDEX__Aerogel"/>
       <property name="ABSLENGTH" ref="ABSLENGTH__Aerogel"/>
     </material>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fixes #202, warning due to aerogel components not summing up to 1. The fraction of carbon is almost certainly not 10%, and instead more likely 0.1%. In fun4all, there was 0 carbon. Ignoring the arbitrary separation into two components of Si02. Also ignoring the 10x higher density than [in fun4all](https://github.com/eic/fun4all_coresoftware/blob/master/simulation/g4simulation/g4main/PHG4Reco.cc#L1360). @msar15 

### What kind of change does this PR introduce?
- [x] Bug fix (issue #202)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.