### PR TITLE
Fix ff vacuum

### DIFF
--- a/compact/far_forward/magnets.xml
+++ b/compact/far_forward/magnets.xml
@@ -7,57 +7,57 @@
       <position x="B0PF_XPosition" y="0" z="B0PF_CenterPosition"/>
       <rotation x="0" y="B0PF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="B0PF_InnerRadius" dz="B0PF_Length*0.5"/>
-      <coefficient coefficient="B0PF_Bmax" skew="0.0*tesla"/>
-      <coefficient coefficient="B0PF_GradientMax" skew="0.0*tesla/m"/>
+      <coefficient coefficient="B0PF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
+      <coefficient coefficient="B0PF_GradientMax*FieldScaleFactor" skew="0.0*tesla/m"/>
     </field>
     <field name="B0APF_Magnet" type="MultipoleMagnet">
       <position x="B0APF_XPosition" y="0" z="B0APF_CenterPosition"/>
       <rotation x="0" y="B0APF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="B0APF_InnerRadius" dz="B0APF_Length*0.5"/>
-      <coefficient coefficient="B0APF_Bmax" skew="0.0*tesla"/>
-          <coefficient coefficient="B0APF_GradientMax" skew="0.0*tesla"/>
+      <coefficient coefficient="B0APF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
+          <coefficient coefficient="B0APF_GradientMax*FieldScaleFactor" skew="0.0*tesla"/>
     </field>
     <field name="Q1APF_Magnet" type="MultipoleMagnet">
       <position x="Q1APF_XPosition" y="0" z="Q1APF_CenterPosition"/>
       <rotation x="0" y="Q1APF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="Q1APF_InnerRadius" dz="Q1APF_Length*0.5"/>
-      <coefficient coefficient="Q1APF_Bmax" skew="0.0*tesla"/>
-      <coefficient coefficient="Q1APF_GradientMax" skew="0.0*tesla/m"/>
+      <coefficient coefficient="Q1APF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
+      <coefficient coefficient="Q1APF_GradientMax*FieldScaleFactor" skew="0.0*tesla/m"/>
     </field>
     <field name="Q1BPF_Magnet" type="MultipoleMagnet">
       <position x="Q1BPF_XPosition" y="0" z="Q1BPF_CenterPosition"/>
       <rotation x="0" y="Q1BPF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="Q1BPF_InnerRadius" dz="Q1BPF_Length*0.5"/>
-      <coefficient coefficient="Q1BPF_Bmax" skew="0.0*tesla"/>
-      <coefficient coefficient="Q1BPF_GradientMax" skew="0.0*tesla/m"/>
+      <coefficient coefficient="Q1BPF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
+      <coefficient coefficient="Q1BPF_GradientMax*FieldScaleFactor" skew="0.0*tesla/m"/>
     </field>
     <field name="Q2PF_Magnet" type="MultipoleMagnet">
       <position x="Q2PF_XPosition" y="0" z="Q2PF_CenterPosition"/>
       <rotation x="0" y="Q2PF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="Q2PF_InnerRadius" dz="Q2PF_Length*0.5"/>
-      <coefficient coefficient="Q2PF_Bmax" skew="0.0*tesla"/>
-      <coefficient coefficient="Q2PF_GradientMax" skew="0.0*tesla/m"/>
+      <coefficient coefficient="Q2PF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
+      <coefficient coefficient="Q2PF_GradientMax*FieldScaleFactor" skew="0.0*tesla/m"/>
     </field>
     <field name="B1PF_Magnet" type="MultipoleMagnet">
       <position x="B1PF_XPosition" y="0" z="B1PF_CenterPosition"/>
       <rotation x="0" y="B1PF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="B1PF_InnerRadius" dz="B1PF_Length*0.5"/>
-      <coefficient coefficient="B1PF_Bmax" skew="0.0*tesla"/>
-          <coefficient coefficient="B1PF_GradientMax" skew="0.0*tesla/m"/>
+      <coefficient coefficient="B1PF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
+          <coefficient coefficient="B1PF_GradientMax*FieldScaleFactor" skew="0.0*tesla/m"/>
     </field>
     <field name="B1APF_Magnet" type="MultipoleMagnet">
       <position x="B1APF_XPosition" y="0" z="B1APF_CenterPosition"/>
       <rotation x="0" y="B1APF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="B1APF_InnerRadius" dz="B1APF_Length*0.5"/>
-      <coefficient coefficient="B1APF_Bmax" skew="0.0*tesla"/>
-          <coefficient coefficient="B1APF_GradientMax" skew="0.0*tesla/m"/>
+      <coefficient coefficient="B1APF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
+          <coefficient coefficient="B1APF_GradientMax*FieldScaleFactor" skew="0.0*tesla/m"/>
     </field>
     <field name="B2PF_Magnet" type="MultipoleMagnet">
       <position x="B2PF_XPosition" y="0" z="B2PF_CenterPosition"/>
       <rotation x="0" y="B2PF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="B2PF_InnerRadius" dz="B2PF_Length*0.5"/>
-      <coefficient coefficient="B2PF_Bmax" skew="0.0*tesla"/>
-      <coefficient coefficient="B2PF_GradientMax" skew="0.0*tesla/cm"/>
+      <coefficient coefficient="B2PF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
+      <coefficient coefficient="B2PF_GradientMax*FieldScaleFactor" skew="0.0*tesla/cm"/>
     </field>
   </fields>
 </lccdd>

--- a/compact/far_forward/offM_tracker.xml
+++ b/compact/far_forward/offM_tracker.xml
@@ -32,7 +32,7 @@
       reflect="false">
       <position x="-780.0*mm" y="0" z="22500*mm"/>
       <rotation x="0*rad" y="-0.047*rad" z="0*rad"/>
-      <module name="Module1" vis="FFTrackerShieldedModuleVis">
+      <module name="OMD1Mod1" vis="FFTrackerShieldedModuleVis">
         <shape x="10.0*cm" y="20.0*cm"/>
         <comment> back-to-front </comment>
         <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
@@ -42,7 +42,7 @@
         <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardOffMTracker_ShieldingAirLayerThickness"/>
         <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
       </module>
-      <layer id="1" module="Module1">
+      <layer id="1" module="OMD1Mod1">
         <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="1.0*cm"
           zstart="0.0/2.0" />
       </layer>
@@ -57,7 +57,7 @@
       reflect="false">
       <position x="-780.0*mm" y="0" z="22520*mm"/>
       <rotation x="0*rad" y="-0.047*rad" z="0*rad"/>
-      <module name="Module1" vis="FFTrackerShieldedModuleVis">
+      <module name="OMD2Mod1" vis="FFTrackerShieldedModuleVis">
         <shape x="10.0*cm" y="20.0*cm"/>
         <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
         <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardOffMTracker_ThermalStripThickness" />
@@ -66,7 +66,7 @@
         <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardOffMTracker_ShieldingAirLayerThickness"/>
         <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
       </module>
-      <layer id="1" module="Module1">
+      <layer id="1" module="OMD2Mod1">
          <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="3.2*mm"
            zstart="0.0/2.0" />
       </layer>
@@ -82,7 +82,7 @@
       reflect="false">
       <position x="-870.0*mm" y="0" z="24500*mm"/>
       <rotation x="0*rad" y="-0.047*rad" z="0*rad"/>
-      <module name="Module1" vis="FFTrackerShieldedModuleVis">
+      <module name="OMD3Mod1" vis="FFTrackerShieldedModuleVis">
         <shape x="10.0*cm" y="20.0*cm"/>
         <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
         <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardOffMTracker_ThermalStripThickness" />
@@ -91,7 +91,7 @@
         <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardOffMTracker_ShieldingAirLayerThickness"/>
         <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
       </module>
-      <layer id="1" module="Module1">
+      <layer id="1" module="OMD3Mod1">
          <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="3.2*mm"
           zstart="0.0/2.0" />
       </layer>
@@ -107,7 +107,7 @@
       reflect="false">
       <position x="-870.0*mm" y="0" z="24520*mm"/>
       <rotation x="0*rad" y="-0.047*rad" z="0*rad"/>
-      <module name="Module1" vis="FFTrackerShieldedModuleVis">
+      <module name="OMD4Mod1" vis="FFTrackerShieldedModuleVis">
         <shape x="10.0*cm" y="20.0*cm"/>
         <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
         <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardOffMTracker_ThermalStripThickness" />
@@ -116,7 +116,7 @@
         <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardOffMTracker_ShieldingAirLayerThickness"/>
         <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
       </module>
-      <layer id="1" module="Module1">
+      <layer id="1" module="OMD4Mod1">
          <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="3.2*mm"
           zstart="0.0/2.0" />
       </layer>

--- a/compact/far_forward/roman_pots_eRD24_design.xml
+++ b/compact/far_forward/roman_pots_eRD24_design.xml
@@ -87,46 +87,46 @@
       reflect="false" vis="FFTrackerVis">
     <position x="ForwardRomanPotStation1_xpos" y="0" z="ForwardRomanPotStation1_zpos" />
     <rotation x="0" y="ForwardRomanPotStation1_rotation" z="0" />
-    <module name="Module1" vis="FFTrackerShieldedModuleVis" nx="2" ny="2" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
-	    <!--<module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>-->
-	    <!--<module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />-->
-	    <!--<module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />-->
-        <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardRomanPot_LGADThickness" sensitive="true"/>
-	<!--<module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardRomanPot_ShieldingAirLayerThickness"/>-->
-	<!--<module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>-->
-      <!--<module_component material="Vacuum"       thickness="ForwardRomanPot_LayerSeparationThickness"/>	-->
+    <module name="ModuleRP1" vis="FFTrackerShieldedModuleVis" nx="2" ny="2" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
+	    <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
+	    <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />
+	    <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />
+            <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardRomanPot_LGADThickness" sensitive="true"/>
+	    <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardRomanPot_ShieldingAirLayerThickness"/>
+	    <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
+      	    <!--<module_component material="Vacuum"       thickness="ForwardRomanPot_LayerSeparationThickness"/>-->
     </module>
     <module_assembly name="Station1Top">
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+      <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="(6*ForwardRomanPot_ModuleWidth)/2.0" y="ForwardRomanPotStation1_insertion_outer"/>
       </array>
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+      <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="ForwardRomanPotStation1_insertion_outer"/>
       </array>
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+      <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="0" y="ForwardRomanPotStation1_insertion_central"/>
       </array>
-	  <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+	  <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
       </array>
-	  <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+	  <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
       </array>
     </module_assembly>
     <module_assembly name="Station1Bottom">
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+      <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="(4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0" y="-ForwardRomanPotStation1_insertion_outer"/>
       </array>
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+      <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="-ForwardRomanPotStation1_insertion_outer"/>
       </array>
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+      <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="0" y="-ForwardRomanPotStation1_insertion_central"/>
       </array>
-      <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+      <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
       </array>
-      <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+      <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
       </array>
     </module_assembly>

--- a/compact/far_forward/roman_pots_eRD24_design.xml
+++ b/compact/far_forward/roman_pots_eRD24_design.xml
@@ -88,12 +88,12 @@
     <position x="ForwardRomanPotStation1_xpos" y="0" z="ForwardRomanPotStation1_zpos" />
     <rotation x="0" y="ForwardRomanPotStation1_rotation" z="0" />
     <module name="Module1" vis="FFTrackerShieldedModuleVis" nx="2" ny="2" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
