### PR TITLE
fix: disable world_region and world_limitset

### DIFF
--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -91,8 +91,8 @@
   </documentation>
   <world material="Air">
     <shape type="Box" dx="world_dx" dy="world_dy" dz="world_dz"/>
-    <regionref   name="world_region"/>
-    <limitsetref name="world_limits"/>
+    <!--regionref   name="world_region"/-->
+    <!--limitsetref name="world_limits"/-->
   </world>
 
   <documentation level="0">


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This disables the `world_region` and `world_limitset` since they seem to be enabled in debug mode for some reason. Both limit sets were set to G4UserLimits defaults so they should not have had any effect anyway.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: too much info output)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.