### PR TITLE
EcalEndcapPInsert: Change Ecal insert readout to 2.5 cm x 2.5 cm

### DIFF
--- a/compact/ecal/forward_insert_homogeneous.xml
+++ b/compact/ecal/forward_insert_homogeneous.xml
@@ -92,12 +92,12 @@
   <readouts>
     <readout name="EcalEndcapPInsertHits">
       <documentation>
-        Readout size is 1.25 cm by 1.25 cm -- half the size of the forward ECal readout in x and y.
+        Readout size matches the size of the forward ECal readout in x and y.
       </documentation>
       <segmentation
         type="CartesianGridXY"
-        grid_size_x="1.25*cm"
-        grid_size_y="1.25*cm"
+        grid_size_x="24.925*mm"
+        grid_size_y="24.65*mm"
       />
       <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>
     </readout>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Matches the Ecal insert readout with the surrounding Ecal readout size (24.925 mm x 24.65 mm, about 2.5 cm x 2.5 cm).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #464 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
None.
### Does this PR change default behavior?
Changes the default size of the Ecal insert readout.