### PR TITLE
refactor(pfRICH): reduce expansion volume by 5 cm

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -425,7 +425,7 @@ Examples:
 
     <constant name="CentralTrackingRegion_rmax"   value="700.0*mm" />
     <constant name="CentralTrackingRegionP_zmax"  value="1800.0*mm" />
-    <constant name="CentralTrackingRegionN_zmax"  value="1186.0*mm" />
+    <constant name="CentralTrackingRegionN_zmax"  value="1236.0*mm" />
     <constant name="CentralTrackingRegion_length" value="CentralTrackingRegionP_zmax + CentralTrackingRegionN_zmax" />
     <comment>
       tan(theta) to determine rmin in the outer tracking region (due to tapered beampipe)
@@ -459,9 +459,9 @@ Examples:
     <constant name="ForwardRICHRegion_tan1"        value="CentralTrackingRegionP_tan * 0.88" />
     <constant name="ForwardRICHRegion_tan2"        value="Eta3_6_tan * 0.89" />
 
-    <constant name="BackwardPIDRegion_length"     value="54.1*cm" />
+    <constant name="BackwardPIDRegion_length"     value="49.1*cm" />
     <constant name="BackwardPIDRegion_zmin"       value="CentralTrackingRegionN_zmax" />
-    <constant name="BackwardPIDRegion_zmax"       value="BackwardPIDRegion_zmin+BackwardPIDRegion_length" />
+    <constant name="BackwardPIDRegion_zmax"       value="BackwardPIDRegion_zmin + BackwardPIDRegion_length" />
     <constant name="BackwardPIDRegion_rmax"       value="63.0*cm" /> <!-- FIXME hardcoded, was CentralTrackingRegion_rmax -->
     <constant name="BackwardPIDRegion_tan"        value="CentralTrackingRegionN_tan * 0.92" />
 

--- a/compact/pid/pfrich.xml
+++ b/compact/pid/pfrich.xml
@@ -5,14 +5,14 @@
 
 <define>
 <!-- vessel geometry -->
-<constant name="PFRICH_length"             value="min(54.1*cm, BackwardRICHRegion_length)" /> <!-- vessel z-length -->
+<constant name="PFRICH_length"             value="BackwardRICHRegion_length" /> <!-- vessel z-length -->
 <constant name="PFRICH_zmax"               value="-BackwardRICHRegion_zmax"/>         <!-- vessel front -->
 <constant name="PFRICH_zmin"               value="PFRICH_zmax + PFRICH_length"/>      <!-- vessel back -->
 <constant name="PFRICH_rmin0"              value="-PFRICH_zmin * Eta3_9_tan * 0.95"/> <!-- bore radius at vessel frontplane -->
 <constant name="PFRICH_rmin1"              value="-PFRICH_zmax * Eta3_9_tan * 0.85"/> <!-- bore radius at vessel backplane -->
 <constant name="PFRICH_rmax"               value="BackwardPIDRegion_rmax"/>           <!-- vessel radius -->
 <constant name="PFRICH_bore_slope"         value="(PFRICH_rmin1 - PFRICH_rmin0) / PFRICH_length"/> <!-- slope of bore radius -->
-<constant name="PFRICH_proximity_gap"      value="35*cm"/>                            <!-- distance between aerogel exit plane and sensor entrance plane -->
+<constant name="PFRICH_proximity_gap"      value="30*cm"/>                            <!-- distance between aerogel exit plane and sensor entrance plane -->
 <constant name="PFRICH_services_length"    value="15*cm"/>                            <!-- span of service materials behind the sensors -->
 <constant name="PFRICH_wall_thickness"     value="0.5*cm"/>                           <!-- thickness of radial walls -->
 <constant name="PFRICH_window_thickness"   value="0.1*cm"/>                           <!-- thickness of entrance and exit walls -->


### PR DESCRIPTION
### Briefly, what does this PR introduce?
See Elke's slides: https://indico.bnl.gov/event/19808/

Decreases z-min of the pfRICH by 5 cm to accommodate 2 new MPGD disks.

No impact on other detector constants (except for tracker support).

#### Before