-        <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
-        <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />
-        <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />
+	    <!--<module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>-->
+	    <!--<module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />-->
+	    <!--<module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />-->
         <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardRomanPot_LGADThickness" sensitive="true"/>
-        <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardRomanPot_ShieldingAirLayerThickness"/>
-        <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
+	<!--<module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardRomanPot_ShieldingAirLayerThickness"/>-->
+	<!--<module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>-->
       <!--<module_component material="Vacuum"       thickness="ForwardRomanPot_LayerSeparationThickness"/>	-->
     </module>
     <module_assembly name="Station1Top">
@@ -163,12 +163,12 @@
       <position x="ForwardRomanPotStation2_xpos" y="0" z="ForwardRomanPotStation2_zpos" />
     <rotation x="0" y="ForwardRomanPotStation1_rotation" z="0" />
     <module name="Module1" vis="FFTrackerShieldedModuleVis" nx="2" ny="2" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
-      <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
-      <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />
-      <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />
+	    <!--<module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>-->
+	    <!--<module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />-->
+	    <!--<module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />-->
       <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardRomanPot_LGADThickness" sensitive="true"/>
-      <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardRomanPot_ShieldingAirLayerThickness"/>
-      <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
+      <!--<module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardRomanPot_ShieldingAirLayerThickness"/>-->
+	    <!--<module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>-->
     </module>
     <module_assembly name="Station2Top">
       <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">

--- a/compact/far_forward/roman_pots_eRD24_design.xml
+++ b/compact/far_forward/roman_pots_eRD24_design.xml
@@ -163,12 +163,12 @@
       <position x="ForwardRomanPotStation2_xpos" y="0" z="ForwardRomanPotStation2_zpos" />
     <rotation x="0" y="ForwardRomanPotStation1_rotation" z="0" />
     <module name="Module1" vis="FFTrackerShieldedModuleVis" nx="2" ny="2" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
-	    <!--<module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>-->
-	    <!--<module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />-->
-	    <!--<module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />-->
-      <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardRomanPot_LGADThickness" sensitive="true"/>
-      <!--<module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardRomanPot_ShieldingAirLayerThickness"/>-->
-	    <!--<module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>-->
+	    <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
+	    <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />
+	    <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />
+      	    <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardRomanPot_LGADThickness" sensitive="true"/>
+      	    <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardRomanPot_ShieldingAirLayerThickness"/>
+	    <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
     </module>
     <module_assembly name="Station2Top">
       <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">

--- a/compact/far_forward/vacuum.xml
+++ b/compact/far_forward/vacuum.xml
@@ -10,7 +10,7 @@
 
   <detectors>
 
-    <detector id="VacuumMagnetElement_1_ID" name="VacuumMagnetElement" type="magnetElementInnerVacuum" vis="InvisibleNoDaughters">
+    <detector id="VacuumMagnetElement_1_ID" name="VacuumMagnetElement" type="magnetElementInnerVacuum" vis="AnlGold">
       <position x="0.0" y="0.0" z="0.0" />
       <rotation x="0*rad" y="0*rad" z="0*rad" />
     </detector>

--- a/compact/fields/beamline_10x100.xml
+++ b/compact/fields/beamline_10x100.xml
@@ -6,6 +6,8 @@
     <constant name="ElectronBeamEnergy" value="10*GeV"  />
     <constant name="IonBeamEnergy"      value="100*GeV" />
 
+    <constant name="FieldScaleFactor" value="1.0"  /> <!-- only use for 275 GeV magnet config ::: ASK FF EXPERTS -->
+
     <comment>
        Backwards Fields
        Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/

--- a/compact/fields/beamline_10x275.xml
+++ b/compact/fields/beamline_10x275.xml
@@ -6,6 +6,8 @@
     <constant name="ElectronBeamEnergy" value="10*GeV"  />
     <constant name="IonBeamEnergy"      value="275*GeV" />
 
+    <constant name="FieldScaleFactor" value="1.0"  /> <!-- only use for 275 GeV magnet config ::: ASK FF EXPERTS -->
+
     <comment>
        Backwards Fields
        Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/

--- a/compact/fields/beamline_18x275.xml
+++ b/compact/fields/beamline_18x275.xml
@@ -6,7 +6,7 @@
     <constant name="ElectronBeamEnergy" value="18*GeV"  />
     <constant name="IonBeamEnergy"      value="275*GeV" />
 
-    
+
     <constant name="FieldScaleFactor" value="82.0/275.0"  />
 
 

--- a/compact/fields/beamline_18x275.xml
+++ b/compact/fields/beamline_18x275.xml
@@ -6,6 +6,10 @@
     <constant name="ElectronBeamEnergy" value="18*GeV"  />
     <constant name="IonBeamEnergy"      value="275*GeV" />
 
+    
+    <constant name="FieldScaleFactor" value="82.0/275.0"  />
+
+
     <comment>
        Backwards Fields
        Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/

--- a/compact/fields/beamline_18x275.xml
+++ b/compact/fields/beamline_18x275.xml
@@ -5,10 +5,8 @@
 
     <constant name="ElectronBeamEnergy" value="18*GeV"  />
     <constant name="IonBeamEnergy"      value="275*GeV" />
-
-
-    <constant name="FieldScaleFactor" value="82.0/275.0"  />
-
+    
+    <constant name="FieldScaleFactor" value="275.0/275.0"  /> <!-- only use for light ion beams!!! ASK FF EXPERTS -->
 
     <comment>
        Backwards Fields

--- a/compact/fields/beamline_18x275.xml
+++ b/compact/fields/beamline_18x275.xml
@@ -5,7 +5,7 @@
 
     <constant name="ElectronBeamEnergy" value="18*GeV"  />
     <constant name="IonBeamEnergy"      value="275*GeV" />
-    
+
     <constant name="FieldScaleFactor" value="275.0/275.0"  /> <!-- only use for light ion beams!!! ASK FF EXPERTS -->
 
     <comment>

--- a/compact/fields/beamline_5x100.xml
+++ b/compact/fields/beamline_5x100.xml
@@ -6,6 +6,8 @@
     <constant name="ElectronBeamEnergy" value="5*GeV"   />
     <constant name="IonBeamEnergy"      value="100*GeV" />
 
+    <constant name="FieldScaleFactor" value="1.0"  /> <!-- only use for 275 GeV magnet config ::: ASK FF EXPERTS -->
+
     <comment>
        Backwards Fields
        Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/

--- a/compact/fields/beamline_5x41.xml
+++ b/compact/fields/beamline_5x41.xml
@@ -6,6 +6,8 @@
     <constant name="ElectronBeamEnergy" value="5*GeV"  />
     <constant name="IonBeamEnergy"      value="41*GeV" />
 
+    <constant name="FieldScaleFactor" value="1.0"  /> <!-- only use for 275 GeV magnet config ::: ASK FF EXPERTS -->
+
     <comment>
        Backwards Fields
        Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/

--- a/src/CylindricalDipoleMagnet_geo.cpp
+++ b/src/CylindricalDipoleMagnet_geo.cpp
@@ -49,7 +49,7 @@ static Ref_t build_magnet(Detector& dtor, xml_h e, SensitiveDetector /* sens */)
   DetElement yoke_de(sdet, "yoke_de", 1);
   yoke_de.setPlacement(yoke_pv);
   yoke_de.setAttributes(dtor, yoke_vol, x_det.regionStr(), x_det.limitsStr(), yoke_vis);
- 
+
 
   // -- finishing steps
   auto final_pos = Transform3D(Translation3D(pos_x, pos_y, pos_z) * RotationY(pos_theta));

--- a/src/CylindricalDipoleMagnet_geo.cpp
+++ b/src/CylindricalDipoleMagnet_geo.cpp
@@ -29,11 +29,11 @@ static Ref_t build_magnet(Detector& dtor, xml_h e, SensitiveDetector /* sens */)
   double    dim_z     = dims.z();
   xml_dim_t apperture = x_det.child(_Unicode(apperture));
   double    app_r     = apperture.r();
-  xml_dim_t coil      = x_det.child(_Unicode(coil));
-  double    coil_x    = coil.dx();
-  double    coil_y    = coil.dy();
+  //xml_dim_t coil      = x_det.child(_Unicode(coil));
+  //double    coil_x    = coil.dx();
+  //double    coil_y    = coil.dy();
   Material  iron      = dtor.material("Iron");
-  Material  niobium   = dtor.material("Niobium");
+  //Material  niobium   = dtor.material("Niobium");
 
   // std::cout << det_name << " positioned at z=" << pos.z() << ", x=" << pos.x() << "\n";
 
@@ -43,18 +43,21 @@ static Ref_t build_magnet(Detector& dtor, xml_h e, SensitiveDetector /* sens */)
   const string module_name = "Quad_magnet";
 
   const string yoke_vis = dd4hep::getAttrOrDefault<std::string>(x_det, _Unicode(vis), "FFMagnetVis");
-  const string coil_vis = dd4hep::getAttrOrDefault<std::string>(coil, _Unicode(vis), "FFMagnetCoilVis");
+  //const string coil_vis = dd4hep::getAttrOrDefault<std::string>(coil, _Unicode(vis), "FFMagnetCoilVis");
 
   sdet.setAttributes(dtor, assembly, x_det.regionStr(), x_det.limitsStr(), yoke_vis);
 
   // -- yoke
-  Tube   yoke_tube(app_r + coil_y, dim_r, 0.5 * dim_z);
+  //Tube   yoke_tube(app_r + coil_y, dim_r, 0.5 * dim_z);
+  Tube   yoke_tube(app_r, dim_r, 0.5 * dim_z);
   Volume yoke_vol("yoke_vol", yoke_tube, iron);
   auto   yoke_pv = assembly.placeVolume(yoke_vol);
   yoke_pv.addPhysVolID("element", 1);
   DetElement yoke_de(sdet, "yoke_de", 1);
   yoke_de.setPlacement(yoke_pv);
   yoke_de.setAttributes(dtor, yoke_vol, x_det.regionStr(), x_det.limitsStr(), yoke_vis);
+ 
+  /*
 
   // -- coils
   double offset       = 1.5 * coil_x;
@@ -93,6 +96,8 @@ static Ref_t build_magnet(Detector& dtor, xml_h e, SensitiveDetector /* sens */)
   DetElement coil_de(sdet, "coil_de", 2);
   coil_de.setAttributes(dtor, coil_vol, x_det.regionStr(), x_det.limitsStr(), coil_vis);
   coil_de.setPlacement(coil_pv);
+
+  */
 
   // -- finishing steps
   auto final_pos = Transform3D(Translation3D(pos_x, pos_y, pos_z) * RotationY(pos_theta));

--- a/src/CylindricalDipoleMagnet_geo.cpp
+++ b/src/CylindricalDipoleMagnet_geo.cpp
@@ -56,7 +56,7 @@ static Ref_t build_magnet(Detector& dtor, xml_h e, SensitiveDetector /* sens */)
   DetElement yoke_de(sdet, "yoke_de", 1);
   yoke_de.setPlacement(yoke_pv);
   yoke_de.setAttributes(dtor, yoke_vol, x_det.regionStr(), x_det.limitsStr(), yoke_vis);
