### PR TITLE
feat(dRICH): add a constant to provide the number of sensors

### DIFF
--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -552,7 +552,6 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
     else if (imod != desc.constantAsLong("DRICH_num_sensors"))
       printout(WARNING, "DRICH_geo", "number of sensors is not the same for each sector");
 
-
   } // END SECTOR LOOP //////////////////////////
 
   return det;

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -546,6 +546,10 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
 
     // END SENSOR MODULE LOOP ------------------------
 
+    // add constant for access to the number of modules per sector
+    if (isec == 0)
+      desc.add(Constant("DRICH_num_sensors", std::to_string(imod))); // per sector
+
   } // END SECTOR LOOP //////////////////////////
 
   return det;

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -548,7 +548,10 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
 
     // add constant for access to the number of modules per sector
     if (isec == 0)
-      desc.add(Constant("DRICH_num_sensors", std::to_string(imod))); // per sector
+      desc.add(Constant("DRICH_num_sensors", std::to_string(imod)));
+    else if (imod != desc.constantAsLong("DRICH_num_sensors"))
+      printout(WARNING, "DRICH_geo", "number of sensors is not the same for each sector");
+
 
   } // END SECTOR LOOP //////////////////////////
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Add constant `DRICH_num_sensors` to provide easy access to the number of SiPM sensors per sector. Warn if this number is different in any sectors.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @DelloStritto

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no