![view1_top](https://github.com/eic/epic/assets/7843751/036bf322-6368-46eb-875a-6a6432bade6b)

#### After

![view1_top](https://github.com/eic/epic/assets/7843751/911e150b-4bae-4f41-912d-be1fa0c07e4f)

#### Constants Diff
```diff
148c148
< BackwardEndcapSupportCyl_length =       49.100 = BackwardEndcapSupportCyl_zmax-BackwardEndcapSupportCyl_zmin
---
> BackwardEndcapSupportCyl_length =       44.100 = BackwardEndcapSupportCyl_zmax-BackwardEndcapSupportCyl_zmin
150c150
< BackwardEndcapSupportCyl_z     =      148.150 = 0.5*(BackwardEndcapSupportCyl_zmin+BackwardEndcapSupportCyl_zmax)
---
> BackwardEndcapSupportCyl_z     =      150.650 = 0.5*(BackwardEndcapSupportCyl_zmin+BackwardEndcapSupportCyl_zmax)
152,154c152,154
< BackwardEndcapSupportCyl_zmin  =      123.600 = BackwardPIDRegion_zmin + 5*cm
< BackwardInnerEndcapRegion_length =       69.100 = BackwardPIDRegion_length + BackwardTrackingRegion_length
< BackwardPIDRegion_length       =       54.100 = 54.1*cm
---
> BackwardEndcapSupportCyl_zmin  =      128.600 = BackwardPIDRegion_zmin + 5*cm
> BackwardInnerEndcapRegion_length =       64.100 = BackwardPIDRegion_length + BackwardTrackingRegion_length
> BackwardPIDRegion_length       =       49.100 = 49.1*cm
157,159c157,159
< BackwardPIDRegion_zmax         =      172.700 = BackwardPIDRegion_zmin+BackwardPIDRegion_length
< BackwardPIDRegion_zmin         =      118.600 = CentralTrackingRegionN_zmax
< BackwardRICHRegion_length      =       54.100 = BackwardPIDRegion_length
---
> BackwardPIDRegion_zmax         =      172.700 = BackwardPIDRegion_zmin + BackwardPIDRegion_length
> BackwardPIDRegion_zmin         =      123.600 = CentralTrackingRegionN_zmax
> BackwardRICHRegion_length      =       49.100 = BackwardPIDRegion_length
243c243
< CentralTrackingRegionN_zmax    =      118.600 = 1186.0*mm
---
> CentralTrackingRegionN_zmax    =      123.600 = 1236.0*mm
246c246
< CentralTrackingRegion_length   =      298.600 = CentralTrackingRegionP_zmax + CentralTrackingRegionN_zmax
---
> CentralTrackingRegion_length   =      303.600 = CentralTrackingRegionP_zmax + CentralTrackingRegionN_zmax
709c709
< InnerTrackerEndcapN_zmax       =      118.600 = CentralTrackingRegionN_zmax
---
> InnerTrackerEndcapN_zmax       =      123.600 = CentralTrackingRegionN_zmax
853,854c853,854
< PFRICH_aerogel_zpos            =     -120.200 = -120.200000
< PFRICH_bore_slope              =        0.026 = (PFRICH_rmin1 - PFRICH_rmin0) / PFRICH_length
---
> PFRICH_aerogel_zpos            =     -125.200 = -125.200000
> PFRICH_bore_slope              =        0.024 = (PFRICH_rmin1 - PFRICH_rmin0) / PFRICH_length
859c859
< PFRICH_filter_zpos             =     -121.716 = -121.716000
---
> PFRICH_filter_zpos             =     -126.716 = -126.716000
861c861
< PFRICH_length                  =       54.100 = min(54.1*cm, BackwardRICHRegion_length)
---
> PFRICH_length                  =       49.100 = BackwardRICHRegion_length
868c868
< PFRICH_rmin0                   =        4.563 = -PFRICH_zmin * Eta3_9_tan * 0.95
---
> PFRICH_rmin0                   =        4.756 = -PFRICH_zmin * Eta3_9_tan * 0.95
879c879
< PFRICH_zmin                    =     -118.600 = PFRICH_zmax + PFRICH_length
---
> PFRICH_zmin                    =     -123.600 = PFRICH_zmax + PFRICH_length
1369c1369
< TrackerSupportConeEndcapN_length =       23.181 = TrackerSupportConeEndcapN_zmax - TrackerSupportConeEndcapN_zmin
---
> TrackerSupportConeEndcapN_length =       28.181 = TrackerSupportConeEndcapN_zmax - TrackerSupportConeEndcapN_zmin
1371,1373c1371,1373
< TrackerSupportConeEndcapN_rmin2 =       54.689 = TrackerSupportConeEndcapN_zmax * tan(TrackerBackwardAngle)
< TrackerSupportConeEndcapN_z    =      107.010 = 0.5*(TrackerSupportConeEndcapN_zmin + TrackerSupportConeEndcapN_zmax)
< TrackerSupportConeEndcapN_zmax =      118.600 = InnerTrackerEndcapN_zmax
---
> TrackerSupportConeEndcapN_rmin2 =       56.995 = TrackerSupportConeEndcapN_zmax * tan(TrackerBackwardAngle)
> TrackerSupportConeEndcapN_z    =      109.510 = 0.5*(TrackerSupportConeEndcapN_zmin + TrackerSupportConeEndcapN_zmax)
> TrackerSupportConeEndcapN_zmax =      123.600 = InnerTrackerEndcapN_zmax
```

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: geometry configuration change

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no