### PR TITLE
visualisation attributes given correct names to allow JSROOT to show detector properly

### DIFF
--- a/compact/display.xml
+++ b/compact/display.xml
@@ -132,9 +132,9 @@
       ZDC visualization
     </comment>
 
-    <vis name="ffi_ZDC_ECAL_Vis"        ref="AnlGreen" showDaughters="true"  visible="true"/>
-    <vis name="ffi_ZDC_ECAL_module_Vis" ref="AnlRed"   showDaughters="false" visible="true"/>
-    <vis name="ffi_ZDC_HCAL_Vis"        ref="AnlBlue"  showDaughters="true"  visible="true"/>
+    <vis name="ZDC_Ecal_Vis"        ref="AnlGreen" showDaughters="true"  visible="true"/>
+    <vis name="ZDC_Ecal_module_Vis" ref="AnlRed"   showDaughters="false" visible="true"/>
+    <vis name="ZDC_Hcal_Vis"        ref="AnlBlue"  showDaughters="true"  visible="true"/>
 
     <comment>
       Backwards beamline vacuum

--- a/compact/far_forward/ZDC_Ecal_WSciFi.xml
+++ b/compact/far_forward/ZDC_Ecal_WSciFi.xml
@@ -20,12 +20,12 @@
     <detector id="ZDCEcal_ID"
       name="ZDCEcal"
       type="ZDCEcalScFiCalorimeter"
-      vis="ZDCEcal_Vis"
+      vis="ZDC_Ecal_Vis"
       readout="ZDCEcalHits">
       <position x="ZDCEcal_x_pos" y="ZDCEcal_y_pos" z="ZDCEcal_z_pos"/>
       <rotation x="ZDCEcal_rotateX_angle" y="ZDCEcal_rotateY_angle" z="ZDCEcal_rotateZ_angle"/>
       <dimensions x="ZDCEcal_width" z="ZDCEcal_length"/>
-      <module sizex="25*mm" sizey="25*mm" sizez="170*mm" material="WSciFi_UCLA_Abs" vis="ZDCEcal_module_Vis">
+      <module sizex="25*mm" sizey="25*mm" sizez="170*mm" material="WSciFi_UCLA_Abs" vis="ZDC_Ecal_module_Vis">
         <fiber material="Polystyrene"
           radius="ZDCEcal_FiberRadius"
           offset="ZDCEcal_FiberOffset"

--- a/compact/far_forward/ZDC_Hcal.xml
+++ b/compact/far_forward/ZDC_Hcal.xml
@@ -10,7 +10,7 @@
   </comment>
 
   <detectors>
-    <detector id="ZDCHcal_ID" name="ZDCHcal" type="ZDC_Sampling" readout="ZDCHcalHits" vis="ZDCHcal_Vis">
+    <detector id="ZDCHcal_ID" name="ZDCHcal" type="ZDC_Sampling" readout="ZDCHcalHits" vis="ZDC_Hcal_Vis">
       <position x="ZDCHcal_x_pos" y="ZDCHcal_y_pos" z="ZDCHcal_z_pos"/>
       <rotation x="ZDCHcal_rotateX_angle" y="ZDCHcal_rotateY_angle" z="ZDCHcal_rotateZ_angle"/>
       <dimensions x="ZDCHcal_width" z="ZDCHcal_length"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Badly named visualization parameters in the ZDCEcal, drich and barrel_sciglass prevented JSRoot from correctly visualizing a number of detectors (for me) including B0 tracker, Roman Pots, LowQ2 tagger

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No