### PR TITLE
fix: set default CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,11 @@ endif()
 # Export compile commands as json for run-clang-tidy
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Install to the top directory by default
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR} CACHE PATH "Install in top directory by default" FORCE)
+endif()
+
 # Install into GNU standard directories
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Install to the top directory by default
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR} CACHE PATH "Install in top directory by default" FORCE)
+    set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/prefix CACHE PATH "Install in $src/prefix/ directory by default" FORCE)
 endif()
 
 # Install into GNU standard directories


### PR DESCRIPTION
### Briefly, what does this PR introduce?
If CMAKE_INSTALL_PREFIX is not defined, then it takes on an incorrect default value that is written into the `setup.sh` script (which leads to a `setup.sh` installed by default in the source dir with a DETECTOR_PATH set to a /usr/local dir).

This commit explicitly defines the CMAKE_INSTALL_PREFIX to the source directory if it is not explicitly set.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: incorrect DETECTOR_PATH in setup.sh)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.