### PR TITLE
Update Geometry for Barrel EMCal

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -513,7 +513,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
   <documentation level="3">
 ## Calorimeter Parameters
   </documentation>
-    <constant name="EcalBarrelStavesN"              value="24"/>
+    <constant name="EcalBarrelStavesN"              value="48"/>
     <constant name="EcalEndcapP_zmin"               value="ForwardServiceGap_zmax" />
     <constant name="EcalEndcapP_length"             value="30*cm" />
     <constant name="EcalEndcapP_zmax"               value="EcalEndcapP_zmin + EcalEndcapP_length"/>

--- a/compact/display.xml
+++ b/compact/display.xml
@@ -66,10 +66,10 @@
     <vis name="EcalBarrelVis"           ref="AnlGold"   showDaughters="false" visible="true"/>
     <vis name="EcalBarrelStaveVis"      ref="AnlOrange" showDaughters="false" visible="true" />
     <vis name="EcalBarrelEnvelopeVis"   ref="AnlGold" showDaughters="false" visible="true" />
-    <vis name="EcalBarrelSupportVis"    ref="AnlOrange" showDaughters="false" visible="true"/>
     <vis name="EcalBarrelLayerVis"      ref="AnlGold"   showDaughters="true"  visible="true"/>
     <vis name="EcalBarrelSliceVis"      ref="AnlGray"   showDaughters="false" visible="true"/>
     <vis name="EcalBarrelFiberLayerVis" ref="AnlGold"   showDaughters="false" visible="true" />
+    <vis name="EcalBarrelSupportVis"    ref="AnlLightGray" showDaughters="false" visible="true"/>
 
     <vis name="EcalEndcapVis"           ref="AnlGold"   showDaughters="true" visible="false"/>
     <vis name="EcalEndcapLayerVis"      ref="AnlGold"   showDaughters="false" visible="true"/>

--- a/compact/display_detailed.xml
+++ b/compact/display_detailed.xml
@@ -60,7 +60,7 @@
     <vis name="EcalBarrelStaveVis"      ref="AnlGold"   showDaughters="true" visible="true" />
     <vis name="EcalBarrelFiberLayerVis" ref="AnlGold"   showDaughters="false" visible="true" />
     <vis name="EcalBarrelSliceVis"      ref="AnlGray"/>
-    <vis name="EcalBarrelSupportVis"    ref="AnlOrange"/>
+    <vis name="EcalBarrelSupportVis"    ref="AnlLightGray"/>
 
     <vis name="EcalVis"                 ref="AnlGold"   showDaughters="true"  visible="false"/>
     <vis name="EcalEndcapVis"           ref="AnlGold"   showDaughters="false" visible="true"/>

--- a/compact/display_geoviewer.xml
+++ b/compact/display_geoviewer.xml
@@ -59,7 +59,7 @@
     <vis name="EcalBarrelStaveVis"      ref="AnlGold"   showDaughters="true" visible="true" />
     <vis name="EcalBarrelFiberLayerVis" ref="AnlGold"   showDaughters="false" visible="true" />
     <vis name="EcalBarrelSliceVis"      ref="AnlGray"/>
-    <vis name="EcalBarrelSupportVis"    ref="AnlOrange"/>
+    <vis name="EcalBarrelSupportVis"    ref="AnlLightGray"/>
 
     <vis name="EcalVis"                 ref="AnlGold"   showDaughters="true"  visible="false"/>
     <vis name="EcalEndcapVis"           ref="AnlGold"   showDaughters="false" visible="true"/>

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -143,7 +143,6 @@
       <dimensions numsides="EcalBarrel_ModRepeat"
         rmin="EcalBarrel_rmin"
         z="EcalBarrel_Calorimeter_length"/>
-      <support thickness="EcalBarrel_Support_thickness" material="Aluminum" vis="EcalBarrelSupportVis"/>
       <staves vis="EcalBarrelStaveVis"/>
       <layer repeat="EcalBarrelImagingLayers_num-1" vis="EcalBarrelLayerVis"
        space_between="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween"
@@ -180,6 +179,7 @@
           </fiber>
         </slice>
       </layer>
+      <support thickness="EcalBarrel_Support_thickness" material="Aluminum" vis="EcalBarrelSupportVis"/>
     </detector>
   </detectors>
 

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -149,7 +149,9 @@
        space_before="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween/2.">
         <slice material="SciFiPb_PbGlue" thickness="EcalBarrel_RadiatorThickness" vis="EcalBarrelFiberLayerVis">
           <fiber material="SciFiPb_Scintillator"
