### PR TITLE
fix grid plotting script for SciFi/Pb

### DIFF
--- a/scripts/subdetector_tests/draw_bemc_scfi_grids.py
+++ b/scripts/subdetector_tests/draw_bemc_scfi_grids.py
@@ -61,7 +61,7 @@ def get_grid_fibers(det_elem, vol_man, id_conv, id_dict):
     for i in np.arange(gnode.GetNdaughters()):
         fnode = gnode.GetDaughter(int(i))
         # NOTE, this is defined in geometry plugin, fiber_core is the only wanted sensitive detector
-        if 'fiber_core' not in fnode.GetName():
+        if 'fiber' not in fnode.GetName():
             continue
         fpos = np.array([0., 0., 0.])
         gpos = np.array([0., 0., 0.])


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR fixes a bug in the SciFi/Pb plotting script. After https://github.com/eic/epic/commit/8d2c50081146390402f4d7178d98b196dcb207d7 the daughter of the grid is `fiber` only, not `fiber_core`. Because of this issue fibers were not plotted correctly. 

### What kind of change does this PR introduce?
- [#] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
 no
### Does this PR change default behavior?
no