- 
+
   /*
 
   // -- coils

--- a/src/CylindricalDipoleMagnet_geo.cpp
+++ b/src/CylindricalDipoleMagnet_geo.cpp
@@ -29,13 +29,8 @@ static Ref_t build_magnet(Detector& dtor, xml_h e, SensitiveDetector /* sens */)
   double    dim_z     = dims.z();
   xml_dim_t apperture = x_det.child(_Unicode(apperture));
   double    app_r     = apperture.r();
-  //xml_dim_t coil      = x_det.child(_Unicode(coil));
-  //double    coil_x    = coil.dx();
-  //double    coil_y    = coil.dy();
   Material  iron      = dtor.material("Iron");
-  //Material  niobium   = dtor.material("Niobium");
 
-  // std::cout << det_name << " positioned at z=" << pos.z() << ", x=" << pos.x() << "\n";
 
   DetElement sdet(det_name, det_id);
   Assembly   assembly(det_name + "_assembly");
@@ -43,12 +38,10 @@ static Ref_t build_magnet(Detector& dtor, xml_h e, SensitiveDetector /* sens */)
   const string module_name = "Quad_magnet";
 
   const string yoke_vis = dd4hep::getAttrOrDefault<std::string>(x_det, _Unicode(vis), "FFMagnetVis");
-  //const string coil_vis = dd4hep::getAttrOrDefault<std::string>(coil, _Unicode(vis), "FFMagnetCoilVis");
 
   sdet.setAttributes(dtor, assembly, x_det.regionStr(), x_det.limitsStr(), yoke_vis);
 
   // -- yoke
-  //Tube   yoke_tube(app_r + coil_y, dim_r, 0.5 * dim_z);
   Tube   yoke_tube(app_r, dim_r, 0.5 * dim_z);
   Volume yoke_vol("yoke_vol", yoke_tube, iron);
   auto   yoke_pv = assembly.placeVolume(yoke_vol);
@@ -56,48 +49,7 @@ static Ref_t build_magnet(Detector& dtor, xml_h e, SensitiveDetector /* sens */)
   DetElement yoke_de(sdet, "yoke_de", 1);
   yoke_de.setPlacement(yoke_pv);
   yoke_de.setAttributes(dtor, yoke_vol, x_det.regionStr(), x_det.limitsStr(), yoke_vis);
-
-  /*
-
-  // -- coils
-  double offset       = 1.5 * coil_x;
-  double appc_r       = app_r + 0.5 * coil_y;
-  double offset_angle = atan(offset / appc_r);
-
-  Tube longrod(app_r, app_r + coil_y, 0.5 * dim_z, atan(coil_x / app_r));
-  Tube connector(app_r, app_r + coil_y, coil_y, 0.5 * M_PI - offset_angle);
-
-  UnionSolid coil1(longrod, longrod, Transform3D(RotationZ(-offset_angle)));
-  UnionSolid coil2(coil1, longrod, Transform3D(RotationZ(0.5 * M_PI)));
-  UnionSolid coil3(coil2, longrod, Transform3D(RotationZ(M_PI)));
-  UnionSolid coil4(coil3, longrod, Transform3D(RotationZ(1.5 * M_PI)));
-
-  UnionSolid coil5(coil4, longrod, Transform3D(RotationZ(0.5 * M_PI - offset_angle)));
-  UnionSolid coil6(coil5, longrod, Transform3D(RotationZ(M_PI - offset_angle)));
-  UnionSolid coil7(coil6, longrod, Transform3D(RotationZ(1.5 * M_PI - offset_angle)));
-
-  UnionSolid coil8(coil7, connector, Transform3D(Translation3D(0.0, 0.0, -0.5 * dim_z + coil_y)));
-  UnionSolid coil9(coil8, connector,
-                   Transform3D(Translation3D(0.0, 0.0, -0.5 * dim_z + coil_y) * RotationZ(0.5 * M_PI)));
-  UnionSolid coil10(coil9, connector, Transform3D(Translation3D(0.0, 0.0, -0.5 * dim_z + coil_y) * RotationZ(M_PI)));
-  UnionSolid coil11(coil10, connector,
-                    Transform3D(Translation3D(0.0, 0.0, -0.5 * dim_z + coil_y) * RotationZ(1.5 * M_PI)));
-  UnionSolid coil12(coil11, connector, Transform3D(Translation3D(0.0, 0.0, 0.5 * dim_z - coil_y)));
-  UnionSolid coil13(coil12, connector,
-                    Transform3D(Translation3D(0.0, 0.0, 0.5 * dim_z - coil_y) * RotationZ(0.5 * M_PI)));
-  UnionSolid coil14(coil13, connector, Transform3D(Translation3D(0.0, 0.0, 0.5 * dim_z - coil_y) * RotationZ(M_PI)));
-  UnionSolid coil15(coil14, connector,
-                    Transform3D(Translation3D(0.0, 0.0, 0.5 * dim_z - coil_y) * RotationZ(1.5 * M_PI)));
-
-  Volume coil_vol("coil_vol", coil14, niobium);
-
-  auto       coil_pos = Transform3D(RotationZ(0.5 * M_PI - offset_angle));
-  auto       coil_pv  = assembly.placeVolume(coil_vol, coil_pos);
-  DetElement coil_de(sdet, "coil_de", 2);
-  coil_de.setAttributes(dtor, coil_vol, x_det.regionStr(), x_det.limitsStr(), coil_vis);
-  coil_de.setPlacement(coil_pv);
-
-  */
+ 
 
   // -- finishing steps
   auto final_pos = Transform3D(Translation3D(pos_x, pos_y, pos_z) * RotationY(pos_theta));

--- a/src/ForwardRomanPot_geo.cpp
+++ b/src/ForwardRomanPot_geo.cpp
@@ -43,7 +43,8 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
     Box    m_solid(mod_width / 2.0, mod_height / 2.0, mod_total_thickness / 2.0);
     Volume m_volume(m_nam, m_solid, vacuum);
-    m_volume.setVisAttributes(description.visAttributes(x_mod.visStr()));
+    //m_volume.setVisAttributes(description.visAttributes(x_mod.visStr()));
+	m_volume.setVisAttributes(description.visAttributes("AnlGold"));
 
     double comp_z_pos = -mod_total_thickness / 2.0;
     int    n_sensor   = 1;
@@ -55,7 +56,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       double     comp_y  = getAttrOrDefault<double>(c, _Unicode(height), mod_height);
 
       Material c_mat  = description.material(c.materialStr());
-      string   c_name = _toString(c_id, "component%d");
+      string   c_name = _toString(c_id, "RP_component%d");
 
       Box    comp_s1(comp_x / 2.0, comp_y / 2.0, c_thick / 2.0);
       Solid  comp_shape = comp_s1;

--- a/src/ForwardRomanPot_geo.cpp
+++ b/src/ForwardRomanPot_geo.cpp
@@ -43,8 +43,9 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
     Box    m_solid(mod_width / 2.0, mod_height / 2.0, mod_total_thickness / 2.0);
     Volume m_volume(m_nam, m_solid, vacuum);
+    //set to AnlGold temporarily for future RP troubleshooting
     //m_volume.setVisAttributes(description.visAttributes(x_mod.visStr()));
-	m_volume.setVisAttributes(description.visAttributes("AnlGold"));
+    m_volume.setVisAttributes(description.visAttributes("AnlGold"));
 
     double comp_z_pos = -mod_total_thickness / 2.0;
     int    n_sensor   = 1;

--- a/src/OffMomentumTracker_geo.cpp
+++ b/src/OffMomentumTracker_geo.cpp
@@ -128,7 +128,7 @@ static Ref_t create_OffMomentumTracker(Detector& description, xml_h e, Sensitive
       auto       comp_y  = getAttrOrDefault(c, _Unicode(y), y1);
 
       Material c_mat  = description.material(c.materialStr());
-      string   c_name = _toString(c_id, "component%d");
+      string   c_name = _toString(c_id, "OMD_component%d");
 
       Box   comp_s1(comp_x / 2.0, comp_y / 2.0, c_thick / 2e0);
       Solid comp_shape = comp_s1;

--- a/src/hadronDownstreamBeamPipe.cpp
+++ b/src/hadronDownstreamBeamPipe.cpp
@@ -84,7 +84,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 					    //(z, x)
   //double orbit_start[2] = {22.0623828, -0.6543372}; //meters!
   //double orbit_end[2] = {38.5445361, -1.4039456}; //meters!
-						  //22.07774534	
+						  //22.07774534
   double orbit_start[2] = {22.07774534, -0.650777226}; //meters
   double orbit_end[2] = {38.54362489, -1.436245325};  //meters
 

--- a/src/hadronDownstreamBeamPipe.cpp
+++ b/src/hadronDownstreamBeamPipe.cpp
@@ -129,7 +129,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 	  	  exit_radius_inner  = drift_hadron_section_1_inner_r;
 		  entrance_r_outer   = drift_hadron_section_1_outer_r;
 		  exit_radius_outer  = drift_hadron_section_1_outer_r;
-		  length = length - 0.03;
+		  length = length - 0.04;
 	  }
 	  if(iSection == 1){
 		  entrance_r_inner   = drift_hadron_section_3_inner_r_ent;
@@ -138,7 +138,9 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 		  exit_radius_outer  = drift_hadron_section_3_outer_r_ex;
 		  drift_hadron_section_3_x = x_center;
 		  drift_hadron_section_3_z = z_center;
-		  drift_hadron_section_3_length = length;
+		  drift_hadron_section_3_length = length - 0.02;
+		  //old numbers commented out for reference - A. Jentsch
+		  //length = length - 0.02;
 		  //x_center = -99.25250431/100.0;
 		  //z_center = 2924.185347/100.0;
 		  //length = drift_hadron_section_3_length/100.0;
@@ -150,9 +152,11 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 		  exit_radius_outer  = drift_hadron_section_4_outer_r;
 		  drift_hadron_section_4_x = x_center;
 		  drift_hadron_section_4_z = z_center;
-		  drift_hadron_section_4_length = length;
-		 // x_center =  -123.076799/100.0;
-		 // z_center = 3423.617428/100.0;
+		  drift_hadron_section_4_length = length - 0.02;
+		  length = length - 0.02;
+		  //old numbers commented out for reference - A. Jentsch
+		  // x_center =  -123.076799/100.0;
+		  // z_center = 3423.617428/100.0;
 		  //length = drift_hadron_section_4_length/100.0;
 	  }
 
@@ -198,7 +202,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 		  exit_radius_inner  = drift_hadron_section_3_inner_r_ex;
 		  x_center = drift_hadron_section_3_x;//-99.25250431/100.0;
 		  z_center = drift_hadron_section_3_z;//2924.185347/100.0;