-            sensitive="yes"
+	    sensitive="yes"
+            grid_n_phi="5"
+	    grid_dr="2*cm"
             radius="EcalBarrel_FiberRadius"
             cladding_thickness="EcalBarrel_CladdingThickness"
             spacing_x="EcalBarrel_FiberXSpacing"
@@ -167,6 +169,8 @@
           vis="EcalBarrelFiberLayerVis">
           <fiber material="SciFiPb_Scintillator"
             sensitive="yes"
+            grid_n_phi="5"
+	    grid_dr="2*cm"
             radius="EcalBarrel_FiberRadius"
             cladding_thickness="EcalBarrel_CladdingThickness"
             spacing_x="EcalBarrel_FiberXSpacing"

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -27,7 +27,7 @@
     <constant name="EcalBarrel_Calorimeter_offset"
       value="(EcalBarrel_Calorimeter_zmax - EcalBarrel_Calorimeter_zmin)/2.0"/>
 
-    <constant name="EcalBarrel_Support_thickness"    value="0*cm"/>
+    <constant name="EcalBarrel_Support_thickness"    value="3*cm"/>
     <constant name="EcalBarrel_SiliconThickness"     value="500*um"/>
     <constant name="EcalBarrel_ElectronicsThickness" value="150*um"/>
     <constant name="EcalBarrel_CopperThickness"      value="100*um"/>
@@ -143,6 +143,7 @@
       <dimensions numsides="EcalBarrel_ModRepeat"
         rmin="EcalBarrel_rmin"
         z="EcalBarrel_Calorimeter_length"/>
+      <support thickness="EcalBarrel_Support_thickness" material="Aluminum" vis="EcalBarrelSupportVis"/>
       <staves vis="EcalBarrelStaveVis"/>
       <layer repeat="EcalBarrelImagingLayers_num-1" vis="EcalBarrelLayerVis"
        space_between="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween"

--- a/scripts/subdetector_tests/draw_bemc_scfi_grids.py
+++ b/scripts/subdetector_tests/draw_bemc_scfi_grids.py
@@ -129,7 +129,11 @@ if __name__ == '__main__':
             )
     parser.add_argument(
             '--no-marker', action='store_true',
-            help='Switch to draw a marker for grid center or not'
+            help='Switch on to not draw a marker for each grid\'s center',
+            )
+    parser.add_argument(
+            '--no-fiber-edge', action='store_true',
+            help='Switch on to not draw fiber edge, might be helpful for a crowded plot.',
             )
     args = parser.parse_args()
 
@@ -181,7 +185,8 @@ if __name__ == '__main__':
         patches = []
         for fi in fibers:
             patches.append(Circle((fi[0], fi[1]), fi[3]))
-        p = PatchCollection(patches, alpha=0.6, facecolors=(c,), edgecolors=('k',))
+        ec = 'k' if not args.no_fiber_edge else c
+        p = PatchCollection(patches, alpha=0.6, facecolors=(c,), edgecolors=(ec,))
         if not args.no_marker:
             ax.plot(gr_pos[0], gr_pos[1], marker='P', mfc=c, mec='k', ms=9, label='grid {}'.format(ids['grid']))
         ax.add_collection(p)

--- a/src/BarrelCalorimeterInterlayers_geo.cpp
+++ b/src/BarrelCalorimeterInterlayers_geo.cpp
@@ -186,9 +186,9 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens)
   if (x_det.hasChild(_U(staves))) {
     xml_comp_t x_staves = x_det.staves();
     mod_vol.setVisAttributes(desc.visAttributes(x_staves.visStr()));
-    if (x_staves.hasChild(_U(support))) {
-      buildSupport(desc, mod_vol, x_staves.child(_U(support)), {inner_r, l_pos_z, x_dim.z(), hphi});
-    }
+  }
+  if (x_det.hasChild(_U(support))) {
+    buildSupport(desc, mod_vol, x_det.child(_U(support)), {inner_r, l_pos_z, x_dim.z(), hphi});
   }
 
   // Set envelope volume attributes.
@@ -297,93 +297,22 @@ void buildFibers(Detector& desc, SensitiveDetector& sens, Volume& s_vol, int lay
   */
 }
 
