### PR TITLE
Implement 6 AstroPix slots with sensitive layers 1-3-5-6

### DIFF
--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -1,5 +1,6 @@
 <!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
 <!-- Copyright (C) 2022 Whitney Armstrong, Chao Peng, Maria Zurek, Jihee Kim -->
+<!-- Active AstroPix layers: 1-3-5-6 -->
 
 <lccdd>
 
@@ -12,9 +13,10 @@
       ---------------------------------------
     </comment>
     <comment>
-      To change the number of imaging layers from, e.g., 9 to 6,
+      To change the number of imaging layer slots from, e.g., 9 to 6,
       change EcalBarrelImagingLayers_nMax variable
     </comment>
+    <!-- Number of imaging layer slots -->
     <constant name="EcalBarrelImagingLayers_nMax"   value="6"/>
     <constant name="EcalBarrel_Calorimeter_zmin"
       value="min(257*cm, EcalBarrelBackward_zmax)"/>
@@ -52,37 +54,46 @@
     <constant name="EcalBarrel_ModWidth"             value="0.5*m"/>
     <constant name="EcalBarrel_AvailThickness"       value="EcalBarrelRegion_thickness-EcalBarrel_Support_thickness"/>
 
-    <constant name="EcalBarrel_ImagingLayerThickness"
+    
+    <constant name="EcalBarrel_ImagingFirstLayerThickness"
       value="EcalBarrel_SiliconThickness
       + EcalBarrel_ElectronicsThickness
       + EcalBarrel_CopperThickness
       + EcalBarrel_KaptonThickness
       + EcalBarrel_EpoxyThickness
       + EcalBarrel_CarbonThickness"/>
+    
+    <constant name="EcalBarrel_ImagingLayerThickness"
+      value="EcalBarrel_CarbonThickness
+      + EcalBarrel_LayerSpacing
+      + EcalBarrel_ImagingFirstLayerThickness"/>
+
+    <constant name="EcalBarrel_ImagingLayerThickness_WithoutFrame"
+      value="EcalBarrel_ImagingLayerThickness
+      - 2*EcalBarrel_CarbonThickness"/>
+
     <constant name="EcalBarrel_ScFiLayerThickness"
-      value="EcalBarrel_RadiatorThickness
-      + EcalBarrel_CarbonThickness
-      + EcalBarrel_LayerSpacing"/>
+      value="EcalBarrel_RadiatorThickness"/>
 
     <constant name="EcalBarrelImagingLayers_num"
         value="min(EcalBarrelImagingLayers_nMax,
-               floor((EcalBarrel_AvailThickness-EcalBarrel_ImagingLayerThickness)/
+               floor((EcalBarrel_AvailThickness-EcalBarrel_ImagingFirstLayerThickness)/
                      (EcalBarrel_ImagingLayerThickness + EcalBarrel_ScFiLayerThickness +
                       EcalBarrel_SpaceBetween)))"/>
     <comment>
       Adjusting size of the ScFi back chunk to match number of imaging layers
-      and 20 radiation lengths in total
+      and ~17.1 radiation lengths in total
     </comment>
-    <constant name="EcalBarrel_FiberChunkLayers_num" value = "EcalBarrel_TotalFiberLayers_num-EcalBarrelImagingLayers_num+1"/>
+    <constant name="EcalBarrel_FiberBulkLayers_num" value = "EcalBarrel_TotalFiberLayers_num-EcalBarrelImagingLayers_num+1"/>
 
     <constant name="EcalBarrel_ImagingPartThickness"
         value="(EcalBarrelImagingLayers_num-1)*(EcalBarrel_ImagingLayerThickness + EcalBarrel_ScFiLayerThickness + EcalBarrel_SpaceBetween)
-              + EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween"/>
+              + EcalBarrel_ImagingFirstLayerThickness + EcalBarrel_SpaceBetween"/>
     <constant name="EcalBarrel_ScFiPartThickness_max"
         value="max(0, EcalBarrel_AvailThickness-EcalBarrel_ImagingPartThickness)"/>
     <constant name="EcalBarrel_ScFiPartThickness"
         value="min(EcalBarrel_ScFiPartThickness_max,
