### PR TITLE
feat: Align Hcal insert's absorbers with LFHCAL's

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -583,8 +583,8 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="LFHCAL_length"        value="140.0*cm"/>
     <constant name="LFHCAL_zmax"          value="LFHCAL_zmin + LFHCAL_length"/>
 
-    <constant name="HcalEndcapPInsert_zmin"     value="HcalEndcapP_zmin"/>
-    <constant name="HcalEndcapPInsert_length"   value="127.97*cm"/>
+    <constant name="HcalEndcapPInsert_zmin"     value="EcalEndcapP_zmin + EcalEndcapP_length"/>
+    <constant name="HcalEndcapPInsert_length"   value="134.75*cm"/>
     <constant name="HcalEndcapPInsert_zmax"     value="HcalEndcapPInsert_zmin + HcalEndcapPInsert_length"/>
     <constant name="HcalEndcapPInsert_width"    value="59.6*cm"/>
     <constant name="HcalEndcapPInsert_height"    value="59.7485*cm"/>

--- a/compact/hcal/forward_insert.xml
+++ b/compact/hcal/forward_insert.xml
@@ -63,8 +63,7 @@
       ESR foil (front and back of scintillator), a PCB, and an aluminum scitnillator cover
 
       Circular hole is cut out from each layer to account for the beampipe
-      Hole will change in size and position throughout layers
-      Due to angled (from crossing angle) and cone-shaped beampipe
+      Hole will change in size and position throughout layers due to angled (from crossing angle) and cone-shaped beampipe
       Hole radius is beampipe radius + 3.85 cm of clearance
 
     </documentation>

--- a/compact/hcal/forward_insert.xml
+++ b/compact/hcal/forward_insert.xml
@@ -86,7 +86,7 @@
       <comment> Front layer to match front walls of LFHCAL modules </comment> 
       <comment> Slices will be ordered according to the slice order listed here </comment>
       <layer repeat="1" thickness="HcalEndcapPInsertFrontLayerThickness" vis="InvisibleWithDaughters">
-        <slice material="Steel235" thickness="LFHCAL_FrontWallThickness" vis="LFHCAL4MModVis" />
+        <slice material="Steel235" thickness="LFHCAL_FrontWallThickness" vis="LFHCAL8MModVis" />
         <slice material="Air" thickness="HcalEndcapPInsertAirThickness"/>
         <slice material="Aluminum" thickness="HcalEndcapPInsertScintillatorCoverThickness" vis="AnlProcess_Blue"/>
         <slice material="Polystyrene" thickness="HcalEndcapPInsertESRFoilThickness" vis="AnlGray"/>

--- a/compact/hcal/forward_insert.xml
+++ b/compact/hcal/forward_insert.xml
@@ -86,7 +86,7 @@
       <comment> Front layer to match front walls of LFHCAL modules </comment> 
       <comment> Slices will be ordered according to the slice order listed here </comment>
       <layer repeat="1" thickness="HcalEndcapPInsertFrontLayerThickness" vis="InvisibleWithDaughters">
-        <slice material="Tungsten" thickness="LFHCAL_FrontWallThickness" vis="LFHCAL4MModVis" />
+        <slice material="Steel235" thickness="LFHCAL_FrontWallThickness" vis="LFHCAL4MModVis" />
         <slice material="Air" thickness="HcalEndcapPInsertAirThickness"/>
         <slice material="Aluminum" thickness="HcalEndcapPInsertScintillatorCoverThickness" vis="AnlProcess_Blue"/>
         <slice material="Polystyrene" thickness="HcalEndcapPInsertESRFoilThickness" vis="AnlGray"/>

--- a/compact/hcal/forward_insert.xml
+++ b/compact/hcal/forward_insert.xml
@@ -146,7 +146,7 @@
         grid_size_x="3.*cm"
         grid_size_y="3.*cm"
       />
-      <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>
+      <id>system:8,layer:8,slice:8,x:32:-16,y:-16</id>
     </readout>
 
   </readouts>

--- a/compact/hcal/forward_insert.xml
+++ b/compact/hcal/forward_insert.xml
@@ -130,9 +130,9 @@
       </documentation>
       <beampipe_hole
         initial_hole_radius="EcalEndcapPInsert_hole_radius"
-        final_hole_radius="17.04*cm"
+        final_hole_radius="17.17*cm"
         initial_hole_x="EcalEndcapPInsert_hole_xposition"