-// DAWN view seems to have some issue with overlapping solids even if they were unions
-// The support is now built without overlapping
+// simple aluminum sheet cover
+// dimensions: (inner r, position in z, length, phi) 
 void buildSupport(Detector& desc, Volume& mod_vol, xml_comp_t x_support,
                   const std::tuple<double, double, double, double>& dimensions)
 {
-  auto [inner_r, l_pos_z, stave_length, hphi] = dimensions;
+  auto     [inner_r, pos_z, stave_length, hphi] = dimensions;
+  double   support_thickness = getAttrOrDefault(x_support, _Unicode(thickness), 3.*cm);
+  auto     material          = desc.material(x_support.materialStr());
+  double   trd_y             = stave_length / 2.;
+  double   trd_x1_support    = std::tan(hphi) * pos_z;
+  double   trd_x2_support    = std::tan(hphi) * (pos_z + support_thickness);
 
-  double support_thickness = getAttrOrDefault(x_support, _Unicode(thickness), 5. * cm);
-  double beam_thickness    = getAttrOrDefault(x_support, _Unicode(beam_thickness), support_thickness / 4.);
-  // sanity check
-  if (beam_thickness > support_thickness / 3.) {
-    std::cerr << Form("beam_thickness (%.2f) cannot be greater than support_thickness/3 (%.2f), shrink it to fit",
-                      beam_thickness, support_thickness / 3.)
-              << std::endl;
-    beam_thickness = support_thickness / 3.;
-  }
-  Assembly env_vol("support_envelope");
-  double   trd_y          = stave_length / 2.;
-  double   trd_x1_support = std::tan(hphi) * l_pos_z;
-  // FIXME trd_x2_support is filled but unused
-  // double   trd_x2_support = std::tan(hphi) * (l_pos_z + support_thickness);
-
-  double grid_size        = getAttrOrDefault(x_support, _Unicode(grid_size), 25. * cm);
-  int    n_cross_supports = std::floor(trd_y - beam_thickness) / grid_size;
-  // number of "beams" running the length of the stave.
-  // @TODO make it configurable
-  int n_beams = getAttrOrDefault(x_support, _Unicode(n_beams), 3);
-  ;
-  double beam_width = 2. * trd_x1_support / (n_beams + 1); // quick hack to make some gap between T beams
-  double beam_gap   = getAttrOrDefault(x_support, _Unicode(beam_gap), 3. * cm);
-
-  // build T-shape beam
-  double                  beam_space_x    = beam_width + beam_gap;
-  [[maybe_unused]] double beam_space_z    = support_thickness - beam_thickness;
-  double                  cross_thickness = support_thickness - beam_thickness;
-  double                  beam_pos_z      = beam_thickness / 2.;
-  [[maybe_unused]] double beam_center_z   = support_thickness / 2. - beam_pos_z;
-
-  Box        beam_vert_s(beam_thickness / 2., trd_y, cross_thickness / 2.);
-  Box        beam_hori_s(beam_width / 2., trd_y, beam_thickness / 2.);
-  UnionSolid T_beam_s(beam_hori_s, beam_vert_s, Position(0., 0., support_thickness / 2.));
-  Volume     H_beam_vol("H_beam", T_beam_s, desc.material(x_support.materialStr()));
-  H_beam_vol.setVisAttributes(desc, x_support.visStr());
-  // place H beams first
-  double beam_start_x = -(n_beams - 1) * (beam_width + beam_gap) / 2.;
-  for (int i = 0; i < n_beams; ++i) {
-    Position beam_pos(beam_start_x + i * (beam_width + beam_gap), 0., -support_thickness / 2. + beam_pos_z);
-    env_vol.placeVolume(H_beam_vol, beam_pos);
-  }
-
-  // place central crossing beams that connects the H beams
-  double cross_x = beam_space_x - beam_thickness;
-  Box    cross_s(cross_x / 2., beam_thickness / 2., cross_thickness / 2.);
-  Volume cross_vol("cross_center_beam", cross_s, desc.material(x_support.materialStr()));
-  cross_vol.setVisAttributes(desc, x_support.visStr());
-  for (int i = 0; i < n_beams - 1; ++i) {
-    env_vol.placeVolume(cross_vol, Position(beam_start_x + beam_space_x * (i + 0.5), 0., beam_pos_z));
-    for (int j = 1; j < n_cross_supports; j++) {
-      env_vol.placeVolume(cross_vol, Position(beam_start_x + beam_space_x * (i + 0.5), -j * grid_size, beam_pos_z));
-      env_vol.placeVolume(cross_vol, Position(beam_start_x + beam_space_x * (i + 0.5), j * grid_size, beam_pos_z));
-    }
-  }
-
-  // place edge crossing beams that connects the neighbour support
-  // @TODO: connection part is still using boolean volumes, maybe problematic to DAWN
-  double           cross_edge_x = trd_x1_support + beam_start_x - beam_thickness / 2.;
-  double           cross_trd_x1 = cross_edge_x + std::tan(hphi) * beam_thickness;
-  double           cross_trd_x2 = cross_trd_x1 + 2. * std::tan(hphi) * cross_thickness;
-  double           edge_pos_x   = beam_start_x - cross_trd_x1 / 2. - beam_thickness / 2;
-  Trapezoid        cross_s2_trd(cross_trd_x1 / 2., cross_trd_x2 / 2., beam_thickness / 2., beam_thickness / 2.,
-                                cross_thickness / 2.);
-  Box              cross_s2_box((cross_trd_x2 - cross_trd_x1) / 4., beam_thickness / 2., cross_thickness / 2.);
-  SubtractionSolid cross_s2(cross_s2_trd, cross_s2_box, Position((cross_trd_x2 + cross_trd_x1) / 4., 0., 0.));
-  Volume           cross_vol2("cross_edge_beam", cross_s2, desc.material(x_support.materialStr()));
-  cross_vol2.setVisAttributes(desc, x_support.visStr());
-  env_vol.placeVolume(cross_vol2, Position(edge_pos_x, 0., beam_pos_z));
-  env_vol.placeVolume(cross_vol2, Transform3D(Translation3D(-edge_pos_x, 0., beam_pos_z) * RotationZ(M_PI)));
-  for (int j = 1; j < n_cross_supports; j++) {
-    env_vol.placeVolume(cross_vol2, Position(edge_pos_x, -j * grid_size, beam_pos_z));
-    env_vol.placeVolume(cross_vol2, Position(edge_pos_x, j * grid_size, beam_pos_z));
-    env_vol.placeVolume(cross_vol2,
-                        Transform3D(Translation3D(-edge_pos_x, -j * grid_size, beam_pos_z) * RotationZ(M_PI)));
-    env_vol.placeVolume(cross_vol2,
-                        Transform3D(Translation3D(-edge_pos_x, j * grid_size, beam_pos_z) * RotationZ(M_PI)));
-  }
-
-  mod_vol.placeVolume(env_vol, Position(0.0, 0.0, l_pos_z + support_thickness / 2.));
+  Trapezoid  s_shape(trd_x1_support, trd_x2_support, trd_y, trd_y, support_thickness / 2.);
+  Volume     s_vol("support_layer", s_shape, material);
+  s_vol.setVisAttributes(desc.visAttributes(x_support.visStr()));
+  mod_vol.placeVolume(s_vol, Position(0.0, 0.0, pos_z + support_thickness / 2.));
 }
 
 // Fill fiber lattice into trapezoid starting from position (0,0) in x-z coordinate system