-		  length = drift_hadron_section_3_length; ///100.0;
+		  length = drift_hadron_section_3_length - 0.02; ///100.0;
 	  }
 	  if(iVac == 6){
 		  entrance_r_inner   = drift_hadron_section_4_inner_r;

--- a/src/hadronDownstreamBeamPipe.cpp
+++ b/src/hadronDownstreamBeamPipe.cpp
@@ -55,9 +55,6 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   //int numPipePieces = 4; //number of individual pipe sections 
 
 
-  //double drift_beam_pipe_angle = -0.047666638;
-  // double zPosShift             = 50.0; //cm
-
   double b0_hadron_tube_inner_r = 2.9;   // cm
   double b0_hadron_tube_outer_r = 3.1;   // cm
   double b0_hadron_tube_length  = 120.0; // cm
@@ -65,12 +62,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   
   double drift_hadron_section_1_inner_r = 19.5;
   double drift_hadron_section_1_outer_r = 20.5;
-  //double drift_hadron_section_1_length  = 342.225466; // 393.4334363;
-  /*
-  double drift_hadron_section_2_inner_r = 19.5;
-  double drift_hadron_section_2_outer_r = 20.5;
-  double drift_hadron_section_2_length  = 300.0;
-  */
+ 
   double drift_hadron_section_3_inner_r_ent = 19.5;
   double drift_hadron_section_3_outer_r_ent = 20.5;
   double drift_hadron_section_3_inner_r_ex  = 5.0;
@@ -93,8 +85,8 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   //double orbit_start[2] = {22.0623828, -0.6543372}; //meters!
   //double orbit_end[2] = {38.5445361, -1.4039456}; //meters!
 
-  double orbit_start[2] = {22.07774534, -0.650777226};
-  double orbit_end[2] = {38.54362489, -1.436245325};
+  double orbit_start[2] = {22.07774534, -0.650777226}; //meters
+  double orbit_end[2] = {38.54362489, -1.436245325};  //meters
 
   //calculate straight line formula x = slope*z + intercept
   
@@ -174,90 +166,10 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 	  DetElement pipe_de(sdet, Form("sector_pipe_%d_de", iSection), 1);
 	  pipe_de.setPlacement(pv_pipe);
   }
-  
-
-  
-  // The tube that goes from B1apf to the start of the RP
-
-  /*
-
-  Tube   drift_tube_section_1(drift_hadron_section_1_inner_r, drift_hadron_section_1_outer_r,
-                              drift_hadron_section_1_length / 2.0);
-  Volume v_drift_tube_section_1("v_drift_tube_section_1", drift_tube_section_1, m_SS);
-  sdet.setAttributes(det, v_drift_tube_section_1, x_det.regionStr(), x_det.limitsStr(), vis_name);
-
-  // The tube that serves as a scattering chamber
-
-  Tube   drift_tube_section_2(drift_hadron_section_2_inner_r, drift_hadron_section_2_outer_r,
-                              drift_hadron_section_2_length / 2.0);
-  Volume v_drift_tube_section_2("v_drift_tube_section_2", drift_tube_section_2, m_SS);
-  sdet.setAttributes(det, v_drift_tube_section_2, x_det.regionStr(), x_det.limitsStr(), vis_name);
-
-  Tube   drift_tube_vacuum_2(0.0, drift_hadron_section_2_inner_r, drift_hadron_section_2_length / 2.0);
-  Volume v_drift_tube_vacuum_2("v_drift_tube_vacuum_2", drift_tube_vacuum_2, m_vac);
-  sdet.setAttributes(det, v_drift_tube_vacuum_2, x_det.regionStr(), x_det.limitsStr(), vis_name);
-
-  // The taper from the RP to last straight section
-
-  Cone   drift_tube_section_3(drift_hadron_section_3_length / 2.0, drift_hadron_section_3_inner_r_ent,
-                              drift_hadron_section_3_outer_r_ent, drift_hadron_section_3_inner_r_ex,
-                              drift_hadron_section_3_outer_r_ex);
-  Volume v_drift_tube_section_3("v_drift_tube_section_3", drift_tube_section_3, m_SS);
-  sdet.setAttributes(det, v_drift_tube_section_3, x_det.regionStr(), x_det.limitsStr(), vis_name);
-
-  // Final tube from taper to B2pf magnet
-
-  Tube   drift_tube_section_4(drift_hadron_section_4_inner_r, drift_hadron_section_4_outer_r,
-                              drift_hadron_section_4_length / 2.0);
-  Volume v_drift_tube_section_4("v_drift_tube_section_4", drift_tube_section_4, m_SS);
-  sdet.setAttributes(det, v_drift_tube_section_4, x_det.regionStr(), x_det.limitsStr(), vis_name);
-
-  //----------------------------//
-
-  auto pv_b0_hadron_tube =
-      assembly.placeVolume(v_b0_hadron_tube, Transform3D(RotationY(-0.025), Position(pos.x(), pos.y(), pos.z())));
-  pv_b0_hadron_tube.addPhysVolID("sector", 1);
-  DetElement tube_de_1(sdet, "sector1_de", 1);
-  tube_de_1.setPlacement(pv_b0_hadron_tube);
-
-  // first tube section - right after b1apf - has same size as RP chamber, but keeping separate.
-  auto pv_drift_tube_section_1 = assembly.placeVolume(
-      v_drift_tube_section_1,
-      Transform3D(RotationY(drift_beam_pipe_angle), Position(-73.23100294, 0.0, 2378.69291))); // 2353.06094)));
-  pv_drift_tube_section_1.addPhysVolID("sector", 1);
-  DetElement tube_de_2(sdet, "sector2_de", 1);
-  tube_de_2.setPlacement(pv_drift_tube_section_1);
-  */
-   
-
-  /*
-  // Second section - RP scattering chamber -- keeping separate for now.
-  auto pv_drift_tube_section_2 = assembly.placeVolume(
-      v_drift_tube_section_2, Transform3D(RotationY(drift_beam_pipe_angle), Position(-88.5315717, 0.0, 2699.440911)));
-  pv_drift_tube_section_2.addPhysVolID("sector", 1);
-  DetElement tube_de_3(sdet, "sector3_de", 1);
-  tube_de_3.setPlacement(pv_drift_tube_section_2);
-
-  auto pv_drift_tube_vacuum_2 = assembly.placeVolume(
-      v_drift_tube_vacuum_2, Transform3D(RotationY(drift_beam_pipe_angle), Position(-88.5315717, 0.0, 2699.440911)));
-  pv_drift_tube_vacuum_2.addPhysVolID("sector", 1);
-  DetElement tube_de_4(sdet, "sector4_de", 1);
-  tube_de_4.setPlacement(pv_drift_tube_vacuum_2);
-
-  // Third section -- tapered section acting as poor man's universal exit window.
-  auto pv_drift_tube_section_3 = assembly.placeVolume(
-      v_drift_tube_section_3, Transform3D(RotationY(drift_beam_pipe_angle), Position(-99.25250431, 0.0, 2924.185347)));
-  pv_drift_tube_section_3.addPhysVolID("sector", 1);
-  DetElement tube_de_5(sdet, "sector5_de", 1);
-  tube_de_5.setPlacement(pv_drift_tube_section_3);
-
-  auto pv_drift_tube_section_4 = assembly.placeVolume(
-      v_drift_tube_section_4, Transform3D(RotationY(drift_beam_pipe_angle), Position(-123.076799, 0.0, 3423.617428)));
-  pv_drift_tube_section_4.addPhysVolID("sector", 1);
-  DetElement tube_de_6(sdet, "sector6_de", 1);
-  tube_de_6.setPlacement(pv_drift_tube_section_4);
-  */
-  //make vacuum volumes here
+ 
+  //------------------------------
+  //  make vacuum volumes here
+  //------------------------------
   
   //last two entries are dummy numbers for now
   double z_start_points[7]    = {orbit_start[0]+0.03, 22.590,  24.590,   26.040, 28.040 , 20.0, 20.0 };

--- a/src/hadronDownstreamBeamPipe.cpp
+++ b/src/hadronDownstreamBeamPipe.cpp
@@ -84,7 +84,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 					    //(z, x)
   //double orbit_start[2] = {22.0623828, -0.6543372}; //meters!
   //double orbit_end[2] = {38.5445361, -1.4039456}; //meters!
-
+						  //22.07774534	
   double orbit_start[2] = {22.07774534, -0.650777226}; //meters
   double orbit_end[2] = {38.54362489, -1.436245325};  //meters
 
@@ -105,7 +105,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   //    build drift beam pipe here
   //----------------------------------
 
-  double z_start_pipe[3]    = {orbit_start[0]+0.03, 30.000,  31.500 };
+  double z_start_pipe[3]    = {orbit_start[0], 30.000,  31.500 };
   double z_end_pipe[3]      = {30.000,              31.500,  40.000 };
 
 
@@ -129,7 +129,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 	  	  exit_radius_inner  = drift_hadron_section_1_inner_r;
 		  entrance_r_outer   = drift_hadron_section_1_outer_r;
 		  exit_radius_outer  = drift_hadron_section_1_outer_r;
