### PR TITLE
Improve the performane for bin/g4MaterialScan_to_csv

### DIFF
--- a/bin/g4MaterialScan_to_csv
+++ b/bin/g4MaterialScan_to_csv
@@ -3,21 +3,78 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2023 Chao Peng
 '''
-    A script to run a 2D (eta, phi) scan using g4MaterialScan.
+    A script to run a 2D (eta, phi) scan using Geant4 kernel.
     Scan results are collected in a CSV format file.
 '''
 
 import os
+import errno
 import argparse
 import pandas as pd
 import numpy as np
 from io import StringIO
 from collections import OrderedDict as odict
 
+import DDG4
+import dd4hep
+import g4units
 
 # pd.set_option('display.max_rows', 1000)
 PROGRESS_STEP = 10
 
+
+class g4MaterialScanner:
+    # singleton to prevent kernel from being accessed by multiple sources
+    _self = None
+
+    def __new__(cls):
+        if cls._self is None:
+            cls._self = super().__new__(cls)
+        return cls._self
+
+    def __init__(self, compact, phy_list='QGSP_BERT'):
+        kernel = DDG4.Kernel()
+        kernel.loadGeometry(compact)
+        DDG4.Core.setPrintFormat(str("%-32s %6s %s"))
+        geant4 = DDG4.Geant4(kernel)
+        geant4.setupCshUI(ui=None)
+        for i in geant4.description.detectors():
+            o = DDG4.DetElement(i.second.ptr())
+            sd = geant4.description.sensitiveDetector(o.name())
+            if sd.isValid():
+                typ = sd.type()
+            if typ in geant4.sensitive_types:
+                geant4.setupDetector(o.name(), geant4.sensitive_types[typ])
+            else:
+                logger.error('+++  %-32s type:%-12s  --> Unknown Sensitive type: %s', o.name(), typ, typ)
+                sys.exit(errno.EINVAL)
+
+        scan = DDG4.SteppingAction(kernel, 'Geant4MaterialScanner/MaterialScan')
+        kernel.steppingAction().adopt(scan)
+
+        # Now build the physics list:
+        geant4.setupPhysics(phy_list)
+        kernel.configure()
+        kernel.initialize()
+
+        self.kernel = kernel
+        self.geant4 = geant4
+
+    def __del__(self):
+        self.kernel.terminate()
+
+    def scan(position, direction):
+        self.geant4.setupGun('Scanner',
+                             Standalone=True,
+                             particle='geantino',
+                             energy=20 8 g4units.GeV,
+                             position='({},{},{})'.format(*position),
+                             direction='({},{},{})'.format(*direction),
+                             multiplicity=1,
+                             isotrop=False)
+
+        self.kernel.NumEvents = 1
+        self.kernel.run()
 
 '''
     A parser function to convert output from g4MaterialScan to a pandas dataframe

--- a/bin/g4MaterialScan_to_csv
+++ b/bin/g4MaterialScan_to_csv
@@ -89,8 +89,10 @@ def args_array(arg, step=1, include_end=True):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-            'A python script to run \"g4MaterialScan\" and save the results in CSV format.' + '\n       ' # 7 spaces for "usage: "
-            + 'The scan is conducted with given ranges for both eta and phi.\n'
+            prog='g4MaterialScan_to_csv',
+            description = 'A python script to run \"g4MaterialScan\" and save the results in CSV format.'
+                        + '\n       ' # 7 spaces for "usage: "
+                        + 'The scan is conducted with given ranges for both eta and phi.'
             )
     parser.add_argument(
             '-c', '--compact', dest='compact', required=True,

--- a/bin/g4MaterialScan_to_csv
+++ b/bin/g4MaterialScan_to_csv
@@ -32,7 +32,7 @@ class g4MaterialScanner:
         DDG4.Core.setPrintFormat(str("%-32s %6s %s"))
         self.kernel = kernel
 
-        # DDG4 Geant4 wrapper to shorten setup
+        # use DDG4 Geant4 wrapper to simplify the setup
         geant4 = DDG4.Geant4(kernel)
         geant4.setupCshUI(ui=None)
         for i in geant4.description.detectors():
@@ -47,7 +47,7 @@ class g4MaterialScanner:
                     sys.exit(errno.EINVAL)
         geant4.setupPhysics(phy_list)
 
-        # save the gun for micromanagement
+        # save the gun for micromanagement later
         self.gun = geant4.setupGun('Scanner',
                                    Standalone=True,
                                    particle='geantino',
@@ -59,7 +59,6 @@ class g4MaterialScanner:
 
         scan = DDG4.SteppingAction(self.kernel, 'Geant4MaterialScanner/MaterialScan')
         self.kernel.steppingAction().adopt(scan)
-        # Now build the physics list:
         self.kernel.configure()
         self.kernel.initialize()
         self.kernel.NumEvents = 1
@@ -74,7 +73,7 @@ class g4MaterialScanner:
             self.kernel.run()
         return self.parse_scan_output(out.getvalue())
 
-    # A parser function to convert output from Gean4MaterialScanner to a pandas dataframe
+    # A parser function to convert the output from Gean4MaterialScanner to a pandas dataframe
     @staticmethod
     def parse_scan_output(output):
         # find material scan lines
@@ -88,8 +87,8 @@ class g4MaterialScanner:
                 add_line = True
 
 
-        # NOTE: the code below depends on DDG4::Geant4MaterialScanner
-        # it may need change if the output format is changed (as of the version on 09/15/2023)
+        # NOTE: the code below depends on the output from DDG4::Geant4MaterialScanner
+        # it is valid on 09/15/2023
         scans = []
         first_digit = False
         for i, l in enumerate(lines):
@@ -103,10 +102,10 @@ class g4MaterialScanner:
             scans.append(line.strip('| ').translate({ord(i): None for i in '()'}).replace(',', ' '))
 
         cols = [
-            'material', 'Z', 'A', 'density',
-            'rad_length', 'int_length', 'thickness', 'path_length',
-            'int_X0', 'int_lambda', 'end_x', 'end_y', 'end_z'
-            ]
+                'material', 'Z', 'A', 'density',
+                'rad_length', 'int_length', 'thickness', 'path_length',
+                'int_X0', 'int_lambda', 'end_x', 'end_y', 'end_z'
+                ]
 
         dft = pd.read_csv(StringIO('\n'.join(scans)), sep='\s+', header=None, index_col=0, names=cols)
         return dft.astype({key: np.float64 for key in cols[1:]})
@@ -177,30 +176,31 @@ if __name__ == '__main__':
     if not len(phis):
         print('No phi values from the input {}, aborted!'.format(args.phi))
         exit(-1)
-    mats_indices = odict()
 
-    # build a multi-indices for the data frame
     eta_phi = []
-    # should exist in the scan as int_{value_type}
+    mats_indices = odict()
+    # should exist in the scan output as int_{value_type}
     value_types = ['X0', 'lambda']
     # a data buffer for the X0 values of ((eta, phi), materials, (X0, Lambda))
     data = np.zeros(shape=(len(etas)*len(phis), args.mat_buffer_size, len(value_types)))
-    # scan eta, phi
-    print('Scanning {:d} eta values in [{:.2f}, {:.2f}] and {:d} phi values in [{:.2f}, {:.2f}] (degree).')
+
+    # scan over eta and phi
     scanner = g4MaterialScanner(args.compact)
+    print('Scanning {:d} eta values in [{:.2f}, {:.2f}] and {:d} phi values in [{:.2f}, {:.2f}] (degree).')
     for i, eta in enumerate(etas):
         for j, phi in enumerate(phis):
+
             nlines = i*len(phis) + j
             if nlines % PROGRESS_STEP == 0:
                 print('Scanned {:d}/{:d} lines.'.format(nlines, len(etas)*len(phis)), end='\r', flush=True)
+
             # scan
             direction = (np.cos(phi/180.*np.pi), np.sin(phi/180.*np.pi), np.sinh(eta))
-            # alternative solution
             dfa = scanner.scan(start_point, direction)
             for vt in value_types:
                 dfa.loc[:, vt] = dfa['int_{}'.format(vt)].diff(1).fillna(dfa['int_{}'.format(vt)])
 
-            # scan result
+            # group by materials
             single_scan = dfa.groupby('material')[value_types].sum()
             # print(single_scan)
             for mat, xvals in single_scan.iterrows():
@@ -213,8 +213,8 @@ if __name__ == '__main__':
                 k = mats_indices.get(mat)
                 data[len(eta_phi), k] = xvals.values
             eta_phi.append((eta, phi))
-
     print('Scanned {:d}/{:d} lines.'.format(len(etas)*len(phis), len(etas)*len(phis)))
+
     # save results
     result = dict()
     for i, vt in enumerate(value_types):

--- a/bin/g4MaterialScan_to_csv
+++ b/bin/g4MaterialScan_to_csv
@@ -222,5 +222,5 @@ if __name__ == '__main__':
         indices = pd.MultiIndex.from_tuples(eta_phi, names=['eta', 'phi'])
         result[vt] = pd.DataFrame(columns=mats_indices.keys(), index=indices, data=data[:, :len(mats_indices), i])
     out_path = args.output.format(**vars(args))
-    pd.concat(result, names=['value_type']).to_csv(out_path, sep=args.sep)
+    pd.concat(result, names=['value_type']).to_csv(out_path, sep=args.sep, float_format='%g')
     print('Scanned results saved to \"{}\"'.format(out_path))

--- a/bin/g4MaterialScan_to_csv
+++ b/bin/g4MaterialScan_to_csv
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2023 Chao Peng
@@ -8,73 +8,88 @@
 '''
 
 import os
