### PR TITLE
Si tracker granularity

### DIFF
--- a/compact/tracking/silicon_barrel.xml
+++ b/compact/tracking/silicon_barrel.xml
@@ -178,7 +178,7 @@
 
   <readouts>
     <readout name="SiBarrelHits">
-      <segmentation type="CartesianGridXY" grid_size_x="0.010*mm" grid_size_y="0.010*mm" />
+      <segmentation type="CartesianGridXY" grid_size_x="0.020*mm" grid_size_y="0.020*mm" />
       <id>system:8,layer:4,module:12,sensor:2,x:32:-12,y:-20</id>
     </readout>
   </readouts>

--- a/compact/tracking/silicon_disks.xml
+++ b/compact/tracking/silicon_disks.xml
@@ -426,7 +426,7 @@
 
   <readouts>
     <readout name="TrackerEndcapHits">
-      <segmentation type="CartesianGridXZ" grid_size_x="0.010*mm" grid_size_z="0.010*mm" />
+      <segmentation type="CartesianGridXZ" grid_size_x="0.020*mm" grid_size_z="0.020*mm" />
       <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
     </readout>
   </readouts>

--- a/compact/tracking/vertex_barrel.xml
+++ b/compact/tracking/vertex_barrel.xml
@@ -145,7 +145,7 @@
 
   <readouts>
     <readout name="VertexBarrelHits">
-      <segmentation type="CartesianGridXY" grid_size_x="0.010*mm" grid_size_y="0.010*mm" />
+      <segmentation type="CartesianGridXY" grid_size_x="0.020*mm" grid_size_y="0.020*mm" />
       <id>system:8,layer:4,module:12,sensor:2,x:32:-16,y:-16</id>
     </readout>
   </readouts>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Updated the segmentation of the silicon tracking detectors from a 10x10um to 20x20um granularity. This reflects the most up-to-date expectations of the pixel size from the tracking working group.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Update to detector configuration

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
