### PR TITLE
test: disable DIRC for `npsim` speedup

### DIFF
--- a/configurations/full.yml
+++ b/configurations/full.yml
@@ -11,7 +11,7 @@ features:
     tof_barrel:
     tof_endcap:
   pid:
-    dirc:
+    # dirc:
     mrich:
     drich:
   ecal:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
test running without the DIRC (seems much faster with `npsim`, no difference for `ddsim`)

### do not merge

this branch exists so dRICH work is not slowed down!