+import sys
 import errno
 import argparse
 import pandas as pd
 import numpy as np
 from io import StringIO
 from collections import OrderedDict as odict
+from contextlib import contextmanager
 
 import DDG4
-import dd4hep
 import g4units
 
 # pd.set_option('display.max_rows', 1000)
 PROGRESS_STEP = 10
 
 
+'''
+    redirect stdout for non-python applications (C stdio)
+'''
+@contextmanager
+def stdout_redirected(to=os.devnull):
+    fd = sys.stdout.fileno()
+
+    def _redirect_stdout(to):
+        sys.stdout.close() # + implicit flush()
+        os.dup2(to.fileno(), fd) # fd writes to 'to' file
+        sys.stdout = os.fdopen(fd, 'w') # Python writes to fd
+
+    with os.fdopen(os.dup(fd), 'w') as old_stdout:
+        with open(to, 'w') as file:
+            _redirect_stdout(to=file)
+        try:
+            yield # allow code to be run with the redirected stdout
+        finally:
+            _redirect_stdout(to=old_stdout) # restore stdout.
+                                            # buffering and flags such as
+                                            # CLOEXEC may be different
+
+# a class to simplify the material scan, avoid the use of multipe instances of it
 class g4MaterialScanner:
-    # singleton to prevent kernel from being accessed by multiple sources
-    _self = None
-
-    def __new__(cls):
-        if cls._self is None:
-            cls._self = super().__new__(cls)
-        return cls._self
-
-    def __init__(self, compact, phy_list='QGSP_BERT'):
+    def __init__(self, compact):
         kernel = DDG4.Kernel()
         kernel.loadGeometry(compact)
         DDG4.Core.setPrintFormat(str("%-32s %6s %s"))
         geant4 = DDG4.Geant4(kernel)