-         EcalBarrel_RadiatorThickness*EcalBarrel_FiberChunkLayers_num)"/>
+         EcalBarrel_RadiatorThickness*EcalBarrel_FiberBulkLayers_num)"/>
     <constant name="EcalBarrel_SensitiveLayers_rmax"
         value="EcalBarrel_rmin + EcalBarrel_ImagingPartThickness + EcalBarrel_ScFiPartThickness"/>
   </define>
@@ -115,15 +126,53 @@
       <dimensions numsides="EcalBarrel_ModRepeat"
         rmin="EcalBarrel_rmin"
         z="EcalBarrel_Calorimeter_length"/>
-      <layer repeat="EcalBarrelImagingLayers_num" vis="EcalBarrelLayerVis"
-        space_between="EcalBarrel_ScFiLayerThickness + EcalBarrel_SpaceBetween"
+      <layer repeat="1" vis="EcalBarrelLayerVis"
         space_before="0.*cm">
         <slice material="Silicon" thickness="EcalBarrel_SiliconThickness" sensitive="yes" limits="cal_limits" vis="EcalBarrelSliceVis"/>
         <slice material="Silicon" thickness="EcalBarrel_ElectronicsThickness" vis="EcalBarrelSliceVis"/>
         <slice material="Copper" thickness="EcalBarrel_CopperThickness"       vis="EcalBarrelSliceVis"/>
         <slice material="Kapton" thickness="EcalBarrel_KaptonThickness"       vis="EcalBarrelSliceVis"/>
         <slice material="Epoxy" thickness="EcalBarrel_EpoxyThickness"         vis="EcalBarrelSliceVis"/>
-        <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness"  vis="EcalBarrelSliceVis"/>
+        <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
+      </layer>
+
+      <layer repeat="1" vis="EcalBarrelLayerVis"
+        space_before="EcalBarrel_ScFiLayerThickness + EcalBarrel_SpaceBetween">
+        <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
+        <slice material="Air" thickness="EcalBarrel_ImagingLayerThickness_WithoutFrame " vis="EcalBarrelSliceVis"/>
+        <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
+      </layer>
+
+      <layer repeat="1" vis="EcalBarrelLayerVis"
+        space_before="EcalBarrel_ScFiLayerThickness + EcalBarrel_SpaceBetween">
+        <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
+        <slice material="Air" thickness="EcalBarrel_LayerSpacing " vis="EcalBarrelSliceVis"/>
+        <slice material="Silicon" thickness="EcalBarrel_SiliconThickness" sensitive="yes" limits="cal_limits" vis="EcalBarrelSliceVis"/>
+        <slice material="Silicon" thickness="EcalBarrel_ElectronicsThickness" vis="EcalBarrelSliceVis"/>
+        <slice material="Copper" thickness="EcalBarrel_CopperThickness"       vis="EcalBarrelSliceVis"/>
+        <slice material="Kapton" thickness="EcalBarrel_KaptonThickness"       vis="EcalBarrelSliceVis"/>
+        <slice material="Epoxy" thickness="EcalBarrel_EpoxyThickness"         vis="EcalBarrelSliceVis"/>
+        <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
+      </layer>
+
+      <layer repeat="1" vis="EcalBarrelLayerVis"
+        space_before="EcalBarrel_ScFiLayerThickness + EcalBarrel_SpaceBetween">
+        <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
+        <slice material="Air" thickness="EcalBarrel_ImagingLayerThickness_WithoutFrame " vis="EcalBarrelSliceVis"/>
+        <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
+      </layer>
+
+      <layer repeat="EcalBarrelImagingLayers_num-4" vis="EcalBarrelLayerVis"
+        space_between="EcalBarrel_ScFiLayerThickness + EcalBarrel_SpaceBetween"
+        space_before="EcalBarrel_ScFiLayerThickness + EcalBarrel_SpaceBetween">
+        <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
+        <slice material="Air" thickness="EcalBarrel_LayerSpacing " vis="EcalBarrelSliceVis"/>
+        <slice material="Silicon" thickness="EcalBarrel_SiliconThickness" sensitive="yes" limits="cal_limits" vis="EcalBarrelSliceVis"/>
+        <slice material="Silicon" thickness="EcalBarrel_ElectronicsThickness" vis="EcalBarrelSliceVis"/>
+        <slice material="Copper" thickness="EcalBarrel_CopperThickness"       vis="EcalBarrelSliceVis"/>
+        <slice material="Kapton" thickness="EcalBarrel_KaptonThickness"       vis="EcalBarrelSliceVis"/>
+        <slice material="Epoxy" thickness="EcalBarrel_EpoxyThickness"         vis="EcalBarrelSliceVis"/>
+        <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
       </layer>
     </detector>
 
