### PR TITLE
fix: dd4hep::CartesianField renamed type to field_type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,6 @@ include(GNUInstallDirs)
 find_package(DD4hep 1.21 REQUIRED COMPONENTS DDCore DDRec)
 find_package(fmt REQUIRED)
 
-# ePIC compile definitions
-option(EPIC_COMPILE_DEFINITIONS "Additional compile definitions" "")
-add_compile_definitions(${EPIC_COMPILE_DEFINITIONS})
-
 #-----------------------------------------------------------------------------------
 set(a_lib_name ${PROJECT_NAME})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,10 @@ include(GNUInstallDirs)
 find_package(DD4hep 1.21 REQUIRED COMPONENTS DDCore DDRec)
 find_package(fmt REQUIRED)
 
+# ePIC compile definitions
+option(EPIC_COMPILE_DEFINITIONS "Additional compile definitions" "")
+add_compile_definitions(${EPIC_COMPILE_DEFINITIONS})
+
 #-----------------------------------------------------------------------------------
 set(a_lib_name ${PROJECT_NAME})
 

--- a/src/FieldMapBrBz.cpp
+++ b/src/FieldMapBrBz.cpp
@@ -23,7 +23,7 @@ using namespace dd4hep;
 // implementation of the field map
 class FieldMapBrBz : public dd4hep::CartesianField::Object {
 public:
-  FieldMapBrBz(const std::string& field_type = "magnetic");
+  FieldMapBrBz(const std::string& field_type_str = "magnetic");
   void Configure(double rmin, double rmax, double rstep, double zmin, double zmax, double zstep);
   void LoadMap(const std::string& map_file, double scale);
   void GetIndices(double r, double z, int& ir, int& iz, double& dr, double& dz);
@@ -42,9 +42,9 @@ private:
 };
 
 // constructor
-FieldMapBrBz::FieldMapBrBz(const std::string& field_type)
+FieldMapBrBz::FieldMapBrBz(const std::string& field_type_str)
 {
-  std::string ftype = field_type;
+  std::string ftype = field_type_str;
   for (auto& c : ftype) {
     c = tolower(c);
   }
@@ -56,7 +56,7 @@ FieldMapBrBz::FieldMapBrBz(const std::string& field_type)
     type = CartesianField::ELECTRIC;
   } else {
     type = CartesianField::UNKNOWN;
-    std::cout << "FieldMapBrBz Warning: Unknown field type " << field_type << "!" << std::endl;
+    std::cout << "FieldMapBrBz Warning: Unknown field type " << field_type_str << "!" << std::endl;
   }
 }
 

--- a/src/FieldMapBrBz.cpp
+++ b/src/FieldMapBrBz.cpp
@@ -20,6 +20,13 @@ namespace fs = std::filesystem;
 
 using namespace dd4hep;
 
+// In DD4hep 1.26, the name for the `field_type` enum changed (from `type`).
+#if DD4HEP_VERSION_GE(1, 26)
+#define DD4HEP_FIELD_TYPE field_type
+#else
+#define DD4HEP_FIELD_TYPE type
+#endif
+
 // implementation of the field map
 class FieldMapBrBz : public dd4hep::CartesianField::Object {
 public:
@@ -51,11 +58,11 @@ FieldMapBrBz::FieldMapBrBz(const std::string& field_type_str)
 
   // set type
   if (ftype == "magnetic") {
-    type = CartesianField::MAGNETIC;
+    DD4HEP_FIELD_TYPE = CartesianField::MAGNETIC;
   } else if (ftype == "electric") {
-    type = CartesianField::ELECTRIC;
+    DD4HEP_FIELD_TYPE = CartesianField::ELECTRIC;
   } else {
-    type = CartesianField::UNKNOWN;
+    DD4HEP_FIELD_TYPE = CartesianField::UNKNOWN;
     std::cout << "FieldMapBrBz Warning: Unknown field type " << field_type_str << "!" << std::endl;
   }
 }

--- a/src/FieldMapBrBz.cpp
+++ b/src/FieldMapBrBz.cpp
@@ -27,6 +27,18 @@ using namespace dd4hep;
 #define DD4HEP_FIELD_TYPE type
 #endif
 
+// This allows us to specify the name of the variable by hand, when patching
+// the previous versions, by setting `DD4HEP_FIELD_TYPE_OVERRIDE`.
+// TODO remove after DD4hep 1.26 release
+#define XSTR(x) STR(x)
+#define STR(x) #x
+#ifdef DD4HEP_FIELD_TYPE_OVERRIDE
+#undef DD4HEP_FIELD_TYPE
+#define DD4HEP_FIELD_TYPE DD4HEP_FIELD_TYPE_OVERRIDE
+#pragma message("DD4HEP_FIELD_TYPE overridden as " XSTR(DD4HEP_FIELD_TYPE))
+#endif
+#pragma message("DD4HEP_FIELD_TYPE is " XSTR(DD4HEP_FIELD_TYPE))
+
 // implementation of the field map
 class FieldMapBrBz : public dd4hep::CartesianField::Object {
 public:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In the next DD4hep version, the field type will be stored in a variable `field_type` not `type`. This will cause epic to fail to compile. Of course, until then this version will fail to compile. And all older geometries will fail to compile with the newer DD4hep as well. So that's kinda annoying and something I don't have a good solution to...

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.