+        self.kernel = kernel
+        self.geant4 = geant4
+
         geant4.setupCshUI(ui=None)
         for i in geant4.description.detectors():
             o = DDG4.DetElement(i.second.ptr())
             sd = geant4.description.sensitiveDetector(o.name())
             if sd.isValid():
                 typ = sd.type()
-            if typ in geant4.sensitive_types:
-                geant4.setupDetector(o.name(), geant4.sensitive_types[typ])
-            else:
-                logger.error('+++  %-32s type:%-12s  --> Unknown Sensitive type: %s', o.name(), typ, typ)
-                sys.exit(errno.EINVAL)
-
-        scan = DDG4.SteppingAction(kernel, 'Geant4MaterialScanner/MaterialScan')
-        kernel.steppingAction().adopt(scan)
-
-        # Now build the physics list:
-        geant4.setupPhysics(phy_list)
-        kernel.configure()
-        kernel.initialize()
-
-        self.kernel = kernel
-        self.geant4 = geant4
+                if typ in geant4.sensitive_types:
+                    geant4.setupDetector(o.name(), geant4.sensitive_types[typ])
+                else:
+                    logger.error('+++  %-32s type:%-12s  --> Unknown Sensitive type: %s', o.name(), typ, typ)
+                    sys.exit(errno.EINVAL)
 
     def __del__(self):
         self.kernel.terminate()
 
