### PR TITLE
fix: use correct layer_pattern for MPGD endcap surfaces

### DIFF
--- a/compact/tracking/mpgd_backward_endcap.xml
+++ b/compact/tracking/mpgd_backward_endcap.xml
@@ -147,7 +147,7 @@
   <plugins>
     <plugin name="DD4hep_ParametersPlugin">
       <argument value="BackwardMPGD"/>
-      <argument value="layer_pattern: str=layer\d"/>
+      <argument value="layer_pattern: str=BackwardMPGD_layer\d_N"/>
     </plugin>
   </plugins>
 

--- a/compact/tracking/mpgd_forward_endcap.xml
+++ b/compact/tracking/mpgd_forward_endcap.xml
@@ -148,7 +148,7 @@
   <plugins>
     <plugin name="DD4hep_ParametersPlugin">
       <argument value="ForwardMPGD"/>
-      <argument value="layer_pattern: str=layer\d"/>
+      <argument value="layer_pattern: str=ForwardMPGD_layer\d_P"/>
     </plugin>
   </plugins>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This fixes the layer_pattern that Acts uses to interpret the MPGD sensitive surfaces in craterlake.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.