-        final_hole_x="-10.27*cm"
+        final_hole_x="-10.44*cm"
         initial_hole_y="EcalEndcapPInsert_hole_yposition"
         final_hole_y="0.*cm"
       />

--- a/compact/hcal/forward_insert.xml
+++ b/compact/hcal/forward_insert.xml
@@ -31,8 +31,8 @@
     <constant name="HcalEndcapPInsertFrontLayerThickness"
       value="LFHCAL_FrontWallThickness +
              HcalEndcapPInsertAirThickness +
-             HcalEndcapPInsertESRFoilThickness +
              HcalEndcapPInsertScintillatorCoverThickness +
+             HcalEndcapPInsertESRFoilThickness +
              HcalEndcapPInsertPolystyreneThickness +
              HcalEndcapPInsertESRFoilThickness +
              HcalEndcapPInsertPCBThickness +
@@ -41,8 +41,8 @@
     <constant name="HcalEndcapPInsertSingleLayerThickness"
       value="HcalEndcapPInsertAbsorberThickness +
              HcalEndcapPInsertAirThickness +
-             HcalEndcapPInsertESRFoilThickness +
              HcalEndcapPInsertScintillatorCoverThickness +
+             HcalEndcapPInsertESRFoilThickness +
              HcalEndcapPInsertPolystyreneThickness +
              HcalEndcapPInsertESRFoilThickness +
              HcalEndcapPInsertPCBThickness +

--- a/compact/hcal/forward_insert.xml
+++ b/compact/hcal/forward_insert.xml
@@ -58,8 +58,8 @@
       ### Forward (Positive Z) Endcap Insert for Hadronic Calorimeter
       Insert goes in the middle of the forward endcap HCal -- around the beampipe
 
-      Insert is 30 layers of W/Sc + 24 layers of Steel/Sc + 1 backplate of steel
-      Each of the 50 layers includes air gaps (front and back of each layer),
+      Insert is 1 front layer of Steel/Sc, 4 layers of W/Sc, 60 layers of Steel/Sc + 1 backplate of steel
+      Each of the layers (sans backplate) includes air gaps (front and back of each layer),
       ESR foil (front and back of scintillator), a PCB, and an aluminum scitnillator cover
 
       Circular hole is cut out from each layer to account for the beampipe

--- a/compact/hcal/forward_insert.xml
+++ b/compact/hcal/forward_insert.xml
@@ -16,21 +16,21 @@
       #### Material Thickness
     </documentation>
     <constant name="HcalEndcapPInsertAirThickness"               value="0.02*cm"/>
-    <constant name="HcalEndcapPInsertAbsorberThickness"          value="1.61*cm"/>
-    <constant name="HcalEndcapPInsertScintillatorCoverThickness" value="0.2*cm"/>
+    <constant name="HcalEndcapPInsertAbsorberThickness"          value="1.52*cm"/>
+    <constant name="HcalEndcapPInsertScintillatorCoverThickness" value="0.08*cm"/>
     <constant name="HcalEndcapPInsertPolystyreneThickness"       value="0.30*cm"/>
-    <constant name="HcalEndcapPInsertPCBThickness"               value="0.16*cm"/>
+    <constant name="HcalEndcapPInsertPCBThickness"               value="0.08*cm"/>
     <constant name="HcalEndcapPInsertESRFoilThickness"           value="0.015*cm"/>
 
-
+    <constant name="LFHCAL_FrontWallThickness"                   value="1.50*cm"/>
 
     <documentation>
       - Insert N Layers and computed Thickness
     </documentation>
 
-    <constant name="HcalEndcapPInsertSingleLayerThickness"
-      value="HcalEndcapPInsertAirThickness +
-             HcalEndcapPInsertAbsorberThickness +
+    <constant name="HcalEndcapPInsertFrontLayerThickness"
+      value="LFHCAL_FrontWallThickness +
+             HcalEndcapPInsertAirThickness +
              HcalEndcapPInsertESRFoilThickness +
              HcalEndcapPInsertScintillatorCoverThickness +
              HcalEndcapPInsertPolystyreneThickness +
@@ -38,9 +38,19 @@
              HcalEndcapPInsertPCBThickness +
              HcalEndcapPInsertAirThickness "
     />
