### PR TITLE
feat: define example world limit set and region

### DIFF
--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -59,7 +59,9 @@
   <include ref="${DETECTOR_PATH}/compact/optical_materials.xml"/>
 
   <limits>
-    <limitset name="EICBeamlineLimits">
+    <limitset name="world_limits">
+    </limitset>
+    <limitset name="beamline_limits">
       <limit name="step_length_max" particles="*" value="1.0" unit="mm" />
       <limit name="track_length_max" particles="*" value="1.0" unit="mm" />
       <limit name="time_max" particles="*" value="0.1" unit="ns" />
@@ -70,6 +72,12 @@
       <limit name="step_length_max" particles="*" value="5.0" unit="mm"/>
     </limitset>
   </limits>
+
+  <regions>
+    <region name="world_region" eunit="MeV" lunit="mm" cut="0.001" threshold="0.001">
+      <limitsetref name="world_limits"/>
+    </region>
+  </regions>
 
   <display>
     <include ref="${DETECTOR_PATH}/compact/{{colors | default("colors.xml", true) }}"/>
@@ -83,6 +91,8 @@
   </documentation>
   <world material="Air">
     <shape type="Box" dx="world_dx" dy="world_dy" dz="world_dz"/>
+    <regionref   name="world_region"/>
+    <limitsetref name="world_limits"/>
   </world>
 
   <documentation level="0">


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Recent DD4hep supports defining a world limit set and region, which extends to the full simulation. This doesn't introduce any limits, but demonstrates how to do it. This can also be extended to individual detectors.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [x] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.