-    def scan(position, direction):
+    def scan(self, position, direction, phy_list='QGSP_BERT'):
         self.geant4.setupGun('Scanner',
                              Standalone=True,
                              particle='geantino',
-                             energy=20 8 g4units.GeV,
+                             energy=20*g4units.GeV,
                              position='({},{},{})'.format(*position),
                              direction='({},{},{})'.format(*direction),
                              multiplicity=1,
                              isotrop=False)
 
+        scan = DDG4.SteppingAction(self.kernel, 'Geant4MaterialScanner/MaterialScan')
+        self.kernel.steppingAction().adopt(scan)
+        # Now build the physics list:
+        self.geant4.setupPhysics(phy_list)
+        self.kernel.configure()
+        self.kernel.initialize()
         self.kernel.NumEvents = 1
         self.kernel.run()
+        # print(output)
 
 '''
     A parser function to convert output from g4MaterialScan to a pandas dataframe
@@ -200,6 +215,7 @@ if __name__ == '__main__':
     # a data buffer for the X0 values of ((eta, phi), materials, (X0, Lambda))
     data = np.zeros(shape=(len(etas)*len(phis), args.mat_buffer_size, len(value_types)))
     # scan eta, phi
+    scanner = g4MaterialScanner(args.compact)
     for i, eta in enumerate(etas):
         if i % PROGRESS_STEP == 0:
             print('Scanned {:d}/{:d} lines for eta in [{:.2f}, {:.2f}], each with {:d} phi values in [{:.2f}, {:.2f}] (degree).'\
@@ -208,7 +224,11 @@ if __name__ == '__main__':
         for j, phi in enumerate(phis):
             # scan
             direction = (np.cos(phi/180.*np.pi), np.sin(phi/180.*np.pi), np.sinh(eta))
-            dfa = g4_material_scan(args.compact, start_point, direction)
+            # alternative solution
+            # from wurlitzer import pipes
+            # with pipes() as (out, err):
+            with stdout_redirected():
+                scanner.scan(start_point, direction)
             for vt in value_types:
                 dfa.loc[:, vt] = dfa['int_{}'.format(vt)].diff(1).fillna(dfa['int_{}'.format(vt)])
 

--- a/bin/g4MaterialScan_to_csv
+++ b/bin/g4MaterialScan_to_csv
@@ -16,46 +16,25 @@ import numpy as np
 from io import StringIO
 from collections import OrderedDict as odict
 from contextlib import contextmanager
+from wurlitzer import pipes
 
 import DDG4
 import g4units
 
 # pd.set_option('display.max_rows', 1000)
-PROGRESS_STEP = 10
+PROGRESS_STEP = 1
 
-
-'''
-    redirect stdout for non-python applications (C stdio)
-'''
-@contextmanager
-def stdout_redirected(to=os.devnull):
-    fd = sys.stdout.fileno()
-
-    def _redirect_stdout(to):
-        sys.stdout.close() # + implicit flush()
-        os.dup2(to.fileno(), fd) # fd writes to 'to' file
-        sys.stdout = os.fdopen(fd, 'w') # Python writes to fd
-
-    with os.fdopen(os.dup(fd), 'w') as old_stdout:
-        with open(to, 'w') as file:
-            _redirect_stdout(to=file)
-        try:
-            yield # allow code to be run with the redirected stdout
-        finally:
-            _redirect_stdout(to=old_stdout) # restore stdout.
-                                            # buffering and flags such as
-                                            # CLOEXEC may be different
 
 # a class to simplify the material scan, avoid the use of multipe instances of it
 class g4MaterialScanner:
-    def __init__(self, compact):
+    def __init__(self, compact, phy_list='QGSP_BERT'):
         kernel = DDG4.Kernel()
         kernel.loadGeometry(compact)
         DDG4.Core.setPrintFormat(str("%-32s %6s %s"))
-        geant4 = DDG4.Geant4(kernel)
         self.kernel = kernel
-        self.geant4 = geant4
 
+        # DDG4 Geant4 wrapper to shorten setup
+        geant4 = DDG4.Geant4(kernel)
         geant4.setupCshUI(ui=None)
         for i in geant4.description.detectors():
             o = DDG4.DetElement(i.second.ptr())
@@ -67,78 +46,76 @@ class g4MaterialScanner:
                 else:
                     logger.error('+++  %-32s type:%-12s  --> Unknown Sensitive type: %s', o.name(), typ, typ)
                     sys.exit(errno.EINVAL)
+        geant4.setupPhysics(phy_list)
+
+        # for a micromanagement of the particle gun
+        
+        self.gun = geant4.setupGun('Scanner',
+                                   Standalone=True,
+                                   particle='geantino',
+                                   energy=20*g4units.GeV,
+                                   position='(0, 0, 0)',
+                                   direction='(0, 0, 1)',
+                                   multiplicity=1,
+                                   isotrop=False)
+
+        scan = DDG4.SteppingAction(self.kernel, 'Geant4MaterialScanner/MaterialScan')
+        self.kernel.steppingAction().adopt(scan)
+        # Now build the physics list:
+        self.kernel.configure()
+        self.kernel.initialize()
+
+        self.kernel.NumEvents = 1
+
 
     def __del__(self):
         self.kernel.terminate()
 
     def scan(self, position, direction, phy_list='QGSP_BERT'):
-        self.geant4.setupGun('Scanner',
-                             Standalone=True,
-                             particle='geantino',
-                             energy=20*g4units.GeV,
-                             position='({},{},{})'.format(*position),
-                             direction='({},{},{})'.format(*direction),
-                             multiplicity=1,
-                             isotrop=False)
+        self.gun.position = '({},{},{})'.format(*position)
+        self.gun.direction = '({},{},{})'.format(*direction)
+        with pipes() as (out, err):
+            self.kernel.run()
+        return self.parse_scan_output(out.getvalue())
 
-        scan = DDG4.SteppingAction(self.kernel, 'Geant4MaterialScanner/MaterialScan')
-        self.kernel.steppingAction().adopt(scan)
-        # Now build the physics list:
-        self.geant4.setupPhysics(phy_list)
-        self.kernel.configure()
-        self.kernel.initialize()
-        self.kernel.NumEvents = 1
-        self.kernel.run()
-        # print(output)
+    '''
+        A parser function to convert output from Gean4MaterialScanner to a pandas dataframe
+    '''
+    @staticmethod
+    def parse_scan_output(output):
+        # find material scan lines
+        lines = []
+        add_line = False
 
-'''
-    A parser function to convert output from g4MaterialScan to a pandas dataframe
-    compact: is path to compact file
-    start_point: a list or tuple for 3D coordinates (e.g., 0,0,0)
-    direction: a list or tuple for direction (e.g., 0.1,0.2,1.0)
-    return: a dataframe for materialScan results
-'''
-def g4_material_scan(compact, start_point, direction, timeout=200):
-    EXEC_NAME = 'g4MaterialScan'
-    cmd = '{} --compact={} --position=\"{},{},{}\" --direction=\"{},{},{}\"'\
-          .format(EXEC_NAME, compact, *np.hstack([start_point, direction]))
-    print(cmd)
-    output = os.popen(cmd).read()
-    # output = subprocess.check_output(cmd.split(' '), timeout=timeout).decode('UTF-8')
-
-    # find material scan lines
-    lines = []
-    add_line = False
-
-    for l in output.split('\n'):
-        if add_line:
-            lines.append(l.strip())
-        if l.strip().startswith('MaterialScan'):
-            add_line = True
+        for l in output.split('\n'):
+            if add_line:
+                lines.append(l.strip())
+            if l.strip().startswith('MaterialScan'):
+                add_line = True
 
 
-    # NOTE: the code below is for materialScan output as of 03/05/2023
-    # it may need change if the output format is changed
-    scans = []
-    first_digit = False
-    for i, l in enumerate(lines):
-        line = l.strip('| ')
-        if not first_digit and not line[:1].isdigit():
-            continue
-        first_digit = True
-        if not line[:1].isdigit():
-            break
-        # break coordinates for endpoint, which has a format of (x, y, z)
-        scans.append(line.strip('| ').translate({ord(i): None for i in '()'}).replace(',', ' '))
+        # NOTE: the code below depends on DDG4::Geant4MaterialScanner
+        # it may need change if the output format is changed (as of the version on 09/15/2023)
+        scans = []
+        first_digit = False
+        for i, l in enumerate(lines):
+            line = l.strip('| ')
+            if not first_digit and not line[:1].isdigit():
+                continue
+            first_digit = True
+            if not line[:1].isdigit():
+                break
+            # break coordinates for endpoint, which has a format of (x, y, z)
+            scans.append(line.strip('| ').translate({ord(i): None for i in '()'}).replace(',', ' '))
 
-    cols = [
-        'material', 'Z', 'A', 'density',
-        'rad_length', 'int_length', 'thickness', 'path_length',
-        'int_X0', 'int_lambda', 'end_x', 'end_y', 'end_z'
-        ]
+        cols = [
+            'material', 'Z', 'A', 'density',
+            'rad_length', 'int_length', 'thickness', 'path_length',
+            'int_X0', 'int_lambda', 'end_x', 'end_y', 'end_z'
+            ]
 
-    dft = pd.read_csv(StringIO('\n'.join(scans)), sep='\s+', header=None, index_col=0, names=cols)
-    return dft.astype({key: np.float64 for key in cols[1:]})
+        dft = pd.read_csv(StringIO('\n'.join(scans)), sep='\s+', header=None, index_col=0, names=cols)
+        return dft.astype({key: np.float64 for key in cols[1:]})
 
 
 '''
