### PR TITLE
fix(dRICH): adjust sensor region boundaries

### DIFF
--- a/compact/pid/drich.xml
+++ b/compact/pid/drich.xml
@@ -216,8 +216,8 @@
   />
 <sphericalpatch
   phiw="30*degree"
-  rmin="DRICH_rmax1 + 3.0*cm"
-  rmax="DRICH_rmax2 - 3.0*cm"
+  rmin="110.0*cm"
+  rmax="179.0*cm"
   zmin="DRICH_snout_length + 3.0*cm"
   />
 

--- a/compact/pid/drich.xml
+++ b/compact/pid/drich.xml
@@ -216,7 +216,7 @@
   />
 <sphericalpatch
   phiw="30*degree"
-  rmin="110.0*cm"
+  rmin="111.0*cm"
   rmax="179.0*cm"
   zmin="DRICH_snout_length + 3.0*cm"
   />


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Adjust `sphericalpatch` cuts, which define the limits of the sensor sphere.

Previous limits:
```
rmin = "DRICH_rmax1 + 3.0*cm" = 107.656 cm
rmax = "DRICH_rmax2 - 3.0*cm" = 182.000 cm
```

New limits from Luca:
```
rmin = 110 cm, but actually needs to be 111 cm to remove extra "dangling" sensors at low theta
rmax = 179 cm
```


### What kind of change does this PR introduce?
- [x] Bug fix (engineering constraints)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @chchatte92 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no, but slight change in polar acceptance boundary