@@ -144,14 +193,15 @@
         rmin="EcalBarrel_rmin"
         z="EcalBarrel_Calorimeter_length"/>
       <staves vis="EcalBarrelStaveVis"/>
+
       <layer repeat="EcalBarrelImagingLayers_num-1" vis="EcalBarrelLayerVis"
        space_between="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween"
-       space_before="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween/2.">
+       space_before="EcalBarrel_ImagingFirstLayerThickness + EcalBarrel_SpaceBetween/2.">
         <slice material="SciFiPb_PbGlue" thickness="EcalBarrel_RadiatorThickness" vis="EcalBarrelFiberLayerVis">
           <fiber material="SciFiPb_Scintillator"
-	    sensitive="yes"
+            sensitive="yes"
             grid_n_phi="5"
-	    grid_dr="2*cm"
+            grid_dr="2*cm"
             radius="EcalBarrel_FiberRadius"
             cladding_thickness="EcalBarrel_CladdingThickness"
             spacing_x="EcalBarrel_FiberXSpacing"
@@ -159,18 +209,17 @@
             vis="EcalBarrelFiberLayerVis">
           </fiber>
         </slice>
-        <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
-        <slice material="Air" thickness="EcalBarrel_LayerSpacing " vis="EcalBarrelSliceVis"/>
       </layer>
-      <layer repeat="EcalBarrel_FiberChunkLayers_num" vis="EcalBarrelLayerVis"
+
+      <layer repeat="EcalBarrel_FiberBulkLayers_num" vis="EcalBarrelLayerVis"
           space_before="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween">
         <slice material="SciFiPb_PbGlue"
-          thickness="EcalBarrel_ScFiPartThickness/EcalBarrel_FiberChunkLayers_num"
+          thickness="EcalBarrel_ScFiPartThickness/EcalBarrel_FiberBulkLayers_num"
           vis="EcalBarrelFiberLayerVis">
           <fiber material="SciFiPb_Scintillator"
             sensitive="yes"
             grid_n_phi="5"
-	    grid_dr="2*cm"
+            grid_dr="2*cm"
             radius="EcalBarrel_FiberRadius"
             cladding_thickness="EcalBarrel_CladdingThickness"
             spacing_x="EcalBarrel_FiberXSpacing"
@@ -179,6 +228,7 @@
           </fiber>
         </slice>
       </layer>
+
       <support thickness="EcalBarrel_Support_thickness" material="Aluminum" vis="EcalBarrelSupportVis"/>
     </detector>
   </detectors>

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -54,7 +54,7 @@
     <constant name="EcalBarrel_ModWidth"             value="0.5*m"/>
     <constant name="EcalBarrel_AvailThickness"       value="EcalBarrelRegion_thickness-EcalBarrel_Support_thickness"/>
 
-    
+
     <constant name="EcalBarrel_ImagingFirstLayerThickness"
       value="EcalBarrel_SiliconThickness
       + EcalBarrel_ElectronicsThickness
@@ -62,7 +62,7 @@
       + EcalBarrel_KaptonThickness
       + EcalBarrel_EpoxyThickness
       + EcalBarrel_CarbonThickness"/>
-    
+
     <constant name="EcalBarrel_ImagingLayerThickness"
       value="EcalBarrel_CarbonThickness
       + EcalBarrel_LayerSpacing


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This #PR implements changes in the Imaging lBarrel ECAL geometry. We currently have 6 slots for AstroPix layers and slots 1-3-5-6 are filled with the sensitive layers. Other slots have only air inside. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #468 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @Chao1009 @wdconinc @sly2j 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no (but the topo cluster reconstruction efficiency will be affected)
### Does this PR change default behaviour?
yes


![barrel-all](https://github.com/eic/epic/assets/33816222/048e844c-1a82-40b0-9747-5d616c9599de)
![imaging-4](https://github.com/eic/epic/assets/33816222/cccbb0fd-c6c9-4a15-a08f-b3e97f01e6d8)
![imaging-3](https://github.com/eic/epic/assets/33816222/eacd01dd-07d9-425e-9325-bf61f485df13)