@@ -215,20 +192,17 @@ if __name__ == '__main__':
     # a data buffer for the X0 values of ((eta, phi), materials, (X0, Lambda))
     data = np.zeros(shape=(len(etas)*len(phis), args.mat_buffer_size, len(value_types)))
     # scan eta, phi
+    print('Scanning {:d} eta values in [{:.2f}, {:.2f}] and {:d} phi values in [{:.2f}, {:.2f}] (degree).')
     scanner = g4MaterialScanner(args.compact)
     for i, eta in enumerate(etas):
-        if i % PROGRESS_STEP == 0:
-            print('Scanned {:d}/{:d} lines for eta in [{:.2f}, {:.2f}], each with {:d} phi values in [{:.2f}, {:.2f}] (degree).'\
-                  .format(i, len(etas), etas[0], etas[-1], len(phis), phis[0], phis[-1])
-                  )
         for j, phi in enumerate(phis):
+            nlines = i*len(phis) + j
+            if nlines % PROGRESS_STEP == 0:
+                print('Scanned {:d}/{:d} lines.'.format(nlines, len(etas)*len(phis)), end='\r', flush=True)
             # scan
             direction = (np.cos(phi/180.*np.pi), np.sin(phi/180.*np.pi), np.sinh(eta))
             # alternative solution
