### PR TITLE
configurations/ip6_*.yml: add marco field

### DIFF
--- a/configurations/crystal_endcap_only.yml
+++ b/configurations/crystal_endcap_only.yml
@@ -1,0 +1,3 @@
+features:
+  ecal:
+    backward_PbWO4:

--- a/configurations/ip6.yml
+++ b/configurations/ip6.yml
@@ -1,4 +1,6 @@
 features:
+  fields:
+    marco:
   beampipe:
   far_forward:
     far_forward:

--- a/configurations/ip6_arches.yml
+++ b/configurations/ip6_arches.yml
@@ -1,6 +1,8 @@
 ebeam: 18
 pbeam: 275
 features:
+  fields:
+    marco:
   beampipe:
   far_forward:
     far_forward:

--- a/configurations/ip6_brycecanyon.yml
+++ b/configurations/ip6_brycecanyon.yml
@@ -1,6 +1,8 @@
 ebeam: 5
 pbeam: 41
 features:
+  fields:
+    marco:
   beampipe:
   far_forward:
     far_forward:

--- a/configurations/ip6_extended.yml
+++ b/configurations/ip6_extended.yml
@@ -1,4 +1,6 @@
 features:
+  fields:
+    marco:
   beampipe:
   far_forward:
     far_forward:


### PR DESCRIPTION
This would enable the barrel magnet field for FF studies by default.