### PR TITLE
Change pECal radius to cover up to eta = 1.4

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -521,7 +521,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="EcalEndcapP_zmax"               value="EcalEndcapP_zmin + EcalEndcapP_length"/>
     <constant name="EcalEndcapP_rmin"               value="200.0*mm" />
     <comment> extra 50cm rmax that "protrudes" into the HCAL</comment>
-    <constant name="EcalEndcapP_rmax"               value="floor(Eta1_1_tan * EcalEndcapP_zmin)"/>
+    <constant name="EcalEndcapP_rmax"               value="floor(Eta1_4_tan * EcalEndcapP_zmin)"/>
     <constant name="EcalEndcapP_numLayers"          value="1"/>
 
     <constant name="EcalEndcapPInsert_zmin"           value="EcalEndcapP_zmin"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
From the discussion in the calorimeter meeting (see [here](https://indico.bnl.gov/event/19514/contributions/76474/attachments/47553/80622/main.pdf)), the pECal only needs to cover up to eta = 1.4.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other: Detector size update

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No breaking changes. Users do not need to update their code.

### Does this PR change default behavior?
No.