### PR TITLE
dRICH: limit sensor azimuthal range (do not merge)

### DIFF
--- a/compact/pid/drich.xml
+++ b/compact/pid/drich.xml
@@ -215,7 +215,7 @@
   radius="110.0*cm"
   />
 <sphericalpatch
-  phiw="30*degree"
+  phiw="18*degree"
   rmin="111.0*cm"
   rmax="179.0*cm"
   zmin="DRICH_snout_length + 3.0*cm"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Trigger CI GDML production with sensor `sphericalpatch` reverted to having 18 degree azimuthal limits.

**do not merge**, since we still prefer to have the expanded range

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators: @chchatte92 @mcontalb

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no