### PR TITLE
fix: bad comment bad

### DIFF
--- a/compact/far_forward/roman_pots_eRD24_design.xml
+++ b/compact/far_forward/roman_pots_eRD24_design.xml
@@ -56,7 +56,7 @@
         <constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
         <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
 
-	--!>
+	-->
 
 	<!-- Each module is a sandwich of 1mm aluminum, 0.3mm air, 0.3mm silicon, 0.3mm inactive silicon, 0.3mm copper, and 1mm aluminum -->
 	<!-- Vacuum is between each module -->


### PR DESCRIPTION
### Briefly, what does this PR introduce?
XML is oddly specific about not having `--` inside a comment, so when a comment tag `<!--`/`-->` is not closed properly and falls through to the next comment end tag, it has an illegal `--` inside the comment.

"For compatibility, the string " -- " (double-hyphen) must not occur within comments." [https://www.w3.org/TR/REC-xml/#sec-comments]

(Git branch names, on the other hands, are more forgiving.)

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added: no, because xmllint can't do this.
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.