--- a/src/BarrelCalorimeterInterlayers_geo.cpp
+++ b/src/BarrelCalorimeterInterlayers_geo.cpp
@@ -423,7 +423,7 @@ vector<Point> fiberPositions(double r, double sx, double sz, double trx, double 
 }
 
 // Determine the number of divisions for the readout grid for the fiber layers
-// Calculate dimensions of the polygonal grid 
+// Calculate dimensions of the polygonal grid
 vector<FiberGrid> gridPoints(int div_n_phi, double div_dr, double trd_x1, double height, double phi)
 {
   /*

--- a/src/BarrelCalorimeterInterlayers_geo.cpp
+++ b/src/BarrelCalorimeterInterlayers_geo.cpp
@@ -298,7 +298,7 @@ void buildFibers(Detector& desc, SensitiveDetector& sens, Volume& s_vol, int lay
 }
 
 // simple aluminum sheet cover
-// dimensions: (inner r, position in z, length, phi) 
+// dimensions: (inner r, position in z, length, phi)
 void buildSupport(Detector& desc, Volume& mod_vol, xml_comp_t x_support,
                   const std::tuple<double, double, double, double>& dimensions)
 {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Update the geometry for barrel ecal:
Change geometry to 48 staves
Change the readout grid to cover even distance in Delta Phi (see the picture below) - i.e., always divide stave (1/48) into 5 readout grids in one readout layer
Add 3 cm of Aluminum at the back of the calo

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Geometry Update

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No