### PR TITLE
ci: consolidate geoviewer job, include epic_ in detector_config json

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -172,7 +172,6 @@ jobs:
         setup: install/setup.sh
         run: |
           configs=${{ needs.list-detector-configs.outputs.configs_csv }}
-
           for config in ${configs//,/ } ; do
             checkGeometry -c ${DETECTOR_PATH}/${config}.xml
           done

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -144,7 +144,7 @@ jobs:
         url: https://eicweb.phy.anl.gov
         project_id: 539
         token: ${{ secrets.EICWEB_GEOVIEWER_TRIGGER }}
-        ref_name: post-pr-comment
+        ref_name: main
         variables: |
           DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
           DETECTOR_REPOSITORYREF=${{ github.ref }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -171,9 +171,10 @@ jobs:
         network_types: "none"
         setup: install/setup.sh
         run: |
-          configs=${{ needs.list-detector-configs.outputs.configs_csv }}
-          IFS=, for config in ${configs} ; do
-            checkGeometry -c ${DETECTOR_PATH}/${config}.xml
+          IFS=, for config in ${{ needs.list-detector-configs.outputs.configs_csv}} ; do
+            echo "::group::${config}" ;
+            checkGeometry -c ${DETECTOR_PATH}/${config}.xml ;
+            echo "::endgroup::" ;
           done
 
   check-tracking-geometry:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -144,7 +144,7 @@ jobs:
         url: https://eicweb.phy.anl.gov
         project_id: 539
         token: ${{ secrets.EICWEB_GEOVIEWER_TRIGGER }}
-        ref_name: main
+        ref_name: post-pr-comment
         variables: |
           DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
           DETECTOR_REPOSITORYREF=${{ github.ref }}
@@ -152,6 +152,7 @@ jobs:
           DETECTOR_VERSION=${{ github.event.pull_request.head.ref || github.ref_name }}
           GITHUB_REPOSITORY=${{ github.repository }}
           GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
+          GITHUB_PR=${{ github.event.pull_request.number }}
 
   check-geometry-configs:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -255,7 +255,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: tgeo
-        path: ${{ github.workspace }}/*.root
+        path: "*.root"
         if-no-files-found: error
 
   dump-constants:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -172,7 +172,7 @@ jobs:
         setup: install/setup.sh
         run: |
           configs=${{ needs.list-detector-configs.outputs.configs_csv }}
-          for config in ${configs//,/ } ; do
+          for config in $(echo ${configs//,/ }) ; do
             checkGeometry -c ${DETECTOR_PATH}/${config}.xml
           done
 
@@ -214,7 +214,7 @@ jobs:
         setup: install/setup.sh
         run: |
           configs=${{ needs.list-detector-configs.outputs.configs_csv }}
-          for config in ${configs//,/ } ; do
+          for config in $(echo ${configs//,/ }) ; do
             geoConverter -compact2gdml -input ${DETECTOR_PATH}/${config}.xml -output ${config}.gdml
           done
     - uses: actions/upload-artifact@v3
@@ -242,7 +242,7 @@ jobs:
         setup: install/setup.sh
         run: |
           configs=${{ needs.list-detector-configs.outputs.configs_csv }}
-          for config in ${configs//,/ } ; do
+          for config in $(echo ${configs//,/ }) ; do
             geoConverter -compact2tgeo -input ${DETECTOR_PATH}/${config}.xml -output ${config}.root
           done
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -37,17 +37,22 @@ jobs:
   list-detector-configs:
     runs-on: ubuntu-latest
     outputs:
-      configs: ${{ steps.list-detector-configs.outputs.configs }}
+      configs_csv: ${{ steps.list-detector-configs.outputs.configs_csv }}
+      configs_json: ${{ steps.list-detector-configs.outputs.configs_json }}
     steps:
     - uses: actions/checkout@v3
     - id: list-detector-configs
       run: |
-        CONFIGS=$((
+        CONFIGS_CSV=$(
+          ls -1 configurations | sed 's/^/epic_/g' | xargs | sed 's/\.yml//g;s/ /,/g'
+        )
+        CONFIGS_JSON=$((
           echo '{ "detector_config": ['
-          ls -1 configurations | xargs | sed 's/\.yml//g;s/ /, /g' | xargs -n 1 echo | sed -r 's/^([^,]*)(,?)$/"\1"\2/'
+          ls -1 configurations | sed 's/^/epic_/g' | xargs | sed 's/\.yml//g;s/ /, /g' | xargs -n 1 echo | sed -r 's/^([^,]*)(,?)$/"\1"\2/'
           echo ' ]}'
         ) | jq -c .)
-        echo "configs=$CONFIGS" | tee -a $GITHUB_OUTPUT
+        echo "configs_csv=${CONFIGS_CSV}" | tee -a $GITHUB_OUTPUT        
+        echo "configs_json=${CONFIGS_JSON}" | tee -a $GITHUB_OUTPUT
 
   build:
     runs-on: ubuntu-latest
@@ -132,8 +137,6 @@ jobs:
     needs:
       - xmllint-after-build
       - list-detector-configs
-    strategy:
-      matrix: ${{ fromJson(needs.list-detector-configs.outputs.configs) }}
     steps:
     - uses: eic/trigger-gitlab-ci@v2
       id: trigger
@@ -141,11 +144,11 @@ jobs:
         url: https://eicweb.phy.anl.gov
         project_id: 539
         token: ${{ secrets.EICWEB_GEOVIEWER_TRIGGER }}
-        ref_name: main
+        ref_name: detector-config-csv-list
         variables: |
           DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
           DETECTOR_REPOSITORYREF=${{ github.ref }}
-          DETECTOR_CONFIG=epic_${{ matrix.detector_config }}
+          DETECTOR_CONFIG=${{ needs.list-detector-configs.outputs.configs_csv }}
           DETECTOR_VERSION=${{ github.event.pull_request.head.ref || github.ref_name }}
           GITHUB_REPOSITORY=${{ github.repository }}
           GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
@@ -157,7 +160,7 @@ jobs:
           -f state="pending" \
           -f target_url="${{ steps.trigger.outputs.web_url }}" \
           -f description="Triggered... $(TZ=America/New_York date)" \
-          -f context="eicweb/geoviewer (epic_${{ matrix.detector_config }})"
+          -f context="eicweb/geoviewer (${{ matrix.detector_config }})"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -167,7 +170,7 @@ jobs:
       - build
       - list-detector-configs
     strategy:
-      matrix: ${{ fromJson(needs.list-detector-configs.outputs.configs) }}
+      matrix: ${{ fromJson(needs.list-detector-configs.outputs.configs_json) }}
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
@@ -182,7 +185,7 @@ jobs:
         network_types: "none"
         setup: install/setup.sh
         run: |
-          checkGeometry -c ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml
+          checkGeometry -c ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml
 
   check-tracking-geometry:
     runs-on: ubuntu-latest
@@ -209,7 +212,7 @@ jobs:
       - build
       - list-detector-configs
     strategy:
-      matrix: ${{ fromJson(needs.list-detector-configs.outputs.configs) }}
+      matrix: ${{ fromJson(needs.list-detector-configs.outputs.configs_json) }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/download-artifact@v3
@@ -223,7 +226,7 @@ jobs:
         network_types: "none"
         setup: install/setup.sh
         run: |
-          geoConverter -compact2gdml -input ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml -output ${{ matrix.detector_config }}.gdml
+          geoConverter -compact2gdml -input ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -output ${{ matrix.detector_config }}.gdml
     - uses: actions/upload-artifact@v3
       with:
         name: gdml
@@ -236,7 +239,7 @@ jobs:
       - build
       - list-detector-configs
     strategy:
-      matrix: ${{ fromJson(needs.list-detector-configs.outputs.configs) }}
+      matrix: ${{ fromJson(needs.list-detector-configs.outputs.configs_json) }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/download-artifact@v3
@@ -250,7 +253,7 @@ jobs:
         network_types: "none"
         setup: install/setup.sh
         run: |
-          geoConverter -compact2tgeo -input ${DETECTOR_PATH}/${DETECTOR}_${{ matrix.detector_config }}.xml -output ${{ matrix.detector_config }}.root
+          geoConverter -compact2tgeo -input ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -output ${{ matrix.detector_config }}.root
     - uses: actions/upload-artifact@v3
       with:
         name: tgeo
@@ -375,7 +378,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - list-detector-configs
     strategy:
       matrix:
         detector_config: [epic_arches, epic_brycecanyon]

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -171,7 +171,8 @@ jobs:
         network_types: "none"
         setup: install/setup.sh
         run: |
-          IFS=, for config in ${{ needs.list-detector-configs.outputs.configs_csv}} ; do
+          IFS=, read -a configs <<< "${{ needs.list-detector-configs.outputs.configs_csv }}"
+          for config in ${configs[@]} ; do
             echo "::group::${config}" ;
             checkGeometry -c ${DETECTOR_PATH}/${config}.xml ;
             echo "::endgroup::" ;

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -172,7 +172,7 @@ jobs:
         setup: install/setup.sh
         run: |
           configs=${{ needs.list-detector-configs.outputs.configs_csv }}
-          for config in $(echo ${configs//,/ }) ; do
+          IFS=, for config in ${configs} ; do
             checkGeometry -c ${DETECTOR_PATH}/${config}.xml
           done
 

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -215,9 +215,11 @@ jobs:
         network_types: "none"
         setup: install/setup.sh
         run: |
-          configs=${{ needs.list-detector-configs.outputs.configs_csv }}
-          for config in $(echo ${configs//,/ }) ; do
-            geoConverter -compact2gdml -input ${DETECTOR_PATH}/${config}.xml -output ${config}.gdml
+          IFS=, read -a configs <<< "${{ needs.list-detector-configs.outputs.configs_csv }}"
+          for config in ${configs[@]} ; do
+            echo "::group::${config}" ;
+            geoConverter -compact2gdml -input ${DETECTOR_PATH}/${config}.xml -output ${config}.gdml ;
+            echo "::endgroup::" ;
           done
     - uses: actions/upload-artifact@v3
       with:
@@ -243,9 +245,11 @@ jobs:
         network_types: "none"
         setup: install/setup.sh
         run: |
-          configs=${{ needs.list-detector-configs.outputs.configs_csv }}
-          for config in $(echo ${configs//,/ }) ; do
-            geoConverter -compact2tgeo -input ${DETECTOR_PATH}/${config}.xml -output ${config}.root
+          IFS=, read -a configs <<< "${{ needs.list-detector-configs.outputs.configs_csv }}"
+          for config in ${configs[@]} ; do
+            echo "::group::${config}" ;
+            geoConverter -compact2tgeo -input ${DETECTOR_PATH}/${config}.xml -output ${config}.root 
+            echo "::endgroup::" ;
           done
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -248,7 +248,7 @@ jobs:
           IFS=, read -a configs <<< "${{ needs.list-detector-configs.outputs.configs_csv }}"
           for config in ${configs[@]} ; do
             echo "::group::${config}" ;
-            geoConverter -compact2tgeo -input ${DETECTOR_PATH}/${config}.xml -output ${config}.root 
+            geoConverter -compact2tgeo -input ${DETECTOR_PATH}/${config}.xml -output ${config}.root
             echo "::endgroup::" ;
           done
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -220,7 +220,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: gdml
-        path: *.gdml
+        path: ${{ github.workspace }}/*.gdml
         if-no-files-found: error
 
   convert-to-tgeo:
@@ -248,7 +248,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: tgeo
-        path: *.root
+        path: ${{ github.workspace }}/*.root
         if-no-files-found: error
 
   dump-constants:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -152,17 +152,6 @@ jobs:
           DETECTOR_VERSION=${{ github.event.pull_request.head.ref || github.ref_name }}
           GITHUB_REPOSITORY=${{ github.repository }}
           GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
-    - run: |
-        gh api \
-           --method POST \
-          -H "Accept: application/vnd.github+json" \
-          /repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha || github.sha }} \
-          -f state="pending" \
-          -f target_url="${{ steps.trigger.outputs.web_url }}" \
-          -f description="Triggered... $(TZ=America/New_York date)" \
-          -f context="eicweb/geoviewer (${{ matrix.detector_config }})"
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   check-geometry-configs:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -225,7 +225,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: gdml
-        path: ${{ github.workspace }}/*.gdml
+        path: "*.gdml"
         if-no-files-found: error
 
   convert-to-tgeo:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -158,9 +158,6 @@ jobs:
     needs:
       - build
       - list-detector-configs
-    strategy:
-      matrix: ${{ fromJson(needs.list-detector-configs.outputs.configs_json) }}
-      fail-fast: false
     steps:
     - uses: actions/checkout@v3
     - uses: actions/download-artifact@v3
@@ -174,7 +171,11 @@ jobs:
         network_types: "none"
         setup: install/setup.sh
         run: |
-          checkGeometry -c ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml
+          configs=${{ needs.list-detector-configs.outputs.configs_csv }}
+
+          for config in ${configs//,/ } ; do
+            checkGeometry -c ${DETECTOR_PATH}/${config}.xml
+          done
 
   check-tracking-geometry:
     runs-on: ubuntu-latest
@@ -200,8 +201,6 @@ jobs:
     needs:
       - build
       - list-detector-configs
-    strategy:
-      matrix: ${{ fromJson(needs.list-detector-configs.outputs.configs_json) }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/download-artifact@v3
@@ -215,11 +214,14 @@ jobs:
         network_types: "none"
         setup: install/setup.sh
         run: |
-          geoConverter -compact2gdml -input ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -output ${{ matrix.detector_config }}.gdml
+          configs=${{ needs.list-detector-configs.outputs.configs_csv }}
+          for config in ${configs//,/ } ; do
+            geoConverter -compact2gdml -input ${DETECTOR_PATH}/${config}.xml -output ${config}.gdml
+          done
     - uses: actions/upload-artifact@v3
       with:
         name: gdml
-        path: ${{ matrix.detector_config }}.gdml
+        path: *.gdml
         if-no-files-found: error
 
   convert-to-tgeo:
@@ -227,8 +229,6 @@ jobs:
     needs:
       - build
       - list-detector-configs
-    strategy:
-      matrix: ${{ fromJson(needs.list-detector-configs.outputs.configs_json) }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/download-artifact@v3
@@ -242,11 +242,14 @@ jobs:
         network_types: "none"
         setup: install/setup.sh
         run: |
-          geoConverter -compact2tgeo -input ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -output ${{ matrix.detector_config }}.root
+          configs=${{ needs.list-detector-configs.outputs.configs_csv }}
+          for config in ${configs//,/ } ; do
+            geoConverter -compact2tgeo -input ${DETECTOR_PATH}/${config}.xml -output ${config}.root
+          done
     - uses: actions/upload-artifact@v3
       with:
         name: tgeo
-        path: ${{ matrix.detector_config }}.root
+        path: *.root
         if-no-files-found: error
 
   dump-constants:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -144,7 +144,7 @@ jobs:
         url: https://eicweb.phy.anl.gov
         project_id: 539
         token: ${{ secrets.EICWEB_GEOVIEWER_TRIGGER }}
-        ref_name: detector-config-csv-list
+        ref_name: main
         variables: |
           DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
           DETECTOR_REPOSITORYREF=${{ github.ref }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -51,7 +51,7 @@ jobs:
           ls -1 configurations | sed 's/^/epic_/g' | xargs | sed 's/\.yml//g;s/ /, /g' | xargs -n 1 echo | sed -r 's/^([^,]*)(,?)$/"\1"\2/'
           echo ' ]}'
         ) | jq -c .)
-        echo "configs_csv=${CONFIGS_CSV}" | tee -a $GITHUB_OUTPUT        
+        echo "configs_csv=${CONFIGS_CSV}" | tee -a $GITHUB_OUTPUT
         echo "configs_json=${CONFIGS_JSON}" | tee -a $GITHUB_OUTPUT
 
   build:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We create a list of detector configs in an early step and use it later on. This expands that functionality to create both a csv and json list. Both have now `epic_<configuration>` as format, consistent with other uses of `DETECTOR_CONFIG`.

This PR also avoids a large number of CI jobs on eicweb to trigger many geoviewers: each CI job was building the entire geometry again. We can avoid this, and just create the geoviewer artifacts in one go. We pass the csv list for that reason.

We also turn the matrix jobs for fast operations back into sequential jobs, avoiding the repeated overhead of starting a container environment.

TODO:
- [x] merge https://eicweb.phy.anl.gov/EIC/benchmarks/geoviewer/-/merge_requests/2 if success
- [x] modify back to using `main` instead of `detector-config-csv-list`

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.