-    <constant name="HcalEndcapPInsertBackplateThickness" value="HcalEndcapPInsertAbsorberThickness"/>
-    <constant name="HcalEndcapPInsertLayer_NTungstenRepeat" value="30"/>
-    <constant name="HcalEndcapPInsertLayer_NSteelRepeat" value="24"/>
+    <constant name="HcalEndcapPInsertSingleLayerThickness"
+      value="HcalEndcapPInsertAbsorberThickness +
+             HcalEndcapPInsertAirThickness +
+             HcalEndcapPInsertESRFoilThickness +
+             HcalEndcapPInsertScintillatorCoverThickness +
+             HcalEndcapPInsertPolystyreneThickness +
+             HcalEndcapPInsertESRFoilThickness +
+             HcalEndcapPInsertPCBThickness +
+             HcalEndcapPInsertAirThickness "
+    />
+    <constant name="HcalEndcapPInsertBackplateThickness"    value="HcalEndcapPInsertAbsorberThickness"/>
+    <constant name="HcalEndcapPInsertLayer_NTungstenRepeat" value="4"/>
+    <constant name="HcalEndcapPInsertLayer_NSteelRepeat"    value="60"/>
   </define>
 
   <detectors>
@@ -73,8 +83,19 @@
         z="HcalEndcapPInsert_length"
       />
       <backplate thickness="HcalEndcapPInsertBackplateThickness"/>
-      <comment> Tungsten/Scintillator layers </comment>
+      <comment> Front layer to match front walls of LFHCAL modules </comment> 
       <comment> Slices will be ordered according to the slice order listed here </comment>
+      <layer repeat="1" thickness="HcalEndcapPInsertFrontLayerThickness" vis="InvisibleWithDaughters">
+        <slice material="Tungsten" thickness="LFHCAL_FrontWallThickness" vis="LFHCAL4MModVis" />
+        <slice material="Air" thickness="HcalEndcapPInsertAirThickness"/>
+        <slice material="Aluminum" thickness="HcalEndcapPInsertScintillatorCoverThickness" vis="AnlProcess_Blue"/>
+        <slice material="Polystyrene" thickness="HcalEndcapPInsertESRFoilThickness" vis="AnlGray"/>
+        <slice material="Polystyrene" thickness="HcalEndcapPInsertPolystyreneThickness" sensitive="true" limits="cal_limits" vis="AnlLightGray"/>
+        <slice material="Polystyrene" thickness="HcalEndcapPInsertESRFoilThickness" vis="AnlGray"/>
+        <slice material="Fr4" thickness="HcalEndcapPInsertPCBThickness"/>
+        <slice material="Air" thickness="HcalEndcapPInsertAirThickness"/>
+      </layer>
+      <comment> Tungsten/Scintillator layers </comment>
       <layer repeat="HcalEndcapPInsertLayer_NTungstenRepeat" thickness="HcalEndcapPInsertSingleLayerThickness" vis="InvisibleWithDaughters">
         <slice material="Tungsten" thickness="HcalEndcapPInsertAbsorberThickness" vis="LFHCAL4MModVis" />
         <slice material="Air" thickness="HcalEndcapPInsertAirThickness"/>

--- a/src/InsertCalorimeter_geo.cpp
+++ b/src/InsertCalorimeter_geo.cpp
@@ -35,14 +35,14 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
   const double          hole_radius_initial =
       dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(initial_hole_radius), 14.61 * cm);
   const double hole_radius_final =
-      dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(final_hole_radius), 17.04 * cm);
+      dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(final_hole_radius), 17.17 * cm);
   const std::pair<double, double> hole_radii_parameters(hole_radius_initial, hole_radius_final);
 
   // Subtract by pos.x() and pos.y() to convert from global to local coordinates
   const double hole_x_initial =
       dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(initial_hole_x), -7.20 * cm) - pos.x();
   const double hole_x_final =
-      dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(final_hole_x), -10.27 * cm) - pos.x();
+      dd4hep::getAttrOrDefault<double>(beampipe_hole_xml, _Unicode(final_hole_x), -10.44 * cm) - pos.x();
   const std::pair<double, double> hole_x_parameters(hole_x_initial, hole_x_final);
 
   const double hole_y_initial =


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This changes the material, z-positions, and thicknesses of the absorbers in the forward Hcal insert to match the specifications of the LFHCAL absorbers.

Other slice component thicknesses are adjusted to accommodate these changes.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #499 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
None that I know of.
### Does this PR change default behavior?
Adjusts default geometry of the forward Hcal insert.