### PR TITLE
fix: disable optical photon generation in hpDIRC

### DIFF
--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -35,6 +35,17 @@
     <composite n="1" ref="Si"/>
     <composite n="2" ref="O"/>
   </material>
+  <material name="Epotek">
+    <D type="density" value="1.2" unit="g/cm3"/>
+    <composite n="5" ref="H"/>
+    <composite n="3" ref="C"/>
+    <composite n="2" ref="O"/>
+  </material>
+  <material name="Sapphire">
+    <D type="density" value="3.98" unit="g/cm3"/>
+    <composite n="2" ref="Al"/>
+    <composite n="3" ref="O"/>
+  </material>
   <material name="G10">
     <D type="density" value="1.7" unit="g/cm3"/>
     <fraction n="0.08" ref="Cl"/>

--- a/compact/optical_materials.xml
+++ b/compact/optical_materials.xml
@@ -918,7 +918,7 @@
         Nlak33aMaterial->AddElement(O, natoms = 2);
       -->
     </material>
-    <material name="Sapphire">
+    <material name="SapphireOptical">
       <D type="density" value="3.98" unit="g/cm3"/>
       <composite n="2" ref="Al"/>
       <composite n="3" ref="O"/>

--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -129,11 +129,15 @@
           repeat_y="DIRCBar_count_y"
           repeat_z="DIRCBar_count_z"
           gap="DIRCBar_gap"
-          material="QuartzOptical"
+          material="Quartz"
           vis="DIRCBar"
         />
 
-        <glue thickness="DIRCGlue_thickness" material="EpotekOptical" vis="DIRCGlue"/>
+	<glue
+          thickness="DIRCGlue_thickness"
+          material="Epotek"
+          vis="DIRCGlue"
+        />
 
         <!-- lens -->
         <lens
@@ -143,9 +147,9 @@
           thickness="DIRCLens_thickness"
           r1="DIRCLens_r1"
           r2="DIRCLens_r2"
-          material1="QuartzOptical"
+          material1="Quartz"
           material2="Sapphire"
-          material3="QuartzOptical"
+          material3="Quartz"
           vis1="DIRCLens1"
           vis2="DIRCLens2"
           vis3="DIRCLens3"
@@ -157,7 +161,7 @@
           angle="DIRCPrism_angle"
           long_edge="DIRCPrism_long_edge"
           short_edge="DIRCPrism_short_edge"
-          material="QuartzOptical"
+          material="Quartz"
           vis="DIRCPrism"
         />
 
@@ -165,7 +169,7 @@
           height="DIRCMCP_height"
           width="DIRCMCP_width"
           thickness="DIRCMCP_thickness"
-          material="QuartzOptical"
+          material="Quartz"
           vis="DIRCMCP"
         />
       </module>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The hpDIRC is very inefficient right, causing 20x slowdowns for DIS datasets. Since there is no reconstruction yet for the hpDIRC, there is no reason to simulate all these photons.

This PR reverts the optical materials to their regular counterparts.

@niwgit This follows in part from today's discussion. There is no digitization or reconstruction of the hpDIRC, so in the short term there is no real use for these optical photons. Before re-enabling the optical photons by default we would probably need digitization and reconstruction, and we need a better understanding of the impact on running times.

Cc: @mdiefent @rahmans1 @T-Britton 

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
  - We need a benchmark to catch regressions in running time like this... @veprbl @torrijeske 
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes, reverts to not having optical photons in the hpDIRC.

### Does this PR change default behavior?
Yes, no more optical photons in the hpDIRC.