### PR TITLE
feat: epic full with pfrich, imaging

### DIFF
--- a/compact/tracking/definitions.xml
+++ b/compact/tracking/definitions.xml
@@ -131,12 +131,6 @@
       vis="TrackerSubAssemblyVis">
       <composite name="BarrelTOF"/>
     </detector>
-    <detector id="TrackerSubAssembly_5_ID"
-        name="OuterMPGDSubAssembly"
-        type="DD4hep_SubdetectorAssembly"
-        vis="TrackerSubAssemblyVis">
-        <composite name="MPGDDIRC_0"/>
-    </detector>
     <detector id="TrackerSubAssembly_6_ID"
       name="EndcapTOFSubSubAssembly"
       type="DD4hep_SubdetectorAssembly"

--- a/compact/tracking/definitions_arches.xml
+++ b/compact/tracking/definitions_arches.xml
@@ -131,6 +131,12 @@
       vis="TrackerSubAssemblyVis">
       <composite name="BarrelTOF"/>
     </detector>
+    <detector id="TrackerSubAssembly_5_ID"
+        name="OuterMPGDSubAssembly"
+        type="DD4hep_SubdetectorAssembly"
+        vis="TrackerSubAssemblyVis">
+        <composite name="MPGDDIRC_0"/>
+    </detector>
     <detector id="TrackerSubAssembly_6_ID"
       name="EndcapTOFSubSubAssembly"
       type="DD4hep_SubdetectorAssembly"

--- a/configurations/arches.yml
+++ b/configurations/arches.yml
@@ -3,7 +3,7 @@ pbeam: 275
 features:
   beampipe:
   tracking:
-    definitions:
+    definitions_arches:
     vertex_barrel:
     silicon_barrel:
     mpgd_barrel:

--- a/configurations/arches_mrich_gdml.yml
+++ b/configurations/arches_mrich_gdml.yml
@@ -3,7 +3,7 @@ pbeam: 275
 features:
   beampipe:
   tracking:
-    definitions:
+    definitions_arches:
     vertex_barrel:
     silicon_barrel:
     mpgd_barrel:

--- a/configurations/brycecanyon.yml
+++ b/configurations/brycecanyon.yml
@@ -3,7 +3,7 @@ pbeam: 41
 features:
   beampipe:
   tracking:
-    definitions_brycecanyon:
+    definitions:
     vertex_barrel:
     silicon_barrel:
     mpgd_barrel:

--- a/configurations/brycecanyon_no_pfrich.yml
+++ b/configurations/brycecanyon_no_pfrich.yml
@@ -3,7 +3,7 @@ pbeam: 41
 features:
   beampipe:
   tracking:
-    definitions_brycecanyon:
+    definitions:
     vertex_barrel:
     silicon_barrel:
     mpgd_barrel:

--- a/configurations/brycecanyon_pfrich_gdml.yml
+++ b/configurations/brycecanyon_pfrich_gdml.yml
@@ -3,7 +3,7 @@ pbeam: 41
 features:
   beampipe:
   tracking:
-    definitions_brycecanyon:
+    definitions:
     vertex_barrel:
     silicon_barrel:
     mpgd_barrel:

--- a/configurations/full.yml
+++ b/configurations/full.yml
@@ -12,12 +12,12 @@ features:
     tof_endcap:
   pid:
     dirc:
-    mrich:
+    pfrich:
     drich:
   ecal:
     forward_homogeneous:
     forward_insert_homogeneous:
-    barrel_sciglass:
+    barrel_interlayers:
     backward_PbWO4:
   solenoid:
   hcal:

--- a/configurations/imaging.yml
+++ b/configurations/imaging.yml
@@ -1,7 +1,7 @@
 features:
   beampipe:
   tracking:
-    definitions_brycecanyon:
+    definitions:
     vertex_barrel:
     silicon_barrel:
     mpgd_barrel:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The default epic.xml geometry, constructed from the full.yml configuration, is updated to use the pfRICH and imaging barrel calorimeter.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, different detector is default.