-		  //length = drift_hadron_section_1_length + drift_hadron_section_2_length;
+		  length = length - 0.03;
 	  }
 	  if(iSection == 1){
 		  entrance_r_inner   = drift_hadron_section_3_inner_r_ent;
@@ -172,8 +172,8 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   //------------------------------
 
   //last two entries are dummy numbers for now
-  double z_start_points[7]    = {orbit_start[0]+0.03, 22.590,  24.590,   26.040, 28.040 , 20.0, 20.0 };
-  double z_endpoints_array[7] = {22.499,              24.499,  25.990,   27.990, z_start_pipe[1] , 25.0, 25.0 };
+  double z_start_points[7]    = {orbit_start[0]+0.03, 22.590,  24.590,   26.055, 28.055 , 20.0, 20.0 };
+  double z_endpoints_array[7] = {22.499,              24.499,  25.980,   27.980, z_start_pipe[1] , 25.0, 25.0 };
 
 
   for(int iVac = 0; iVac < 7; iVac++){

--- a/src/hadronDownstreamBeamPipe.cpp
+++ b/src/hadronDownstreamBeamPipe.cpp
@@ -44,47 +44,142 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   // Material   m_Al    = det.material("Aluminum");
   Material m_Be     = det.material("Beryllium");
   Material m_SS     = det.material("StainlessSteel");
+  Material m_vac    = det.material("Vacuum");
   string   vis_name = x_det.visStr();
 
   PlacedVolume pv_assembly;
 
-  xml::Component pos = x_det.position();
+  //xml::Component pos = x_det.position();
   // xml::Component rot   = x_det.rotation();
+  
+  //int numPipePieces = 4; //number of individual pipe sections 
 
-  /// hard-code defintion here, then refine and make more general
 
-  double drift_beam_pipe_angle = -0.047666638;
+  //double drift_beam_pipe_angle = -0.047666638;
   // double zPosShift             = 50.0; //cm
 
   double b0_hadron_tube_inner_r = 2.9;   // cm
   double b0_hadron_tube_outer_r = 3.1;   // cm
   double b0_hadron_tube_length  = 120.0; // cm
-
+  
+  
   double drift_hadron_section_1_inner_r = 19.5;
   double drift_hadron_section_1_outer_r = 20.5;
-  double drift_hadron_section_1_length  = 342.225466; // 393.4334363;
-
+  //double drift_hadron_section_1_length  = 342.225466; // 393.4334363;
+  /*
   double drift_hadron_section_2_inner_r = 19.5;
   double drift_hadron_section_2_outer_r = 20.5;
   double drift_hadron_section_2_length  = 300.0;
-
+  */
   double drift_hadron_section_3_inner_r_ent = 19.5;
   double drift_hadron_section_3_outer_r_ent = 20.5;
   double drift_hadron_section_3_inner_r_ex  = 5.0;
   double drift_hadron_section_3_outer_r_ex  = 5.2;
   double drift_hadron_section_3_length      = 150.0;
 
+  double drift_hadron_section_3_x = 0.0;
+  double drift_hadron_section_3_z = 0.0;
+
   double drift_hadron_section_4_inner_r = 5.0;
   double drift_hadron_section_4_outer_r = 5.2;
   double drift_hadron_section_4_length  = 850.0;
+  
+  double drift_hadron_section_4_x = 0.0;
+  double drift_hadron_section_4_z = 0.0;
 
-  // This is the beam tube in the B0 magnet for the hadron beam
+  //Calculatate full drift region from line formula for proton orbit
+  					
+					    //(z, x)
+  //double orbit_start[2] = {22.0623828, -0.6543372}; //meters!
+  //double orbit_end[2] = {38.5445361, -1.4039456}; //meters!
+
+  double orbit_start[2] = {22.07774534, -0.650777226};
+  double orbit_end[2] = {38.54362489, -1.436245325};
+
+  //calculate straight line formula x = slope*z + intercept
+  
+  double slope = (orbit_end[1]-orbit_start[1])/(orbit_end[0]-orbit_start[0]);
+  double intercept = orbit_start[1]-(slope*orbit_start[0]);
+  
+  
+  // This is the beam tube in the B0 magnet for the hadron beam  
+  // doesn't use the slope information calculated before - it stands alone
 
   Tube   b0_hadron_tube(b0_hadron_tube_inner_r, b0_hadron_tube_outer_r, b0_hadron_tube_length / 2.0);
   Volume v_b0_hadron_tube("v_b0_hadron_tube", b0_hadron_tube, m_Be);
   sdet.setAttributes(det, v_b0_hadron_tube, x_det.regionStr(), x_det.limitsStr(), vis_name);
 
-  // The tube that goes from B0pf to the start of the RP
+  //----------------------------------
+  //    build drift beam pipe here
+  //----------------------------------
+
+  double z_start_pipe[3]    = {orbit_start[0]+0.03, 30.000,  31.500 };
+  double z_end_pipe[3]      = {30.000,              31.500,  40.000 };
+  
+  
+  for(int iSection = 0; iSection < 3; iSection++){
+  	
+	  double z_endpoint   = z_end_pipe[iSection]; //meters
+	  double x_endpoint   = (slope*z_endpoint) + intercept;
+  	  double x_startpoint = (slope*z_start_pipe[iSection]) + intercept;
+  
+	  double length = sqrt(pow(z_endpoint - z_start_pipe[iSection],2) + pow(x_endpoint - x_startpoint,2));
+	  double z_center = (0.5*length + z_start_pipe[iSection])*cos(slope);
+	  double x_center = (slope*z_center) + intercept;
+  
+  	  double entrance_r_inner  = 0.0; //drift_hadron_section_1_inner_r;
+  	  double exit_radius_inner = 0.0;
+  	  double entrance_r_outer  = 0.0; //drift_hadron_section_1_inner_r;
+  	  double exit_radius_outer = 0.0;
+	  
+	  if(iSection < 1){ 
+		  entrance_r_inner   = drift_hadron_section_1_inner_r;
+	  	  exit_radius_inner  = drift_hadron_section_1_inner_r;
+		  entrance_r_outer   = drift_hadron_section_1_outer_r; 
+		  exit_radius_outer  = drift_hadron_section_1_outer_r;
+		  //length = drift_hadron_section_1_length + drift_hadron_section_2_length;
+	  }
+	  if(iSection == 1){ 
+		  entrance_r_inner   = drift_hadron_section_3_inner_r_ent;
+	  	  exit_radius_inner  = drift_hadron_section_3_inner_r_ex;
+		  entrance_r_outer   = drift_hadron_section_3_outer_r_ent; 
+		  exit_radius_outer  = drift_hadron_section_3_outer_r_ex;
+		  drift_hadron_section_3_x = x_center;
+		  drift_hadron_section_3_z = z_center;
+		  drift_hadron_section_3_length = length;
+		  //x_center = -99.25250431/100.0; 
+		  //z_center = 2924.185347/100.0;
+		  //length = drift_hadron_section_3_length/100.0;
+	  }
+	  if(iSection == 2){ 
+		  entrance_r_inner   = drift_hadron_section_4_inner_r;
+		  exit_radius_inner  = drift_hadron_section_4_inner_r;
+		  entrance_r_outer   = drift_hadron_section_4_outer_r; 
+		  exit_radius_outer  = drift_hadron_section_4_outer_r;
+		  drift_hadron_section_4_x = x_center;
+		  drift_hadron_section_4_z = z_center;
+		  drift_hadron_section_4_length = length;
+		 // x_center =  -123.076799/100.0; 
+		 // z_center = 3423.617428/100.0;
+		  //length = drift_hadron_section_4_length/100.0;
+	  }
+	  
+	  Cone drift_pipe((length*100.0) / 2.0, entrance_r_inner, entrance_r_outer, exit_radius_inner, exit_radius_outer);
+	  
+	  Volume v_pipe(Form("v_drift_tube_pipe_%d", iSection), drift_pipe, m_SS);
+	  sdet.setAttributes(det, v_pipe, x_det.regionStr(), x_det.limitsStr(), vis_name);
+    
+	  auto pv_pipe = assembly.placeVolume(v_pipe, Transform3D(RotationY(slope), Position(100.0*x_center, 0.0, 100.0*z_center))); // 2353.06094)));
+	  pv_pipe.addPhysVolID("sector", 1);
+	  DetElement pipe_de(sdet, Form("sector_pipe_%d_de", iSection), 1);
+	  pipe_de.setPlacement(pv_pipe);
+  }
+  
+
+  
+  // The tube that goes from B1apf to the start of the RP
+
+  /*
 
   Tube   drift_tube_section_1(drift_hadron_section_1_inner_r, drift_hadron_section_1_outer_r,
                               drift_hadron_section_1_length / 2.0);
@@ -97,6 +192,10 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
                               drift_hadron_section_2_length / 2.0);
   Volume v_drift_tube_section_2("v_drift_tube_section_2", drift_tube_section_2, m_SS);
   sdet.setAttributes(det, v_drift_tube_section_2, x_det.regionStr(), x_det.limitsStr(), vis_name);
+
+  Tube   drift_tube_vacuum_2(0.0, drift_hadron_section_2_inner_r, drift_hadron_section_2_length / 2.0);
+  Volume v_drift_tube_vacuum_2("v_drift_tube_vacuum_2", drift_tube_vacuum_2, m_vac);
+  sdet.setAttributes(det, v_drift_tube_vacuum_2, x_det.regionStr(), x_det.limitsStr(), vis_name);
 
   // The taper from the RP to last straight section
 
@@ -128,7 +227,10 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   pv_drift_tube_section_1.addPhysVolID("sector", 1);
   DetElement tube_de_2(sdet, "sector2_de", 1);
   tube_de_2.setPlacement(pv_drift_tube_section_1);
+  */
+   
 
+  /*
   // Second section - RP scattering chamber -- keeping separate for now.
   auto pv_drift_tube_section_2 = assembly.placeVolume(
       v_drift_tube_section_2, Transform3D(RotationY(drift_beam_pipe_angle), Position(-88.5315717, 0.0, 2699.440911)));
@@ -136,18 +238,77 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   DetElement tube_de_3(sdet, "sector3_de", 1);
   tube_de_3.setPlacement(pv_drift_tube_section_2);
 
+  auto pv_drift_tube_vacuum_2 = assembly.placeVolume(
+      v_drift_tube_vacuum_2, Transform3D(RotationY(drift_beam_pipe_angle), Position(-88.5315717, 0.0, 2699.440911)));
+  pv_drift_tube_vacuum_2.addPhysVolID("sector", 1);
+  DetElement tube_de_4(sdet, "sector4_de", 1);
+  tube_de_4.setPlacement(pv_drift_tube_vacuum_2);
+
   // Third section -- tapered section acting as poor man's universal exit window.
   auto pv_drift_tube_section_3 = assembly.placeVolume(
       v_drift_tube_section_3, Transform3D(RotationY(drift_beam_pipe_angle), Position(-99.25250431, 0.0, 2924.185347)));
   pv_drift_tube_section_3.addPhysVolID("sector", 1);
-  DetElement tube_de_4(sdet, "sector4_de", 1);
-  tube_de_4.setPlacement(pv_drift_tube_section_3);
+  DetElement tube_de_5(sdet, "sector5_de", 1);
+  tube_de_5.setPlacement(pv_drift_tube_section_3);
 
   auto pv_drift_tube_section_4 = assembly.placeVolume(
       v_drift_tube_section_4, Transform3D(RotationY(drift_beam_pipe_angle), Position(-123.076799, 0.0, 3423.617428)));
   pv_drift_tube_section_4.addPhysVolID("sector", 1);
-  DetElement tube_de_5(sdet, "sector5_de", 1);
-  tube_de_5.setPlacement(pv_drift_tube_section_4);
+  DetElement tube_de_6(sdet, "sector6_de", 1);
+  tube_de_6.setPlacement(pv_drift_tube_section_4);
+  */
+  //make vacuum volumes here
+  
+  //last two entries are dummy numbers for now
+  double z_start_points[7]    = {orbit_start[0]+0.03, 22.590,  24.590,   26.040, 28.040 , 20.0, 20.0 };
+  double z_endpoints_array[7] = {22.499,              24.499,  25.990,   27.990, z_start_pipe[1] , 25.0, 25.0 };
+  
+  
+  for(int iVac = 0; iVac < 7; iVac++){
+  	
+	  double z_endpoint   = z_endpoints_array[iVac]; //meters
+	  double x_endpoint   = (slope*z_endpoint) + intercept;
+  	  double x_startpoint = (slope*z_start_points[iVac]) + intercept;
+  
+	  double length = sqrt(pow(z_endpoint - z_start_points[iVac],2) + pow(x_endpoint - x_startpoint,2));
+	  double z_center = (0.5*length + z_start_points[iVac])*cos(slope);
+	  double x_center = (slope*z_center) + intercept;
+  
+  	  double entrance_r_inner  = 0.0; //drift_hadron_section_1_inner_r;
+  	  double exit_radius_inner = 0.0;
+	  
+	  if(iVac < 5){ 
+		  entrance_r_inner   = drift_hadron_section_1_inner_r;
+	  	  exit_radius_inner  = drift_hadron_section_1_inner_r;
+	  }
+	  if(iVac == 5){ 
+		  entrance_r_inner   = drift_hadron_section_1_inner_r;
+		  exit_radius_inner  = drift_hadron_section_3_inner_r_ex;
+		  x_center = drift_hadron_section_3_x;//-99.25250431/100.0;
+		  z_center = drift_hadron_section_3_z;//2924.185347/100.0;
+		  length = drift_hadron_section_3_length; ///100.0;
+	  }
+	  if(iVac == 6){ 
+		  entrance_r_inner   = drift_hadron_section_4_inner_r;
+		  exit_radius_inner  = drift_hadron_section_4_inner_r;
+		  //x_center =  -123.076799/100.0; 
+		  //z_center = 3423.617428/100.0;
+		  //length = drift_hadron_section_4_length/100.0;
+		  x_center = drift_hadron_section_4_x;
+		  z_center = drift_hadron_section_4_z;
+		  length = drift_hadron_section_4_length;
+	  }
+	  
+	  Cone drift_vacuum((length*100.0) / 2.0, 0.0, entrance_r_inner-0.5, 0.0, exit_radius_inner-0.5);
+	  
+	  Volume v_vacuum(Form("v_drift_tube_vacuum_%d", iVac), drift_vacuum, m_vac);
+	  sdet.setAttributes(det, v_vacuum, x_det.regionStr(), x_det.limitsStr(), "AnlBlue");
+    
+	  auto pv_vacuum = assembly.placeVolume(v_vacuum, Transform3D(RotationY(slope), Position(100.0*x_center, 0.0, 100.0*z_center))); // 2353.06094)));
+	  pv_vacuum.addPhysVolID("sector", 1);
+	  DetElement vacuum_de(sdet, Form("sector_vac_%d_de", iVac), 1);
+	  vacuum_de.setPlacement(pv_vacuum);
+  }
 
   // Transform3D posAndRot(RotationZYX(rot.z(), rot.y(), rot.x()), Position(pos.x(), pos.y(), pos.z()));
   // Transform3D posAndRot(RotationZYX(rot.z(), rot.y(), rot.x()), Position(x_position, y_position, z_position));

--- a/src/hadronDownstreamBeamPipe.cpp
+++ b/src/hadronDownstreamBeamPipe.cpp
@@ -51,18 +51,18 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 
   //xml::Component pos = x_det.position();
   // xml::Component rot   = x_det.rotation();
-  
-  //int numPipePieces = 4; //number of individual pipe sections 
+
+  //int numPipePieces = 4; //number of individual pipe sections
 
 
   double b0_hadron_tube_inner_r = 2.9;   // cm
   double b0_hadron_tube_outer_r = 3.1;   // cm
   double b0_hadron_tube_length  = 120.0; // cm
-  
-  
+
+
   double drift_hadron_section_1_inner_r = 19.5;
   double drift_hadron_section_1_outer_r = 20.5;
- 
+
   double drift_hadron_section_3_inner_r_ent = 19.5;
   double drift_hadron_section_3_outer_r_ent = 20.5;
   double drift_hadron_section_3_inner_r_ex  = 5.0;
@@ -75,12 +75,12 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   double drift_hadron_section_4_inner_r = 5.0;
   double drift_hadron_section_4_outer_r = 5.2;
   double drift_hadron_section_4_length  = 850.0;
-  
+
   double drift_hadron_section_4_x = 0.0;
   double drift_hadron_section_4_z = 0.0;
 
   //Calculatate full drift region from line formula for proton orbit
-  					
+
 					    //(z, x)
   //double orbit_start[2] = {22.0623828, -0.6543372}; //meters!
   //double orbit_end[2] = {38.5445361, -1.4039456}; //meters!
@@ -89,12 +89,12 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   double orbit_end[2] = {38.54362489, -1.436245325};  //meters
 
   //calculate straight line formula x = slope*z + intercept
-  
+
   double slope = (orbit_end[1]-orbit_start[1])/(orbit_end[0]-orbit_start[0]);
   double intercept = orbit_start[1]-(slope*orbit_start[0]);
-  
-  
-  // This is the beam tube in the B0 magnet for the hadron beam  
+
+
+  // This is the beam tube in the B0 magnet for the hadron beam
   // doesn't use the slope information calculated before - it stands alone
 
   Tube   b0_hadron_tube(b0_hadron_tube_inner_r, b0_hadron_tube_outer_r, b0_hadron_tube_length / 2.0);
@@ -107,115 +107,115 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 
   double z_start_pipe[3]    = {orbit_start[0]+0.03, 30.000,  31.500 };
   double z_end_pipe[3]      = {30.000,              31.500,  40.000 };
-  
-  
+
+
   for(int iSection = 0; iSection < 3; iSection++){
-  	
+
 	  double z_endpoint   = z_end_pipe[iSection]; //meters
 	  double x_endpoint   = (slope*z_endpoint) + intercept;
   	  double x_startpoint = (slope*z_start_pipe[iSection]) + intercept;
-  
+
 	  double length = sqrt(pow(z_endpoint - z_start_pipe[iSection],2) + pow(x_endpoint - x_startpoint,2));
 	  double z_center = (0.5*length + z_start_pipe[iSection])*cos(slope);
 	  double x_center = (slope*z_center) + intercept;
-  
+
   	  double entrance_r_inner  = 0.0; //drift_hadron_section_1_inner_r;
   	  double exit_radius_inner = 0.0;
   	  double entrance_r_outer  = 0.0; //drift_hadron_section_1_inner_r;
   	  double exit_radius_outer = 0.0;
-	  
-	  if(iSection < 1){ 
+
+	  if(iSection < 1){
 		  entrance_r_inner   = drift_hadron_section_1_inner_r;
 	  	  exit_radius_inner  = drift_hadron_section_1_inner_r;
-		  entrance_r_outer   = drift_hadron_section_1_outer_r; 
+		  entrance_r_outer   = drift_hadron_section_1_outer_r;
 		  exit_radius_outer  = drift_hadron_section_1_outer_r;
 		  //length = drift_hadron_section_1_length + drift_hadron_section_2_length;
 	  }
-	  if(iSection == 1){ 
+	  if(iSection == 1){
 		  entrance_r_inner   = drift_hadron_section_3_inner_r_ent;
 	  	  exit_radius_inner  = drift_hadron_section_3_inner_r_ex;
-		  entrance_r_outer   = drift_hadron_section_3_outer_r_ent; 
+		  entrance_r_outer   = drift_hadron_section_3_outer_r_ent;
 		  exit_radius_outer  = drift_hadron_section_3_outer_r_ex;
 		  drift_hadron_section_3_x = x_center;
 		  drift_hadron_section_3_z = z_center;
 		  drift_hadron_section_3_length = length;
-		  //x_center = -99.25250431/100.0; 
+		  //x_center = -99.25250431/100.0;
 		  //z_center = 2924.185347/100.0;
 		  //length = drift_hadron_section_3_length/100.0;
 	  }
-	  if(iSection == 2){ 
+	  if(iSection == 2){
 		  entrance_r_inner   = drift_hadron_section_4_inner_r;
 		  exit_radius_inner  = drift_hadron_section_4_inner_r;
-		  entrance_r_outer   = drift_hadron_section_4_outer_r; 
+		  entrance_r_outer   = drift_hadron_section_4_outer_r;
 		  exit_radius_outer  = drift_hadron_section_4_outer_r;
 		  drift_hadron_section_4_x = x_center;
 		  drift_hadron_section_4_z = z_center;
 		  drift_hadron_section_4_length = length;
-		 // x_center =  -123.076799/100.0; 
+		 // x_center =  -123.076799/100.0;
 		 // z_center = 3423.617428/100.0;
 		  //length = drift_hadron_section_4_length/100.0;
 	  }
-	  
+
 	  Cone drift_pipe((length*100.0) / 2.0, entrance_r_inner, entrance_r_outer, exit_radius_inner, exit_radius_outer);
-	  
+
 	  Volume v_pipe(Form("v_drift_tube_pipe_%d", iSection), drift_pipe, m_SS);
 	  sdet.setAttributes(det, v_pipe, x_det.regionStr(), x_det.limitsStr(), vis_name);
-    
+
 	  auto pv_pipe = assembly.placeVolume(v_pipe, Transform3D(RotationY(slope), Position(100.0*x_center, 0.0, 100.0*z_center))); // 2353.06094)));
 	  pv_pipe.addPhysVolID("sector", 1);
 	  DetElement pipe_de(sdet, Form("sector_pipe_%d_de", iSection), 1);
 	  pipe_de.setPlacement(pv_pipe);
   }
- 
+
   //------------------------------
   //  make vacuum volumes here
   //------------------------------
-  
+
   //last two entries are dummy numbers for now
   double z_start_points[7]    = {orbit_start[0]+0.03, 22.590,  24.590,   26.040, 28.040 , 20.0, 20.0 };
   double z_endpoints_array[7] = {22.499,              24.499,  25.990,   27.990, z_start_pipe[1] , 25.0, 25.0 };
-  
-  
+
+
   for(int iVac = 0; iVac < 7; iVac++){
-  	
+
 	  double z_endpoint   = z_endpoints_array[iVac]; //meters
 	  double x_endpoint   = (slope*z_endpoint) + intercept;
   	  double x_startpoint = (slope*z_start_points[iVac]) + intercept;
-  
+
 	  double length = sqrt(pow(z_endpoint - z_start_points[iVac],2) + pow(x_endpoint - x_startpoint,2));
 	  double z_center = (0.5*length + z_start_points[iVac])*cos(slope);
 	  double x_center = (slope*z_center) + intercept;
-  
+
   	  double entrance_r_inner  = 0.0; //drift_hadron_section_1_inner_r;
   	  double exit_radius_inner = 0.0;
-	  
-	  if(iVac < 5){ 
+
+	  if(iVac < 5){
 		  entrance_r_inner   = drift_hadron_section_1_inner_r;
 	  	  exit_radius_inner  = drift_hadron_section_1_inner_r;
 	  }
-	  if(iVac == 5){ 
+	  if(iVac == 5){
 		  entrance_r_inner   = drift_hadron_section_1_inner_r;
 		  exit_radius_inner  = drift_hadron_section_3_inner_r_ex;
 		  x_center = drift_hadron_section_3_x;//-99.25250431/100.0;
 		  z_center = drift_hadron_section_3_z;//2924.185347/100.0;
 		  length = drift_hadron_section_3_length; ///100.0;
 	  }
-	  if(iVac == 6){ 
+	  if(iVac == 6){
 		  entrance_r_inner   = drift_hadron_section_4_inner_r;
 		  exit_radius_inner  = drift_hadron_section_4_inner_r;
-		  //x_center =  -123.076799/100.0; 
+		  //x_center =  -123.076799/100.0;
 		  //z_center = 3423.617428/100.0;
 		  //length = drift_hadron_section_4_length/100.0;
 		  x_center = drift_hadron_section_4_x;
 		  z_center = drift_hadron_section_4_z;
 		  length = drift_hadron_section_4_length;
 	  }
-	  
+
 	  Cone drift_vacuum((length*100.0) / 2.0, 0.0, entrance_r_inner-0.5, 0.0, exit_radius_inner-0.5);
-	  
+
 	  Volume v_vacuum(Form("v_drift_tube_vacuum_%d", iVac), drift_vacuum, m_vac);
 	  sdet.setAttributes(det, v_vacuum, x_det.regionStr(), x_det.limitsStr(), "AnlBlue");
-    
+
 	  auto pv_vacuum = assembly.placeVolume(v_vacuum, Transform3D(RotationY(slope), Position(100.0*x_center, 0.0, 100.0*z_center))); // 2353.06094)));
 	  pv_vacuum.addPhysVolID("sector", 1);
 	  DetElement vacuum_de(sdet, Form("sector_vac_%d_de", iVac), 1);

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -44,124 +44,61 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   string     vis_name = x_det.visStr();
 
   PlacedVolume pv_assembly;
-
-  // xml::Component pos   = x_det.position();
-  // xml::Component rot   = x_det.rotation();
+	
 
   /// hard-code defintion here, then refine and make more general
 
-  // double drift_beam_pipe_angle = -0.047666638;
-  // double zPosShift             = 50.0; //cm
 
-  // enter dimensions of vaccum cylinders here
-
-  //-----b0pf pipe----
-  /*
-  double radius_b0pf   = 2.9;     // cm
-  double length_b0pf   = 120.0;   // 848.2683995; //290.0;    //cm
+  double radius_b0pf = 2.9*dd4hep::cm;  
+  double length_b0pf = 250.028*dd4hep::cm;   //cm -- shorten by 6mm
   double rotation_b0pf = -0.025;  // radians
-  double x_b0pf        = -16.5;   // cm
-  double y_b0pf        = 0.0;     // cm
-  double z_b0pf        = 640.0;   // cm
+  double x_b0pf = -14.8832*dd4hep::cm;   
+  double y_b0pf = 0.0*dd4hep::cm;    
+  double z_b0pf = 575.314*dd4hep::cm;   
 
-  double radius_b0apf   = 4.3;    // cm
-  double length_b0apf   = 60.0;   // cm
-  double rotation_b0apf = -0.025; // radians
-  double x_b0apf        = -21.0480535;
-  double y_b0apf        = 0.0;
-  double z_b0apf        = 819.8946015;
-
-  double radius_q1apf   = 5.6;     // cm
-  double length_q1apf   = 146.0;   // cm
-  double rotation_q1apf = -0.0195; // radians
-  double x_q1apf        = -25.4342857;
-  double y_q1apf        = 0.0;
-  double z_q1apf        = 962.8296939;
-
-  double radius_q1bpf   = 7.8;    // cm
-  double length_q1bpf   = 161.0;  // cm
-  double rotation_q1bpf = -0.015; // radians
-  double x_q1bpf        = -31.2840809;
-  double y_q1bpf        = 0.0;
-  double z_q1bpf        = 1156.243847;
-
-  double radius_q2pf   = 13.15;   // cm
-  double length_q2pf   = 380.0;   // cm
-  double rotation_q2pf = -0.0148; // radians
-  double x_q2pf        = -40.7362293;
-  double y_q2pf        = 0.0;
-  double z_q2pf        = 1466.604545;
-
-  double radius_b1pf   = 13.5;   // cm
-  double length_b1pf   = 300.0;  // cm
-  double rotation_b1pf = -0.034; // radians
-  double x_b1pf        = -50.3165042;
-  double y_b1pf        = 0.0;
-  double z_b1pf        = 1856.486896;
-
-  double radius_b1apf   = 16.8;   // cm
-  double length_b1apf   = 150.0;  // cm
-  double rotation_b1apf = -0.025; // radians
-  double x_b1apf        = -61.2903791;
-  double y_b1apf        = 0.0;
-  double z_b1apf        = 2131.298439;
-	*/
-
-  double radius_b0pf = 2.9;   //cm
-  double length_b0pf = 250.028;   //cm -- shorten by 6mm
-  double rotation_b0pf = -0.025;  // radians
-  double x_b0pf = -14.8832;   // cm
-  double y_b0pf = 0.0;    // cm
-  double z_b0pf = 575.314;   // cm
-
-  double radius_b0apf = 4.3;   //cm
-  double length_b0apf = 149.452;   //cm -- shorten by 5mm
+  double radius_b0apf = 4.3*dd4hep::cm;   
+  double length_b0apf = 149.452*dd4hep::cm;   //cm -- shorten by 5mm
   double rotation_b0apf = -0.025;  // radians
-  double x_b0apf = -19.9248;   // cm
-  double y_b0apf = 0.0;    // cm
-  double z_b0apf = 774.957;   // cm
+  double x_b0apf = -19.9248*dd4hep::cm;   
+  double y_b0apf = 0.0*dd4hep::cm;    
+  double z_b0apf = 774.957*dd4hep::cm;  
 
-  double radius_q1apf = 5.6;   //cm
-  double length_q1apf = 185.999;   //cm
+  double radius_q1apf = 5.6*dd4hep::cm;   
+  double length_q1apf = 185.999*dd4hep::cm;   
   double rotation_q1apf = -0.0195;  // radians
-  double x_q1apf = -25.0455;   // cm
-  double y_q1apf = 0.0;    // cm
-  double z_q1apf = 942.885;   // cm
+  double x_q1apf = -25.0455*dd4hep::cm;   
+  double y_q1apf = 0.0*dd4hep::cm;    
+  double z_q1apf = 942.885*dd4hep::cm;   
 
-  double radius_q1bpf = 7.8;   //cm
-  double length_q1bpf = 200.998;   //cm
+  double radius_q1bpf = 7.8*dd4hep::cm;   
+  double length_q1bpf = 200.998*dd4hep::cm; 
   double rotation_q1bpf = -0.015;  // radians
-  double x_q1bpf = -30.9852;   // cm
-  double y_q1bpf = 0.0;    // cm
-  double z_q1bpf = 1136.31;   // cm
+  double x_q1bpf = -30.9852*dd4hep::cm;   
+  double y_q1bpf = 0.0*dd4hep::cm;   
+  double z_q1bpf = 1136.31*dd4hep::cm; 
 
-  double radius_q2pf = 13.15;   //cm
-  double length_q2pf = 419.495;   //cm -- shorten by 5mm
+  double radius_q2pf = 13.15*dd4hep::cm;  
+  double length_q2pf = 419.495*dd4hep::cm;   //cm -- shorten by 5mm
   double rotation_q2pf = -0.0148;  // radians
-  double x_q2pf = -40.4423;   // cm
-  double y_q2pf = 0.0;    // cm
-  double z_q2pf = 1446.73;   // cm
+  double x_q2pf = -40.4423*dd4hep::cm;   
+  double y_q2pf = 0.0*dd4hep::cm;    
+  double z_q2pf = 1446.73*dd4hep::cm;   
 
-  double radius_b1pf = 13.5;   //cm
-  double length_b1pf = 349.718;   //cm -- shorten by 3mm
+  double radius_b1pf = 13.5*dd4hep::cm;   
+  double length_b1pf = 349.718*dd4hep::cm;   //cm -- shorten by 3mm
   double rotation_b1pf = -0.034;  // radians
-  double x_b1pf = -49.4721;   // cm
-  double y_b1pf = 0.0;    // cm
-  double z_b1pf = 1831.59;   // cm
+  double x_b1pf = -49.4721*dd4hep::cm;  
+  double y_b1pf = 0.0*dd4hep::cm;    
+  double z_b1pf = 1831.59*dd4hep::cm;   
 
-  double radius_b1apf = 16.8;   //cm
-  double length_b1apf = 200.025;   //cm
+  double radius_b1apf = 16.8*dd4hep::cm;   
+  double length_b1apf = 200.025*dd4hep::cm;   
   double rotation_b1apf = -0.025;  // radians
-  double x_b1apf = -60.6686;   // cm
-  double y_b1apf = 0.0;    // cm
-  double z_b1apf = 2106.41;   // cm
+  double x_b1apf = -60.6686*dd4hep::cm;   
+  double y_b1apf = 0.0*dd4hep::cm;   
+  double z_b1apf = 2106.41*dd4hep::cm;
 
-  //double radius_drift_pipe_1 = 19.0;   //cm
-  //double length_drift_pipe_1 = 200.025;   //cm
-  //double rotation_drift_pipe_1 = -0.047;  // radians
-  //double x_drift_pipe_1 = -60.6686;   // cm
-  //double y_drift_pipe_1 = 0.0;    // cm
-  //double z_drift_pipe_1 = 2106.41;   // cm
+ 
 
   // define shapes here
 
@@ -237,8 +174,6 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   DetElement tube_de_7(sdet, "sector7_de", 1);
   tube_de_7.setPlacement(pv_b1apf_vacuum);
 
-  // Transform3D posAndRot(RotationZYX(rot.z(), rot.y(), rot.x()), Position(pos.x(), pos.y(), pos.z()));
-  // Transform3D posAndRot(RotationZYX(rot.z(), rot.y(), rot.x()), Position(x_position, y_position, z_position));
 
   pv_assembly = det.pickMotherVolume(sdet).placeVolume(assembly); //, posAndRot);
   pv_assembly.addPhysVolID("system", x_det.id()).addPhysVolID("barrel", 1);

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -108,14 +108,14 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 	*/
 
   double radius_b0pf = 2.9;   //cm
-  double length_b0pf = 700.213;   //cm
+  double length_b0pf = 250.028;   //cm -- shorten by 6mm
   double rotation_b0pf = -0.025;  // radians
-  double x_b0pf = -9.25297;   // cm
+  double x_b0pf = -14.8832;   // cm
   double y_b0pf = 0.0;    // cm
-  double z_b0pf = 350.106;   // cm
+  double z_b0pf = 575.314;   // cm
 
   double radius_b0apf = 4.3;   //cm
-  double length_b0apf = 149.952;   //cm
+  double length_b0apf = 149.452;   //cm -- shorten by 5mm
   double rotation_b0apf = -0.025;  // radians
   double x_b0apf = -19.9248;   // cm
   double y_b0apf = 0.0;    // cm
@@ -136,14 +136,14 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   double z_q1bpf = 1136.31;   // cm
 
   double radius_q2pf = 13.15;   //cm
-  double length_q2pf = 419.995;   //cm
+  double length_q2pf = 419.495;   //cm -- shorten by 5mm
   double rotation_q2pf = -0.0148;  // radians
   double x_q2pf = -40.4423;   // cm
   double y_q2pf = 0.0;    // cm
   double z_q2pf = 1446.73;   // cm
 
   double radius_b1pf = 13.5;   //cm
-  double length_b1pf = 350.018;   //cm
+  double length_b1pf = 349.718;   //cm -- shorten by 3mm
   double rotation_b1pf = -0.034;  // radians
   double x_b1pf = -49.4721;   // cm
   double y_b1pf = 0.0;    // cm

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -55,7 +55,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 
   // enter dimensions of vaccum cylinders here
 
-  //-----b0pf pipe----	
+  //-----b0pf pipe----
   /*
   double radius_b0pf   = 2.9;     // cm
   double length_b0pf   = 120.0;   // 848.2683995; //290.0;    //cm

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -55,8 +55,8 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 
   // enter dimensions of vaccum cylinders here
 
-  //-----b0pf pipe----
-
+  //-----b0pf pipe----	
+  /*
   double radius_b0pf   = 2.9;     // cm
   double length_b0pf   = 120.0;   // 848.2683995; //290.0;    //cm
   double rotation_b0pf = -0.025;  // radians
@@ -105,6 +105,57 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   double x_b1apf        = -61.2903791;
   double y_b1apf        = 0.0;
   double z_b1apf        = 2131.298439;
+	*/
+
+  double radius_b0pf = 2.9;   //cm
+  double length_b0pf = 700.213;   //cm
+  double rotation_b0pf = -0.025;  // radians
+  double x_b0pf = -9.25297;   // cm
+  double y_b0pf = 0.0;    // cm
+  double z_b0pf = 350.106;   // cm
+
+  double radius_b0apf = 4.3;   //cm
+  double length_b0apf = 149.952;   //cm
+  double rotation_b0apf = -0.025;  // radians
+  double x_b0apf = -19.9248;   // cm
+  double y_b0apf = 0.0;    // cm
+  double z_b0apf = 774.957;   // cm
+
+  double radius_q1apf = 5.6;   //cm
+  double length_q1apf = 185.999;   //cm
+  double rotation_q1apf = -0.0195;  // radians
+  double x_q1apf = -25.0455;   // cm
+  double y_q1apf = 0.0;    // cm
+  double z_q1apf = 942.885;   // cm
+
+  double radius_q1bpf = 7.8;   //cm
+  double length_q1bpf = 200.998;   //cm
+  double rotation_q1bpf = -0.015;  // radians
+  double x_q1bpf = -30.9852;   // cm
+  double y_q1bpf = 0.0;    // cm
+  double z_q1bpf = 1136.31;   // cm
+
+  double radius_q2pf = 13.15;   //cm
+  double length_q2pf = 419.995;   //cm
+  double rotation_q2pf = -0.0148;  // radians
+  double x_q2pf = -40.4423;   // cm
+  double y_q2pf = 0.0;    // cm
+  double z_q2pf = 1446.73;   // cm
+
+  double radius_b1pf = 13.5;   //cm
+  double length_b1pf = 350.018;   //cm
+  double rotation_b1pf = -0.034;  // radians
+  double x_b1pf = -49.4721;   // cm
+  double y_b1pf = 0.0;    // cm
+  double z_b1pf = 1831.59;   // cm
+
+  double radius_b1apf = 16.8;   //cm
+  double length_b1apf = 200.025;   //cm
+  double rotation_b1apf = -0.025;  // radians
+  double x_b1apf = -60.6686;   // cm
+  double y_b1apf = 0.0;    // cm
+  double z_b1apf = 2106.41;   // cm
+
 
   // define shapes here
 

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -156,6 +156,12 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   double y_b1apf = 0.0;    // cm
   double z_b1apf = 2106.41;   // cm
 
+  //double radius_drift_pipe_1 = 19.0;   //cm
+  //double length_drift_pipe_1 = 200.025;   //cm
+  //double rotation_drift_pipe_1 = -0.047;  // radians
+  //double x_drift_pipe_1 = -60.6686;   // cm
+  //double y_drift_pipe_1 = 0.0;    // cm
+  //double z_drift_pipe_1 = 2106.41;   // cm
 
   // define shapes here
 

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -56,22 +56,22 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   double y_b0pf = 0.0*dd4hep::cm;
   double z_b0pf = 575.314*dd4hep::cm;
 
-  double radius_b0apf = 4.3*dd4hep::cm;
-  double length_b0apf = 149.452*dd4hep::cm;   //cm -- shorten by 5mm
+  double radius_b0apf = 4.3*dd4hep::cm;   
+  double length_b0apf = 149.352*dd4hep::cm;   //cm -- shorten by 6mm
   double rotation_b0apf = -0.025;  // radians
   double x_b0apf = -19.9248*dd4hep::cm;
   double y_b0apf = 0.0*dd4hep::cm;
   double z_b0apf = 774.957*dd4hep::cm;
 
-  double radius_q1apf = 5.6*dd4hep::cm;
-  double length_q1apf = 185.999*dd4hep::cm;
+  double radius_q1apf = 5.6*dd4hep::cm;   
+  double length_q1apf = 185.699*dd4hep::cm; //cm -- shorten by 3mm  
   double rotation_q1apf = -0.0195;  // radians
   double x_q1apf = -25.0455*dd4hep::cm;
   double y_q1apf = 0.0*dd4hep::cm;
   double z_q1apf = 942.885*dd4hep::cm;
 
-  double radius_q1bpf = 7.8*dd4hep::cm;
-  double length_q1bpf = 200.998*dd4hep::cm;
+  double radius_q1bpf = 7.8*dd4hep::cm;   
+  double length_q1bpf = 200.698*dd4hep::cm; //cm -- shorten by 3mm
   double rotation_q1bpf = -0.015;  // radians
   double x_q1bpf = -30.9852*dd4hep::cm;
   double y_q1bpf = 0.0*dd4hep::cm;
@@ -91,8 +91,8 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   double y_b1pf = 0.0*dd4hep::cm;
   double z_b1pf = 1831.59*dd4hep::cm;
 
-  double radius_b1apf = 16.8*dd4hep::cm;
-  double length_b1apf = 200.025*dd4hep::cm;
+  double radius_b1apf = 16.8*dd4hep::cm;   
+  double length_b1apf = 199.725*dd4hep::cm; //cm -- shorten by 3mm  
   double rotation_b1apf = -0.025;  // radians
   double x_b1apf = -60.6686*dd4hep::cm;
   double y_b1apf = 0.0*dd4hep::cm;

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -44,61 +44,61 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   string     vis_name = x_det.visStr();
 
   PlacedVolume pv_assembly;
-	
+
 
   /// hard-code defintion here, then refine and make more general
 
 
-  double radius_b0pf = 2.9*dd4hep::cm;  
+  double radius_b0pf = 2.9*dd4hep::cm;
   double length_b0pf = 250.028*dd4hep::cm;   //cm -- shorten by 6mm
   double rotation_b0pf = -0.025;  // radians
-  double x_b0pf = -14.8832*dd4hep::cm;   
-  double y_b0pf = 0.0*dd4hep::cm;    
-  double z_b0pf = 575.314*dd4hep::cm;   
+  double x_b0pf = -14.8832*dd4hep::cm;
+  double y_b0pf = 0.0*dd4hep::cm;
+  double z_b0pf = 575.314*dd4hep::cm;
 
-  double radius_b0apf = 4.3*dd4hep::cm;   
+  double radius_b0apf = 4.3*dd4hep::cm;
   double length_b0apf = 149.452*dd4hep::cm;   //cm -- shorten by 5mm
   double rotation_b0apf = -0.025;  // radians
-  double x_b0apf = -19.9248*dd4hep::cm;   
-  double y_b0apf = 0.0*dd4hep::cm;    
-  double z_b0apf = 774.957*dd4hep::cm;  
+  double x_b0apf = -19.9248*dd4hep::cm;
+  double y_b0apf = 0.0*dd4hep::cm;
+  double z_b0apf = 774.957*dd4hep::cm;
 
-  double radius_q1apf = 5.6*dd4hep::cm;   
-  double length_q1apf = 185.999*dd4hep::cm;   
+  double radius_q1apf = 5.6*dd4hep::cm;
+  double length_q1apf = 185.999*dd4hep::cm;
   double rotation_q1apf = -0.0195;  // radians
-  double x_q1apf = -25.0455*dd4hep::cm;   
-  double y_q1apf = 0.0*dd4hep::cm;    
-  double z_q1apf = 942.885*dd4hep::cm;   
+  double x_q1apf = -25.0455*dd4hep::cm;
+  double y_q1apf = 0.0*dd4hep::cm;
+  double z_q1apf = 942.885*dd4hep::cm;
 
-  double radius_q1bpf = 7.8*dd4hep::cm;   
-  double length_q1bpf = 200.998*dd4hep::cm; 
+  double radius_q1bpf = 7.8*dd4hep::cm;
+  double length_q1bpf = 200.998*dd4hep::cm;
   double rotation_q1bpf = -0.015;  // radians
-  double x_q1bpf = -30.9852*dd4hep::cm;   
-  double y_q1bpf = 0.0*dd4hep::cm;   
-  double z_q1bpf = 1136.31*dd4hep::cm; 
+  double x_q1bpf = -30.9852*dd4hep::cm;
+  double y_q1bpf = 0.0*dd4hep::cm;
+  double z_q1bpf = 1136.31*dd4hep::cm;
 
-  double radius_q2pf = 13.15*dd4hep::cm;  
+  double radius_q2pf = 13.15*dd4hep::cm;
   double length_q2pf = 419.495*dd4hep::cm;   //cm -- shorten by 5mm
   double rotation_q2pf = -0.0148;  // radians
-  double x_q2pf = -40.4423*dd4hep::cm;   
-  double y_q2pf = 0.0*dd4hep::cm;    
-  double z_q2pf = 1446.73*dd4hep::cm;   
+  double x_q2pf = -40.4423*dd4hep::cm;
+  double y_q2pf = 0.0*dd4hep::cm;
+  double z_q2pf = 1446.73*dd4hep::cm;
 
-  double radius_b1pf = 13.5*dd4hep::cm;   
+  double radius_b1pf = 13.5*dd4hep::cm;
   double length_b1pf = 349.718*dd4hep::cm;   //cm -- shorten by 3mm
   double rotation_b1pf = -0.034;  // radians
-  double x_b1pf = -49.4721*dd4hep::cm;  
-  double y_b1pf = 0.0*dd4hep::cm;    
-  double z_b1pf = 1831.59*dd4hep::cm;   
+  double x_b1pf = -49.4721*dd4hep::cm;
+  double y_b1pf = 0.0*dd4hep::cm;
+  double z_b1pf = 1831.59*dd4hep::cm;
 
-  double radius_b1apf = 16.8*dd4hep::cm;   
-  double length_b1apf = 200.025*dd4hep::cm;   
+  double radius_b1apf = 16.8*dd4hep::cm;
+  double length_b1apf = 200.025*dd4hep::cm;
   double rotation_b1apf = -0.025;  // radians
-  double x_b1apf = -60.6686*dd4hep::cm;   
-  double y_b1apf = 0.0*dd4hep::cm;   
+  double x_b1apf = -60.6686*dd4hep::cm;
+  double y_b1apf = 0.0*dd4hep::cm;
   double z_b1apf = 2106.41*dd4hep::cm;
 
- 
+
 
   // define shapes here
 

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -56,21 +56,21 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   double y_b0pf = 0.0*dd4hep::cm;
   double z_b0pf = 575.314*dd4hep::cm;
 
-  double radius_b0apf = 4.3*dd4hep::cm;   
+  double radius_b0apf = 4.3*dd4hep::cm;
   double length_b0apf = 149.352*dd4hep::cm;   //cm -- shorten by 6mm
   double rotation_b0apf = -0.025;  // radians
   double x_b0apf = -19.9248*dd4hep::cm;
   double y_b0apf = 0.0*dd4hep::cm;
   double z_b0apf = 774.957*dd4hep::cm;
 
-  double radius_q1apf = 5.6*dd4hep::cm;   
-  double length_q1apf = 185.699*dd4hep::cm; //cm -- shorten by 3mm  
+  double radius_q1apf = 5.6*dd4hep::cm;
+  double length_q1apf = 185.699*dd4hep::cm; //cm -- shorten by 3mm
   double rotation_q1apf = -0.0195;  // radians
   double x_q1apf = -25.0455*dd4hep::cm;
   double y_q1apf = 0.0*dd4hep::cm;
   double z_q1apf = 942.885*dd4hep::cm;
 
-  double radius_q1bpf = 7.8*dd4hep::cm;   
+  double radius_q1bpf = 7.8*dd4hep::cm;
   double length_q1bpf = 200.698*dd4hep::cm; //cm -- shorten by 3mm
   double rotation_q1bpf = -0.015;  // radians
   double x_q1bpf = -30.9852*dd4hep::cm;
@@ -91,8 +91,8 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   double y_b1pf = 0.0*dd4hep::cm;
   double z_b1pf = 1831.59*dd4hep::cm;
 
-  double radius_b1apf = 16.8*dd4hep::cm;   
-  double length_b1apf = 199.725*dd4hep::cm; //cm -- shorten by 3mm  
+  double radius_b1apf = 16.8*dd4hep::cm;
+  double length_b1apf = 199.725*dd4hep::cm; //cm -- shorten by 3mm
   double rotation_b1apf = -0.025;  // radians
   double x_b1apf = -60.6686*dd4hep::cm;
   double y_b1apf = 0.0*dd4hep::cm;


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Adds vacuum volumes throughout the FF region, from the B0 all the way to B2PF. There are currently cutouts for the sections where the OMD and RP are sitting, since this would create an overlap.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [x] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No, it should improve simulation results.

### Does this PR change default behavior?

Yes, FF particles should be traversing vacuum for the vast majority of the z = 40m FF area inside the beam pipe.