-            # from wurlitzer import pipes
-            # with pipes() as (out, err):
-            with stdout_redirected():
-                scanner.scan(start_point, direction)
+            dfa = scanner.scan(start_point, direction)
             for vt in value_types:
                 dfa.loc[:, vt] = dfa['int_{}'.format(vt)].diff(1).fillna(dfa['int_{}'.format(vt)])
 
@@ -246,6 +220,7 @@ if __name__ == '__main__':
                 data[len(eta_phi), k] = xvals.values
             eta_phi.append((eta, phi))
 
+    print('Scanned {:d}/{:d} lines.'.format(len(etas)*len(phis), len(etas)*len(phis)))
     # save results
     result = dict()
     for i, vt in enumerate(value_types):

--- a/bin/g4MaterialScan_to_csv
+++ b/bin/g4MaterialScan_to_csv
@@ -146,9 +146,9 @@ def args_array(arg, step=1, include_end=True):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
             prog='g4MaterialScan_to_csv',
-            description = 'A python script to run \"g4MaterialScan\" and save the results in CSV format.'
+            description = 'A python script to scan materials of a DD4Hep geometry in geant4 kernel.'
                         + '\n       ' # 7 spaces for "usage: "
-                        + 'The scan is conducted with given ranges for both eta and phi.'
+                        + 'The scanned results are saved in a CSV file.'
             )
     parser.add_argument(
             '-c', '--compact', dest='compact', required=True,
@@ -173,6 +173,10 @@ if __name__ == '__main__':
     parser.add_argument(
             '--mat-buffer-size', type=int, default=50,
             help='Material buffer size.'
+            )
+    parser.add_argument(
+            '--sep', default='\t',
+            help='Seperator for the CSV file.'
             )
     args = parser.parse_args()
 
@@ -228,5 +232,5 @@ if __name__ == '__main__':
         indices = pd.MultiIndex.from_tuples(eta_phi, names=['eta', 'phi'])
         result[vt] = pd.DataFrame(columns=mats_indices.keys(), index=indices, data=data[:, :len(mats_indices), i])
     out_path = args.output.format(**vars(args))
-    pd.concat(result, names=['value_type']).to_csv(out_path, sep="\t")
+    pd.concat(result, names=['value_type']).to_csv(out_path, sep=args.sep)
     print('Scanned results saved to \"{}\"'.format(out_path))

--- a/bin/g4MaterialScan_to_csv
+++ b/bin/g4MaterialScan_to_csv
@@ -17,7 +17,6 @@ from collections import OrderedDict as odict
 
 # pd.set_option('display.max_rows', 1000)
 PROGRESS_STEP = 10
-ALLOWED_VALUE_TYPES = ['X0', 'lambda']
 
 
 '''
@@ -99,8 +98,8 @@ if __name__ == '__main__':
             help='Top-level xml file of the detector description.'
             )
     parser.add_argument(
-            '-o', '--output', default='g4mat_scan_{value_type}.csv',
-            help='Path of the output csv file. Support python formatting of args, e.g., g4mat_scan_{value_type}.csv.'
+            '-o', '--output', default='g4mat_scan.csv',
+            help='Path of the output csv file. Support python formatting of args, e.g., g4mat_scan_{eta}_{phi}.csv.'
             )
     parser.add_argument(
             '--start-point', default='0,0,0',
@@ -115,10 +114,6 @@ if __name__ == '__main__':
             help='Phi angle range, in the format of \"<min>[:<max>[:<step>]]\" (degree).'
             )
     parser.add_argument(
-            '--value-type', default='X0',
-            help='Choose one in {}.'.format(ALLOWED_VALUE_TYPES)
-            )
-    parser.add_argument(
             '--mat-buffer-size', type=int, default=50,
             help='Material buffer size.'
             )
@@ -126,10 +121,6 @@ if __name__ == '__main__':
 
     if not os.path.exists(args.compact):
         print('Cannot find compact file {}'.format(args.compact))
-        exit(-1)
-
-    if args.value_type not in ALLOWED_VALUE_TYPES:
-        print('Cannot find value type {}, choose one in {}'.format(args.value_type, ALLOWED_VALUE_TYPES))
         exit(-1)
 
     start_point = np.array([float(v.strip()) for v in args.start_point.split(',')])
@@ -140,12 +131,14 @@ if __name__ == '__main__':
         print('No phi values from the input {}, aborted!'.format(args.phi))
         exit(-1)
     mats_indices = odict()
-    # a data buffer for the X0 values of (eta, material)
-    data = np.zeros(shape=(len(etas)*len(phis), args.mat_buffer_size))
 
     # build a multi-indices for the data frame
-    indices = []
-    # scan eta
+    eta_phi = []
+    # should exist in the scan as int_{value_type}
+    value_types = ['X0', 'lambda']
+    # a data buffer for the X0 values of ((eta, phi), materials, (X0, Lambda))
+    data = np.zeros(shape=(len(etas)*len(phis), args.mat_buffer_size, len(value_types)))
+    # scan eta, phi
     for i, eta in enumerate(etas):
         if i % PROGRESS_STEP == 0:
             print('Scanned {:d}/{:d} lines for eta in [{:.2f}, {:.2f}], each with {:d} phi values in [{:.2f}, {:.2f}] (degree).'\
@@ -155,12 +148,13 @@ if __name__ == '__main__':
             # scan
             direction = (np.cos(phi/180.*np.pi), np.sin(phi/180.*np.pi), np.sinh(eta))
             dfa = g4_material_scan(args.compact, start_point, direction)
-            dfa.loc[:, 'X0'] = dfa['int_X0'].diff(1).fillna(dfa['int_X0'])
-            dfa.loc[:, 'lambda'] = dfa['int_lambda'].diff(1).fillna(dfa['int_lambda'])
+            for vt in value_types:
+                dfa.loc[:, vt] = dfa['int_{}'.format(vt)].diff(1).fillna(dfa['int_{}'.format(vt)])
 
             # scan result
-            single_scan = dfa.groupby('material')[args.value_type].sum()
-            for mat, xval in single_scan.items():
+            single_scan = dfa.groupby('material')[value_types].sum()
+            # print(single_scan)
+            for mat, xvals in single_scan.iterrows():
                 if mat not in mats_indices:
                     if len(mats_indices) >= args.mat_buffer_size:
                         print('Number of materials exceeds MAT_BUFFER_SIZE ({:d}), dropped material {}.'.format(args.mat_buffer_size, mat))
@@ -168,11 +162,14 @@ if __name__ == '__main__':
                         continue
                     mats_indices[mat] = len(mats_indices)
                 k = mats_indices.get(mat)
-                data[len(indices), k] = xval
-            indices.append((eta, phi))
+                data[len(eta_phi), k] = xvals.values
+            eta_phi.append((eta, phi))
 
-    indices = pd.MultiIndex.from_tuples(indices, names=['eta', 'phi'])
-    result = pd.DataFrame(columns=mats_indices.keys(), index=indices, data=data[:, :len(mats_indices)])
+    # save results
+    result = dict()
+    for i, vt in enumerate(value_types):
+        indices = pd.MultiIndex.from_tuples(eta_phi, names=['eta', 'phi'])
+        result[vt] = pd.DataFrame(columns=mats_indices.keys(), index=indices, data=data[:, :len(mats_indices), i])
     out_path = args.output.format(**vars(args))
-    result.to_csv(out_path, sep="\t")
+    pd.concat(result, names=['value_type']).to_csv(out_path, sep="\t")
     print('Scanned results saved to \"{}\"'.format(out_path))

--- a/bin/g4MaterialScan_to_csv
+++ b/bin/g4MaterialScan_to_csv
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2023 Chao Peng

--- a/bin/g4MaterialScan_to_csv
+++ b/bin/g4MaterialScan_to_csv
@@ -186,7 +186,8 @@ if __name__ == '__main__':
 
     # scan over eta and phi
     scanner = g4MaterialScanner(args.compact)
-    print('Scanning {:d} eta values in [{:.2f}, {:.2f}] and {:d} phi values in [{:.2f}, {:.2f}] (degree).')
+    print('Scanning {:d} eta values in [{:.2f}, {:.2f}] and {:d} phi values in [{:.2f}, {:.2f}] (degree).'\
+          .format(len(etas), etas[0], etas[-1], len(phis), phis[0], phis[-1]))
     for i, eta in enumerate(etas):
         for j, phi in enumerate(phis):
 

--- a/bin/g4MaterialScan_to_csv
+++ b/bin/g4MaterialScan_to_csv
@@ -49,7 +49,7 @@ class g4MaterialScanner:
         geant4.setupPhysics(phy_list)
 
         # for a micromanagement of the particle gun
-        
+
         self.gun = geant4.setupGun('Scanner',
                                    Standalone=True,
                                    particle='geantino',

--- a/bin/g4MaterialScan_to_csv
+++ b/bin/g4MaterialScan_to_csv
@@ -47,8 +47,7 @@ class g4MaterialScanner:
                     sys.exit(errno.EINVAL)
         geant4.setupPhysics(phy_list)
 
-        # for a micromanagement of the particle gun
-
+        # save the gun for micromanagement
         self.gun = geant4.setupGun('Scanner',
                                    Standalone=True,
                                    particle='geantino',
@@ -63,9 +62,7 @@ class g4MaterialScanner:
         # Now build the physics list:
         self.kernel.configure()
         self.kernel.initialize()
-
         self.kernel.NumEvents = 1
-
 
     def __del__(self):
         self.kernel.terminate()
@@ -77,9 +74,7 @@ class g4MaterialScanner:
             self.kernel.run()
         return self.parse_scan_output(out.getvalue())
 
-    '''
-        A parser function to convert output from Gean4MaterialScanner to a pandas dataframe
-    '''
+    # A parser function to convert output from Gean4MaterialScanner to a pandas dataframe
     @staticmethod
     def parse_scan_output(output):
         # find material scan lines

--- a/bin/g4MaterialScan_to_csv
+++ b/bin/g4MaterialScan_to_csv
@@ -15,7 +15,6 @@ import pandas as pd
 import numpy as np
 from io import StringIO
 from collections import OrderedDict as odict
-from contextlib import contextmanager
 from wurlitzer import pipes
 
 import DDG4


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Improve the performance of g4MaterialScan_to_csv. It now does the scans without reloading geometry. It also outputs both X0 and Lambda in a single scan

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No