### PR TITLE
Change ECal insert readout size to 1.25 cm x 1.25 cm

### DIFF
--- a/compact/ecal/forward_insert_homogeneous.xml
+++ b/compact/ecal/forward_insert_homogeneous.xml
@@ -91,6 +91,9 @@
 
   <readouts>
     <readout name="EcalEndcapPInsertHits">
+      <documentation>
+        Readout size is 1.25 cm by 1.25 cm -- half the size of the forward ECal readout in x and y.
+      </documentation>
       <segmentation
         type="CartesianGridXY"
         grid_size_x="1.25*cm"

--- a/compact/ecal/forward_insert_homogeneous.xml
+++ b/compact/ecal/forward_insert_homogeneous.xml
@@ -93,8 +93,8 @@
     <readout name="EcalEndcapPInsertHits">
       <segmentation
         type="CartesianGridXY"
-        grid_size_x="1.*cm"
-        grid_size_y="1.*cm"
+        grid_size_x="1.25*cm"
+        grid_size_y="1.25*cm"
       />
       <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>
     </readout>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
As mentioned in Issue #440, this changes the ECal insert readout size to 1.25 cm x 1.25 cm from 1 cm x 1 cm.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #440 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
None that I know of.
### Does this PR change default behavior?
Changes default readout size of ECal insert.