### PR TITLE
EcalBarrelScFi: reduce EcalBarrel_TotalFiberLayers_num from 15 to 12

### DIFF
--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -46,7 +46,7 @@
       For W/SiFi (sPHENIX): X0 ~ 0.7 cm (but different fiber orientation)
     </comment>
     <constant name="EcalBarrel_RadiatorThickness"    value="EcalBarrel_FiberZSpacing*17"/>
-    <constant name="EcalBarrel_TotalFiberLayers_num" value="15"/>
+    <constant name="EcalBarrel_TotalFiberLayers_num" value="12"/>
     <constant name="EcalBarrel_ModRepeat"            value="EcalBarrelStavesN"/>
     <constant name="EcalBarrel_ModLength"            value="0.5*m"/>
     <constant name="EcalBarrel_ModWidth"             value="0.5*m"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Reduced the number of sublayers in Barrel ECAL from 15 to 12

![StaveLay15](https://github.com/eic/epic/assets/135090475/5e977966-aed6-4e55-bf3b-5ee3bfef0ea3)
to
![ShorterStave](https://github.com/eic/epic/assets/135090475/c666d9b5-15a3-4115-978b-70afbd484819)

Overall shrinking of the barrel
![EcalBarrelLay15](https://github.com/eic/epic/assets/135090475/eec7ad5e-7e70-4e14-a749-b28e43f924dc)
to
![ShorterBarrel](https://github.com/eic/epic/assets/135090475/a770aa6d-b597-4faa-aa2e-e9ceb84e6934)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #436 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Shortens Barrel Calorimeter size