### PR TITLE
FileLoader improvements

### DIFF
--- a/src/FileLoader.cpp
+++ b/src/FileLoader.cpp
@@ -20,8 +20,7 @@ using namespace dd4hep;
 
 void usage(int argc, char** argv)
 {
-  std::cout << "Usage: -plugin <name> -arg [-arg]                                                  \n"
-               "     name:   factory name     FileLoader                                           \n"
+  std::cerr << "Usage: -plugin <name> -arg [-arg]                                                  \n"
                "     cache:<string>           cache location (may be read-only)                    \n"
                "     file:<string>            file location                                        \n"
                "     url:<string>             url location                                         \n"
@@ -46,8 +45,10 @@ long load_file(Detector& /* desc */, int argc, char** argv)
       url = (argv[i] + 4);
     else if (0 == std::strncmp("cmd:", argv[i], 4))
       cmd = (argv[i] + 4);
-    else
+    else {
+      std::cerr << "Unexpected argument \"" << argv[i] << "\"" << std::endl;
       usage(argc, argv);
+    }
   }
   printout(DEBUG, "FileLoader", "arg cache: " + cache);
   printout(DEBUG, "FileLoader", "arg file: " + file);

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -92,12 +92,12 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
             // symlink hash to cache/.../hash
             printout(INFO, "FileLoader",
                      "file " + file + " with hash " + hash + " found in " + cache_hash_path.string());
-	    fs::path link_target;
-	    if (cache_hash_path.is_absolute()) {
-	      link_target = cache_hash_path;
-	    } else {
-	      link_target = fs::proximate(cache_hash_path, parent_path);
-	    }
+            fs::path link_target;
+            if (cache_hash_path.is_absolute()) {
+              link_target = cache_hash_path;
+            } else {
+              link_target = fs::proximate(cache_hash_path, parent_path);
+            }
             try {
               fs::create_symlink(link_target, hash_path);
               success = true;
@@ -108,9 +108,9 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
             }
             return true;
           }
-	  return false;
+          return false;
         };
-	if (!check_path(cache_path)) {
+        if (!check_path(cache_path)) {
           for (auto const& dir_entry : fs::recursive_directory_iterator(cache_path)) {
             if (!dir_entry.is_directory())
               continue;

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -72,6 +72,11 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
     return;
   }
 
+  if (fs::exists(fs::symlink_status(hash_path)) && !fs::exists(fs::status(hash_path))) {
+    printout(INFO, "FileLoader", "removing broken \"" + hash_path.string() + "\" symlink");
+    remove(hash_path);
+  }
+
   // if hash does not exist, we try to retrieve file from cache
   if (!fs::exists(hash_path)) {
     // recursive loop into cache directories
@@ -102,8 +107,6 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
             } catch (const fs::filesystem_error&) {
               printout(ERROR, "FileLoader",
                        "unable to link from " + hash_path.string() + " to " + link_target.string());
-              printout(ERROR, "FileLoader", "hint: this may be resolved by removing directory " + parent_path.string());
-              printout(ERROR, "FileLoader", "hint: or in that directory removing the file or link " + cache_hash_path.string());
               std::_Exit(EXIT_FAILURE);
             }
             break;


### PR DESCRIPTION
Fixes some edge cases, improves usability.

FileLoader: improve usage
---
Remove line starting with "name:" to not suggest that it's a parseable parameter.
Print which entry was not recognized during parsing.
Use cerr.

FileLoaderHelper: fix for when cache is a relative path
---
Previously

    mkdir ./cache/sub/dir -p
    echo q > cache/sub/dir/33b980fae79f456c
    geoPluginRun -compact $DETECTOR_PATH/$DETECTOR_CONFIG.xml -plugin epic_FileLoader file:bar/baz url:https://example.com/ cache:./cache

Would result in

    FileLoader       INFO  checking ./cache/./cache/sub
    FileLoader       INFO  checking ./cache/./cache/sub/dir

Now ./cache produces a symlink in bar:

    33b980fae79f456c -> ../cache/sub/dir/33b980fae79f456c

but $PWD/cache produces a symlink

    33b980fae79f456c -> /path/to/cache/sub/dir/33b980fae79f456c

FileLoaderHelper: remove invalid hashed symlinks
---
If an entry from the cache directory disappears, the loader will fail to recreate a symlink like so:

    FileLoader       INFO  file bar/baz with hash 33b980fae79f456c found in /home/veprbl/epic/cache/sub/dir/33b980fae79f456c
    FileLoader       ERROR unable to link from bar/33b980fae79f456c to /home/veprbl/epic/cache/sub/dir/33b980fae79f456c
    FileLoader       ERROR hint: this may be resolved by removing directory bar
    FileLoader       ERROR hint: or in that directory removing the file or link /home/veprbl/epic/cache/sub/dir/33b980fae79f456c

or fail to download like so:

    FileLoader       INFO  downloading bar/baz as hash 33b980fae79f456c with curl --retry 5 -f https://example.com/ -o bar/33b980fae79f456c
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
      0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to open the file bar/33b980fae79f456c: No such file or
    Warning: directory
    100  1256  100  1256    0     0  21830      0 --:--:-- --:--:-- --:--:-- 22035
    curl: (23) Failure writing output to destination
    FileLoader       ERROR unable to run the download command curl --retry 5 -f https://example.com/ -o bar/33b980fae79f456c
    FileLoader       ERROR the return value was
    FileLoader       ERROR hint: check the command and try running manually
    FileLoader       ERROR hint: allow insecure connections on some systems with the flag -k

FileLoaderHelper: allow finding hash directly in top-level cache directory
---
Previously it would not work to do `echo q > cache/33b980fae79f456c`,
because the recursive_directory_iterator starts at depth=1. An
explicit check on the top-level is needed.