### PR TITLE
feat: add the inter-MPGD/DIRC aluminum support rails

### DIFF
--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -173,6 +173,11 @@
           vis="DIRCMCP"
         />
       </module>
+      <support>
+        <rail height="78.50*mm" width="46.17*mm" length="DIRCBar_count_z*DIRCBar_length" material="Aluminum">
+          <position x="20*mm" y="0" z="0"/>
+        </rail>
+      </support>
     </detector>
   </detectors>
 

--- a/src/DIRC_geo.cpp
+++ b/src/DIRC_geo.cpp
@@ -226,6 +226,42 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens)
     det_volume.placeVolume(dirc_module, tr).addPhysVolID("module", i);
   }
 
+  // Construct support
+  xml_comp_t xml_support = xml_det.child(_U(support));
+  Assembly dirc_support("DIRCSupport");
+  dirc_support.setVisAttributes(desc.visAttributes(xml_support.visStr()));
+
+  // Rail
+  xml_comp_t xml_rail    = xml_support.child(_Unicode(rail));
+  xml_dim_t  rail_pos = xml_rail.position();
+  double     rail_height = xml_rail.height();
+  double     rail_width2 = xml_rail.width();
+  double     rail_distance_to_chord2 = rail_width2/2 / tan(dphi/2);
+  double     rail_distance_to_chord1 = rail_distance_to_chord2 - rail_height;
+  double     rail_width1 = 2*rail_distance_to_chord1 * tan(dphi/2);
+  double     rail_length = xml_rail.length();
+  Trap       rail_trap("rail_trap", rail_length / 2, 0, 0,
+                       rail_height / 2, rail_width1 / 2, rail_width2 / 2, 0,
+                       rail_height / 2, rail_width1 / 2, rail_width2 / 2, 0);
+  Volume     rail_vol("rail_vol", rail_trap, desc.material(xml_rail.materialStr()));
+  rail_vol.setVisAttributes(desc.visAttributes(xml_rail.visStr()));
+
+  // Place rail
+  Position rail_position(rail_pos.x(), rail_pos.y(), rail_pos.z());
+  RotationZ rail_rotation(-M_PI / 2.);
+  dirc_support.placeVolume(rail_vol, Transform3D(rail_rotation, rail_position));
+
+  // Place support
+  for (int i = 0; i < module_repeat; i++) {
+    double phi = dphi * i + dphi / 2;
+    double x   = det_ravg * cos(phi);
+    double y   = det_ravg * sin(phi);
+
+    Transform3D tr(RotationZ(phi), Position(x, y, 0));
+    det_volume.placeVolume(dirc_support, tr);
+  }
+
+
   return det;
 }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds the inter-MPGD/DIRC aluminum support rails. These are solid aluminum (for now), and somewhat arbitrarily placed due to lack of info on their position relative to the DIRC or MPGD. They are somewhat arbitrarily added to the DIRC as opposed to the MPGD, but I assume ultimately both will need to be connected with another bracket (of minimal X0).

The aluminum rails are approximated as a trapezoid that ignores the top 360/48 angle, and that extends to the bottom of the round rail (which isn't implemented here).

![image](https://github.com/eic/epic/assets/4656391/4f50a2c6-f246-46d5-8cbe-f5e2757da942)
![image](https://github.com/eic/epic/assets/4656391/8446a327-91cc-4149-a5e0-ae537c5da5b6)
![image](https://github.com/eic/epic/assets/4656391/a8ab5bb9-9d3b-4bec-8e31-83cd1cf609e2)

TODO:
- [ ] fix the inevitable overlaps...

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @mariakzurek @sly2j 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.