### PR TITLE
fix: use id="ECalBarrel_ID" in barrel_sciglass.xml

### DIFF
--- a/compact/ecal/barrel_sciglass.xml
+++ b/compact/ecal/barrel_sciglass.xml
@@ -38,7 +38,7 @@
       An EM calorimeter with SciGlass blocks
     </comment>
 
-    <detector id="4" name="EcalBarrel" type="epic_EcalBarrelSciGlass" readout="EcalBarrelSciGlassHits" vis="det_vis" calorimeterType="EM_BARREL">
+    <detector id="ECalBarrel_ID" name="EcalBarrelSciGlass" type="epic_EcalBarrelSciGlass" readout="EcalBarrelSciGlassHits" vis="det_vis" calorimeterType="EM_BARREL">
       <comment>
         Global detector dimensions from https://eic.jlab.org/Geometry/Detector/Detector-20220624102507.html
       </comment>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This removes the hard-coded detector `id` for the EcalBarrelSciGlass and avoids potentially overlapping definitions.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: all detector ids should be centrally defined to avoid duplicate use)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @veprbl 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No, unless you explicitly require system values of 4 in cellIDs.

### Does this PR change default behavior?
No, unless you explicitly require system values of 4 in cellIDs.