### PR TITLE
Update solenoid material budget

### DIFF
--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -478,18 +478,18 @@
     <D type="density" value="8.41" unit="g / cm3"/>
     <fraction n="0.70" ref="Cu"/>
     <fraction n="0.30" ref="Zn"/>
-  </material> 
+  </material>
   <material name="NbTi">
     <D type="density" value="6.54" unit="g / cm3"/>
     <fraction n="0.50" ref="Nb"/>
     <fraction n="0.50" ref="Ti"/>
-  </material> 
+  </material>
   <material name="Solder">
     <D type="density" value="11.35" unit="g / cm3"/>
     <fraction n="0.975" ref="Pb"/>
     <fraction n="0.015" ref="Sn"/>
     <fraction n="0.010" ref="Ag"/>
-  </material> 
+  </material>
  <material name="SolenoidCoil">
     <D type="density" value="8.73" unit="g / cm3"/>
     <fraction n="0.9201" ref="Cu"/>

--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -485,10 +485,9 @@
     <fraction n="0.50" ref="Ti"/>
   </material>
   <material name="Solder">
-    <D type="density" value="11.35" unit="g / cm3"/>
-    <fraction n="0.975" ref="Pb"/>
-    <fraction n="0.015" ref="Sn"/>
-    <fraction n="0.010" ref="Ag"/>
+    <D type="density" value="8.60" unit="g / cm3"/>
+    <fraction n="0.40" ref="Pb"/>
+    <fraction n="0.60" ref="Sn"/>
   </material>
  <material name="SolenoidCoil">
     <D type="density" value="8.73" unit="g / cm3"/>

--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -474,4 +474,26 @@
     <fraction n="0.9622" ref="Pb"/>
     <fraction n="0.0378" ref="SciFiPb_Glue"/>
   </material>
+  <material name="Brass">
+    <D type="density" value="8.41" unit="g / cm3"/>
+    <fraction n="0.70" ref="Cu"/>
+    <fraction n="0.30" ref="Zn"/>
+  </material> 
+  <material name="NbTi">
+    <D type="density" value="6.54" unit="g / cm3"/>
+    <fraction n="0.50" ref="Nb"/>
+    <fraction n="0.50" ref="Ti"/>
+  </material> 
+  <material name="Solder">
+    <D type="density" value="11.35" unit="g / cm3"/>
+    <fraction n="0.975" ref="Pb"/>
+    <fraction n="0.015" ref="Sn"/>
+    <fraction n="0.010" ref="Ag"/>
+  </material> 
+ <material name="SolenoidCoil">
+    <D type="density" value="8.73" unit="g / cm3"/>
+    <fraction n="0.9201" ref="Cu"/>
+    <fraction n="0.0638" ref="NbTi"/>
+    <fraction n="0.0161" ref="Solder"/>
+  </material>
 </materials>

--- a/compact/solenoid.xml
+++ b/compact/solenoid.xml
@@ -13,12 +13,12 @@
     <constant name="SolenoidBarrelInnerSecondMLILayerThickness" value=" 20.0 * mm"/>
     <constant name="SolenoidBarrelInnerThermalShieldThickness"  value=" 5.0 * mm"/>
     <constant name="SolenoidBarrelInnerFirstMLILayerThickness"  value=" 32.0 * mm"/>
-    <constant name="SolenoidBarrelInnerHeliumThickness"         value=" 15.0 * mm"/> 
-    <constant name="SolenoidBarrelInnerG10Thickness"            value=" 3.0 * mm"/>  
+    <constant name="SolenoidBarrelInnerHeliumThickness"         value=" 15.0 * mm"/>
+    <constant name="SolenoidBarrelInnerG10Thickness"            value=" 3.0 * mm"/>
     <constant name="SolenoidBarrelCoilThickness"                value=" 33.6 * mm"/>
-    <constant name="SolenoidBarrelOuterG10Thickness"            value=" 3.0 * mm"/> 
+    <constant name="SolenoidBarrelOuterG10Thickness"            value=" 3.0 * mm"/>
     <constant name="SolenoidBarrelCoilFormerThickness"          value=" 30.0 * mm"/>
-    <constant name="SolenoidBarrelOuterHeliumThickness"         value=" 15.0 * mm"/> 
+    <constant name="SolenoidBarrelOuterHeliumThickness"         value=" 15.0 * mm"/>
     <constant name="SolenoidBarrelOuterThermalShieldThickness"  value=" 5.0 * mm"/>
     <constant name="SolenoidBarrelOuterSecondMLILayerThickness" value=" 62.5 * mm"/>
     <constant name="SolenoidBarrelOuterVacuumVesselThickness"   value=" 25.0 * mm"/>

--- a/compact/solenoid.xml
+++ b/compact/solenoid.xml
@@ -9,51 +9,47 @@
       --------------------------
     </comment>
     <comment>Solenoid Barrel Parameters</comment>
-    <constant name="SolenoidBarrelInnerVacuumVesselThickness"   value=" 20.0 * mm"/>
+    <constant name="SolenoidBarrelInnerVacuumVesselThickness"   value=" 10.0 * mm"/>
     <constant name="SolenoidBarrelInnerSecondMLILayerThickness" value=" 20.0 * mm"/>
-    <constant name="SolenoidBarrelInnerThermalShieldThickness"  value=" 10.0 * mm"/>
-    <constant name="SolenoidBarrelInnerFirstMLILayerThickness"  value=" 10.0 * mm"/>
-    <constant name="SolenoidBarrelInnerHeliumVesselThickness"   value=" 10.0 * mm"/>
-    <constant name="SolenoidBarrelInnerHeliumThickness"         value=" 15.0 * mm"/>
-    <constant name="SolenoidBarrelCoilFormerThickness"          value=" 10.0 * mm"/>
-    <constant name="SolenoidBarrelCoilThickness"                value="100.0 * mm"/>
-    <constant name="SolenoidBarrelCoilOverbindThickness"        value=" 40.0 * mm"/>
-    <constant name="SolenoidBarrelOuterHeliumThickness"         value=" 15.0 * mm"/>
-    <constant name="SolenoidBarrelOuterHeliumVesselThickness"   value=" 10.0 * mm"/>
-    <constant name="SolenoidBarrelOuterFirstMLILayerThickness"  value=" 10.0 * mm"/>
-    <constant name="SolenoidBarrelOuterThermalShieldThickness"  value=" 10.0 * mm"/>
-    <constant name="SolenoidBarrelOuterSecondMLILayerThickness" value=" 20.0 * mm"/>
-    <constant name="SolenoidBarrelOuterVacuumVesselThickness"   value=" 20.0 * mm"/>
+    <constant name="SolenoidBarrelInnerThermalShieldThickness"  value=" 5.0 * mm"/>
+    <constant name="SolenoidBarrelInnerFirstMLILayerThickness"  value=" 32.0 * mm"/>
+    <constant name="SolenoidBarrelInnerHeliumThickness"         value=" 15.0 * mm"/> 
+    <constant name="SolenoidBarrelInnerG10Thickness"            value=" 3.0 * mm"/>  
+    <constant name="SolenoidBarrelCoilThickness"                value=" 33.6 * mm"/>
+    <constant name="SolenoidBarrelOuterG10Thickness"            value=" 3.0 * mm"/> 
+    <constant name="SolenoidBarrelCoilFormerThickness"          value=" 30.0 * mm"/>
+    <constant name="SolenoidBarrelOuterHeliumThickness"         value=" 15.0 * mm"/> 
+    <constant name="SolenoidBarrelOuterThermalShieldThickness"  value=" 5.0 * mm"/>
+    <constant name="SolenoidBarrelOuterSecondMLILayerThickness" value=" 62.5 * mm"/>
+    <constant name="SolenoidBarrelOuterVacuumVesselThickness"   value=" 25.0 * mm"/>
 
     <comment>Solenoid Endcap Parameters</comment>
-    <constant name="SolenoidEndcapCoilEndSupportThickness"  value="20.0 * mm"/>
+    <constant name="SolenoidEndcapCoilEndSupportThickness"  value="45.2 * mm"/>
+    <constant name="SolenoidEndcapG10Thickness"             value=" 3.0 * mm"/>
     <constant name="SolenoidEndcapHeliumThickness"          value="15.0 * mm"/>
-    <constant name="SolenoidEndcapHeliumVesselThickness"    value="10.0 * mm"/>
-    <constant name="SolenoidEndcapFirstMLILayerThickness"   value="10.0 * mm"/>
-    <constant name="SolenoidEndcapThermalShieldThickness"   value="10.0 * mm"/>
+    <constant name="SolenoidEndcapFirstMLILayerThickness"   value="15.0 * mm"/>
+    <constant name="SolenoidEndcapThermalShieldThickness"   value=" 5.0 * mm"/>
     <constant name="SolenoidEndcapSecondMLILayerThickness"  value="20.0 * mm"/>
-    <constant name="SolenoidEndcapVacuumVesselThickness"    value="20.0 * mm"/>
+    <constant name="SolenoidEndcapVacuumVesselThickness"    value="40.0 * mm"/>
 
     <comment>Barrel layer zmax extends to the endcap layer zmin</comment>
     <constant name="SolenoidBarrelInnerVacuumVessel_zmax"   value="SolenoidBarrel_length/2.0 - SolenoidEndcapVacuumVesselThickness"/>
     <constant name="SolenoidBarrelInnerSecondMLILayer_zmax" value="SolenoidBarrelInnerVacuumVessel_zmax - SolenoidEndcapSecondMLILayerThickness"/>
     <constant name="SolenoidBarrelInnerThermalShield_zmax"  value="SolenoidBarrelInnerSecondMLILayer_zmax - SolenoidEndcapThermalShieldThickness"/>
     <constant name="SolenoidBarrelInnerFirstMLILayer_zmax"  value="SolenoidBarrelInnerThermalShield_zmax - SolenoidEndcapFirstMLILayerThickness"/>
-    <constant name="SolenoidBarrelInnerHeliumVessel_zmax"   value="SolenoidBarrelInnerFirstMLILayer_zmax - SolenoidEndcapHeliumVesselThickness"/>
-    <constant name="SolenoidBarrelInnerHelium_zmax"         value="SolenoidBarrelInnerHeliumVessel_zmax - SolenoidEndcapHeliumThickness"/>
-    <constant name="SolenoidBarrelCoil_zmax"                value="SolenoidBarrelInnerHelium_zmax - SolenoidEndcapCoilEndSupportThickness"/>
-    <constant name="SolenoidBarrelCoilFormer_zmax"          value="SolenoidBarrelCoil_zmax"/>
-    <constant name="SolenoidBarrelCoilOverbind_zmax"        value="SolenoidBarrelCoil_zmax"/>
+    <constant name="SolenoidBarrelInnerHelium_zmax"         value="SolenoidBarrelInnerFirstMLILayer_zmax - SolenoidEndcapHeliumThickness"/>
+    <constant name="SolenoidBarrelInnerG10_zmax"            value="SolenoidBarrelInnerHelium_zmax - SolenoidEndcapG10Thickness"/>
+    <constant name="SolenoidBarrelCoil_zmax"                value="SolenoidBarrelInnerG10_zmax - SolenoidEndcapCoilEndSupportThickness"/>
+    <constant name="SolenoidBarrelOuterG10_zmax"            value="SolenoidBarrelInnerG10_zmax"/>
+    <constant name="SolenoidBarrelCoilFormer_zmax"          value="SolenoidBarrelInnerG10_zmax"/>
     <constant name="SolenoidBarrelOuterHelium_zmax"         value="SolenoidBarrelInnerHelium_zmax"/>
-    <constant name="SolenoidBarrelOuterHeliumVessel_zmax"   value="SolenoidBarrelInnerHeliumVessel_zmax"/>
-    <constant name="SolenoidBarrelOuterFirstMLILayer_zmax"  value="SolenoidBarrelInnerFirstMLILayer_zmax"/>
     <constant name="SolenoidBarrelOuterThermalShield_zmax"  value="SolenoidBarrelInnerThermalShield_zmax"/>
     <constant name="SolenoidBarrelOuterSecondMLILayer_zmax" value="SolenoidBarrelInnerSecondMLILayer_zmax"/>
     <constant name="SolenoidBarrelOuterVacuumVessel_zmax"   value="SolenoidBarrelInnerVacuumVessel_zmax"/>
 
     <constant name="SolenoidEndcapCoilEndSupport_zmin"      value="SolenoidBarrelCoil_zmax"/>
+    <constant name="SolenoidEndcapG10_zmin"                 value="SolenoidBarrelInnerG10_zmax"/>
     <constant name="SolenoidEndcapHelium_zmin"              value="SolenoidBarrelInnerHelium_zmax"/>
-    <constant name="SolenoidEndcapHeliumVessel_zmin"        value="SolenoidBarrelInnerHeliumVessel_zmax"/>
     <constant name="SolenoidEndcapFirstMLILayer_zmin"       value="SolenoidBarrelInnerFirstMLILayer_zmax"/>
     <constant name="SolenoidEndcapThermalShield_zmin"       value="SolenoidBarrelInnerThermalShield_zmax"/>
     <constant name="SolenoidEndcapSecondMLILayer_zmin"      value="SolenoidBarrelInnerSecondMLILayer_zmax"/>
@@ -67,23 +63,19 @@
     <constant name="SolenoidBarrelInnerThermalShield_rmax"  value="SolenoidBarrelInnerThermalShield_rmin + SolenoidBarrelInnerThermalShieldThickness"/>
     <constant name="SolenoidBarrelInnerFirstMLILayer_rmin"  value="SolenoidBarrelInnerThermalShield_rmax"/>
     <constant name="SolenoidBarrelInnerFirstMLILayer_rmax"  value="SolenoidBarrelInnerFirstMLILayer_rmin + SolenoidBarrelInnerFirstMLILayerThickness"/>
-    <constant name="SolenoidBarrelInnerHeliumVessel_rmin"   value="SolenoidBarrelInnerFirstMLILayer_rmax"/>
-    <constant name="SolenoidBarrelInnerHeliumVessel_rmax"   value="SolenoidBarrelInnerHeliumVessel_rmin + SolenoidBarrelInnerHeliumVesselThickness"/>
-    <constant name="SolenoidBarrelInnerHelium_rmin"         value="SolenoidBarrelInnerHeliumVessel_rmax"/>
+    <constant name="SolenoidBarrelInnerHelium_rmin"         value="SolenoidBarrelInnerFirstMLILayer_rmax"/>
     <constant name="SolenoidBarrelInnerHelium_rmax"         value="SolenoidBarrelInnerHelium_rmin + SolenoidBarrelInnerHeliumThickness"/>
-    <constant name="SolenoidBarrelCoilFormer_rmin"          value="SolenoidBarrelInnerHelium_rmax"/>
-    <constant name="SolenoidBarrelCoilFormer_rmax"          value="SolenoidBarrelCoilFormer_rmin + SolenoidBarrelCoilFormerThickness"/>
-    <constant name="SolenoidBarrelCoil_rmin"                value="SolenoidBarrelCoilFormer_rmax"/>
+    <constant name="SolenoidBarrelInnerG10_rmin"            value="SolenoidBarrelInnerHelium_rmax"/>
+    <constant name="SolenoidBarrelInnerG10_rmax"            value="SolenoidBarrelInnerG10_rmin + SolenoidBarrelInnerG10Thickness"/>
+    <constant name="SolenoidBarrelCoil_rmin"                value="SolenoidBarrelInnerG10_rmax"/>
     <constant name="SolenoidBarrelCoil_rmax"                value="SolenoidBarrelCoil_rmin + SolenoidBarrelCoilThickness"/>
-    <constant name="SolenoidBarrelCoilOverbind_rmin"        value="SolenoidBarrelCoil_rmax"/>
-    <constant name="SolenoidBarrelCoilOverbind_rmax"        value="SolenoidBarrelCoilOverbind_rmin + SolenoidBarrelCoilOverbindThickness"/>
-    <constant name="SolenoidBarrelOuterHelium_rmin"         value="SolenoidBarrelCoilOverbind_rmax"/>
+    <constant name="SolenoidBarrelOuterG10_rmin"            value="SolenoidBarrelCoil_rmax"/>
+    <constant name="SolenoidBarrelOuterG10_rmax"            value="SolenoidBarrelOuterG10_rmin + SolenoidBarrelOuterG10Thickness"/>
+    <constant name="SolenoidBarrelCoilFormer_rmin"          value="SolenoidBarrelOuterG10_rmax"/>
+    <constant name="SolenoidBarrelCoilFormer_rmax"          value="SolenoidBarrelCoilFormer_rmin + SolenoidBarrelCoilFormerThickness"/>
+    <constant name="SolenoidBarrelOuterHelium_rmin"         value="SolenoidBarrelCoilFormer_rmax"/>
     <constant name="SolenoidBarrelOuterHelium_rmax"         value="SolenoidBarrelOuterHelium_rmin + SolenoidBarrelOuterHeliumThickness"/>
-    <constant name="SolenoidBarrelOuterHeliumVessel_rmin"   value="SolenoidBarrelOuterHelium_rmax"/>
-    <constant name="SolenoidBarrelOuterHeliumVessel_rmax"   value="SolenoidBarrelOuterHeliumVessel_rmin + SolenoidBarrelOuterHeliumVesselThickness"/>
-    <constant name="SolenoidBarrelOuterFirstMLILayer_rmin"  value="SolenoidBarrelOuterHeliumVessel_rmax"/>
-    <constant name="SolenoidBarrelOuterFirstMLILayer_rmax"  value="SolenoidBarrelOuterFirstMLILayer_rmin + SolenoidBarrelOuterFirstMLILayerThickness"/>
-    <constant name="SolenoidBarrelOuterThermalShield_rmin"  value="SolenoidBarrelOuterFirstMLILayer_rmax"/>
+    <constant name="SolenoidBarrelOuterThermalShield_rmin"  value="SolenoidBarrelOuterHelium_rmax"/>
     <constant name="SolenoidBarrelOuterThermalShield_rmax"  value="SolenoidBarrelOuterThermalShield_rmin + SolenoidBarrelOuterThermalShieldThickness"/>
     <constant name="SolenoidBarrelOuterSecondMLILayer_rmin" value="SolenoidBarrelOuterThermalShield_rmax"/>
     <constant name="SolenoidBarrelOuterSecondMLILayer_rmax" value="SolenoidBarrelOuterSecondMLILayer_rmin + SolenoidBarrelOuterSecondMLILayerThickness"/>
@@ -95,14 +87,14 @@
 
     <comment> Solenoid Endcap </comment>
     <comment>At the center, the end caps are outside the barrels</comment>
-    <constant name="SolenoidEndcapCoilEndSupport_rmin" value="SolenoidBarrelCoilFormer_rmin"/>
-    <constant name="SolenoidEndcapCoilEndSupport_rmax" value="SolenoidBarrelCoilOverbind_rmax"/>
+    <constant name="SolenoidEndcapCoilEndSupport_rmin" value="SolenoidBarrelCoil_rmin"/>
+    <constant name="SolenoidEndcapCoilEndSupport_rmax" value="SolenoidBarrelCoil_rmax"/>
+    <constant name="SolenoidEndcapG10_rmin"            value="SolenoidBarrelInnerG10_rmin"/>
+    <constant name="SolenoidEndcapG10_rmax"            value="SolenoidBarrelOuterG10_rmax"/>
     <constant name="SolenoidEndcapHelium_rmin"         value="SolenoidBarrelInnerHelium_rmin"/>
     <constant name="SolenoidEndcapHelium_rmax"         value="SolenoidBarrelOuterHelium_rmax"/>
-    <constant name="SolenoidEndcapHeliumVessel_rmin"   value="SolenoidBarrelInnerHeliumVessel_rmin"/>
-    <constant name="SolenoidEndcapHeliumVessel_rmax"   value="SolenoidBarrelOuterHeliumVessel_rmax"/>
     <constant name="SolenoidEndcapFirstMLILayer_rmin"  value="SolenoidBarrelInnerFirstMLILayer_rmin"/>
-    <constant name="SolenoidEndcapFirstMLILayer_rmax"  value="SolenoidBarrelOuterFirstMLILayer_rmax"/>
+    <constant name="SolenoidEndcapFirstMLILayer_rmax"  value="SolenoidBarrelCoilFormer_rmax"/>
     <constant name="SolenoidEndcapThermalShield_rmin"  value="SolenoidBarrelInnerThermalShield_rmin"/>
     <constant name="SolenoidEndcapThermalShield_rmax"  value="SolenoidBarrelOuterThermalShield_rmax"/>
     <constant name="SolenoidEndcapSecondMLILayer_rmin" value="SolenoidBarrelInnerSecondMLILayer_rmin"/>
@@ -149,71 +141,55 @@
         vis="SolenoidCryostatVis">
         <slice material="MylarMLI" thickness="SolenoidBarrelInnerFirstMLILayerThickness"/>
       </layer>
-      <layer id="5" name="InnerHeliumVessel"
-        inner_r="SolenoidBarrelInnerHeliumVessel_rmin"
-        outer_z="SolenoidBarrelInnerHeliumVessel_zmax"
-        vis="SolenoidCryostatVis">
-        <slice material="Aluminum5083" thickness="SolenoidBarrelInnerHeliumVesselThickness"/>
-      </layer>
-
-      <layer id="6" name="InnerHelium"
+      <layer id="5" name="InnerHelium"
         inner_r="SolenoidBarrelInnerHelium_rmin"
         outer_z="SolenoidBarrelInnerHelium_zmax"
         vis="SolenoidCryostatVis">
         <slice material="Helium" thickness="SolenoidBarrelInnerHeliumThickness"/>
       </layer>
-
-      <layer id="7" name="CoilFormer"
-        inner_r="SolenoidBarrelCoilFormer_rmin"
-        outer_z="SolenoidBarrelCoilFormer_zmax"
+      <layer id="6" name="InnerG10"
+        inner_r="SolenoidBarrelInnerG10_rmin"
+        outer_z="SolenoidBarrelInnerG10_zmax"
         vis="SolenoidCryostatVis">
-        <slice material="Aluminum5083" thickness="SolenoidBarrelCoilFormerThickness"/>
+        <slice material="G10" thickness="SolenoidBarrelInnerG10Thickness"/>
       </layer>
-      <layer id="8" name="Coil"
+      <layer id="7" name="Coil"
         inner_r="SolenoidBarrelCoil_rmin"
         outer_z="SolenoidBarrelCoil_zmax"
         vis="SolenoidCryostatVis">
-        <slice material="Aluminum" thickness="SolenoidBarrelCoilThickness"/>
+        <slice material="SolenoidCoil" thickness="SolenoidBarrelCoilThickness"/>
       </layer>
-      <layer id="9" name="CoilOverbind"
-        inner_r="SolenoidBarrelCoilOverbind_rmin"
-        outer_z="SolenoidBarrelCoilOverbind_zmax"
+      <layer id="8" name="OuterG10"
+        inner_r="SolenoidBarrelOuterG10_rmin"
+        outer_z="SolenoidBarrelOuterG10_zmax"
         vis="SolenoidCryostatVis">
-        <slice material="Aluminum5083" thickness="SolenoidBarrelCoilOverbindThickness"/>
+        <slice material="G10" thickness="SolenoidBarrelOuterG10Thickness"/>
       </layer>
-
+      <layer id="9" name="CoilFormer"
+        inner_r="SolenoidBarrelCoilFormer_rmin"
+        outer_z="SolenoidBarrelCoilFormer_zmax"
+        vis="SolenoidCryostatVis">
+        <slice material="Brass" thickness="SolenoidBarrelCoilFormerThickness"/>
+      </layer>
       <layer id="10" name="OuterHelium"
         inner_r="SolenoidBarrelOuterHelium_rmin"
         outer_z="SolenoidBarrelOuterHelium_zmax"
         vis="SolenoidCryostatVis">
         <slice material="Helium" thickness="SolenoidBarrelOuterHeliumThickness"/>
       </layer>
-
-      <layer id="11" name="OuterHeliumVessel"
-        inner_r="SolenoidBarrelOuterHeliumVessel_rmin"
-        outer_z="SolenoidBarrelOuterHeliumVessel_zmax"
-        vis="SolenoidCryostatVis">
-        <slice material="Aluminum5083" thickness="SolenoidBarrelOuterHeliumVesselThickness"/>
-      </layer>
-      <layer id="12" name="OuterFirstMLILayer"
-        inner_r="SolenoidBarrelOuterFirstMLILayer_rmin"
-        outer_z="SolenoidBarrelOuterFirstMLILayer_zmax"
-        vis="SolenoidCryostatVis">
-        <slice material="MylarMLI" thickness="SolenoidBarrelOuterFirstMLILayerThickness"/>
-      </layer>
-      <layer id="13" name="OuterThermalShield"
+      <layer id="11" name="OuterThermalShield"
         inner_r="SolenoidBarrelOuterThermalShield_rmin"
         outer_z="SolenoidBarrelOuterThermalShield_zmax"
         vis="SolenoidCryostatVis">
         <slice material="Copper" thickness="SolenoidBarrelOuterThermalShieldThickness"/>
       </layer>
-      <layer id="14" name="OuterSecondMLILayer"
+      <layer id="12" name="OuterSecondMLILayer"
         inner_r="SolenoidBarrelOuterSecondMLILayer_rmin"
         outer_z="SolenoidBarrelOuterSecondMLILayer_zmax"
         vis="SolenoidCryostatVis">
         <slice material="MylarMLI" thickness="SolenoidBarrelOuterSecondMLILayerThickness"/>
       </layer>
-      <layer id="15" name="OuterVacuumVessel"
+      <layer id="13" name="OuterVacuumVessel"
         inner_r="SolenoidBarrelOuterVacuumVessel_rmin"
         outer_z="SolenoidBarrelOuterVacuumVessel_zmax"
         vis="SolenoidCryostatVis">
@@ -233,19 +209,19 @@
         inner_z="SolenoidEndcapCoilEndSupport_zmin"
         inner_r="SolenoidEndcapCoilEndSupport_rmin"
         outer_r="SolenoidEndcapCoilEndSupport_rmax">
-        <slice material="Aluminum5083" thickness="SolenoidEndcapCoilEndSupportThickness"/>
+        <slice material="Brass" thickness="SolenoidEndcapCoilEndSupportThickness"/>
       </layer>
-      <layer id="2" name="Helium"
+      <layer id="2" name="EndcapG10"
+        inner_z="SolenoidEndcapG10_zmin"
+        inner_r="SolenoidEndcapG10_rmin"
+        outer_r="SolenoidEndcapG10_rmax">
+        <slice material="G10" thickness="SolenoidEndcapG10Thickness"/>
+      </layer>
+      <layer id="3" name="Helium"
         inner_z="SolenoidEndcapHelium_zmin"
         inner_r="SolenoidEndcapHelium_rmin"
         outer_r="SolenoidEndcapHelium_rmax">
         <slice material="Helium" thickness="SolenoidEndcapHeliumThickness"/>
-      </layer>
-      <layer id="3" name="HeliumVessel"
-        inner_z="SolenoidEndcapHeliumVessel_zmin"
-        inner_r="SolenoidEndcapHeliumVessel_rmin"
-        outer_r="SolenoidEndcapHeliumVessel_rmax">
-        <slice material="Aluminum5083" thickness="SolenoidEndcapHeliumVesselThickness"/>
       </layer>
       <layer id="4" name="FirstMLILayer"
         inner_z="SolenoidEndcapFirstMLILayer_zmin"
@@ -257,7 +233,7 @@
         inner_z="SolenoidEndcapThermalShield_zmin"
         inner_r="SolenoidEndcapThermalShield_rmin"
         outer_r="SolenoidEndcapThermalShield_rmax">
-        <slice material="Copper" thickness="SolenoidEndcapThermalShieldThickness"/>
+        <slice material="Aluminum" thickness="SolenoidEndcapThermalShieldThickness"/>
       </layer>
       <layer id="6" name="SecondMLILayer"
         inner_z="SolenoidEndcapSecondMLILayer_zmin"
@@ -285,19 +261,19 @@
         inner_z="SolenoidEndcapCoilEndSupport_zmin"
         inner_r="SolenoidEndcapCoilEndSupport_rmin"
         outer_r="SolenoidEndcapCoilEndSupport_rmax">
-        <slice material="Aluminum5083" thickness="SolenoidEndcapCoilEndSupportThickness"/>
+        <slice material="Brass" thickness="SolenoidEndcapCoilEndSupportThickness"/>
       </layer>
-      <layer id="2" name="Helium"
+      <layer id="2" name="EndcapG10"
+        inner_z="SolenoidEndcapG10_zmin"
+        inner_r="SolenoidEndcapG10_rmin"
+        outer_r="SolenoidEndcapG10_rmax">
+        <slice material="G10" thickness="SolenoidEndcapG10Thickness"/>
+      </layer>
+      <layer id="3" name="Helium"
         inner_z="SolenoidEndcapHelium_zmin"
         inner_r="SolenoidEndcapHelium_rmin"
         outer_r="SolenoidEndcapHelium_rmax">
         <slice material="Helium" thickness="SolenoidEndcapHeliumThickness"/>
-      </layer>
-      <layer id="3" name="HeliumVessel"
-        inner_z="SolenoidEndcapHeliumVessel_zmin"
-        inner_r="SolenoidEndcapHeliumVessel_rmin"
-        outer_r="SolenoidEndcapHeliumVessel_rmax">
-        <slice material="Aluminum5083" thickness="SolenoidEndcapHeliumVesselThickness"/>
       </layer>
       <layer id="4" name="FirstMLILayer"
         inner_z="SolenoidEndcapFirstMLILayer_zmin"
@@ -309,7 +285,7 @@
         inner_z="SolenoidEndcapThermalShield_zmin"
         inner_r="SolenoidEndcapThermalShield_rmin"
         outer_r="SolenoidEndcapThermalShield_rmax">
-        <slice material="Copper" thickness="SolenoidEndcapThermalShieldThickness"/>
+        <slice material="Aluminum" thickness="SolenoidEndcapThermalShieldThickness"/>
       </layer>
       <layer id="6" name="SecondMLILayer"
         inner_z="SolenoidEndcapSecondMLILayer_zmin"

--- a/compact/solenoid.xml
+++ b/compact/solenoid.xml
@@ -13,20 +13,17 @@
     <constant name="SolenoidBarrelInnerSecondMLILayerThickness" value=" 20.0 * mm"/>
     <constant name="SolenoidBarrelInnerThermalShieldThickness"  value=" 5.0 * mm"/>
     <constant name="SolenoidBarrelInnerFirstMLILayerThickness"  value=" 32.0 * mm"/>
-    <constant name="SolenoidBarrelInnerHeliumThickness"         value=" 15.0 * mm"/>
     <constant name="SolenoidBarrelInnerG10Thickness"            value=" 3.0 * mm"/>
-    <constant name="SolenoidBarrelCoilThickness"                value=" 33.6 * mm"/>
-    <constant name="SolenoidBarrelOuterG10Thickness"            value=" 3.0 * mm"/>
+    <constant name="SolenoidBarrelCoilThickness"                value=" 32.5 * mm"/>
+    <constant name="SolenoidBarrelOuterG10Thickness"            value=" 1.0 * mm"/>
     <constant name="SolenoidBarrelCoilFormerThickness"          value=" 30.0 * mm"/>
-    <constant name="SolenoidBarrelOuterHeliumThickness"         value=" 15.0 * mm"/>
     <constant name="SolenoidBarrelOuterThermalShieldThickness"  value=" 5.0 * mm"/>
     <constant name="SolenoidBarrelOuterSecondMLILayerThickness" value=" 62.5 * mm"/>
     <constant name="SolenoidBarrelOuterVacuumVesselThickness"   value=" 25.0 * mm"/>
 
     <comment>Solenoid Endcap Parameters</comment>
-    <constant name="SolenoidEndcapCoilEndSupportThickness"  value="45.2 * mm"/>
+    <constant name="SolenoidEndcapCoilEndSupportThickness"  value="92.0 * mm"/>
     <constant name="SolenoidEndcapG10Thickness"             value=" 3.0 * mm"/>
-    <constant name="SolenoidEndcapHeliumThickness"          value="15.0 * mm"/>
     <constant name="SolenoidEndcapFirstMLILayerThickness"   value="15.0 * mm"/>
     <constant name="SolenoidEndcapThermalShieldThickness"   value=" 5.0 * mm"/>
     <constant name="SolenoidEndcapSecondMLILayerThickness"  value="20.0 * mm"/>
@@ -37,19 +34,16 @@
     <constant name="SolenoidBarrelInnerSecondMLILayer_zmax" value="SolenoidBarrelInnerVacuumVessel_zmax - SolenoidEndcapSecondMLILayerThickness"/>
     <constant name="SolenoidBarrelInnerThermalShield_zmax"  value="SolenoidBarrelInnerSecondMLILayer_zmax - SolenoidEndcapThermalShieldThickness"/>
     <constant name="SolenoidBarrelInnerFirstMLILayer_zmax"  value="SolenoidBarrelInnerThermalShield_zmax - SolenoidEndcapFirstMLILayerThickness"/>
-    <constant name="SolenoidBarrelInnerHelium_zmax"         value="SolenoidBarrelInnerFirstMLILayer_zmax - SolenoidEndcapHeliumThickness"/>
-    <constant name="SolenoidBarrelInnerG10_zmax"            value="SolenoidBarrelInnerHelium_zmax - SolenoidEndcapG10Thickness"/>
+    <constant name="SolenoidBarrelInnerG10_zmax"            value="SolenoidBarrelInnerFirstMLILayer_zmax - SolenoidEndcapG10Thickness"/>
     <constant name="SolenoidBarrelCoil_zmax"                value="SolenoidBarrelInnerG10_zmax - SolenoidEndcapCoilEndSupportThickness"/>
     <constant name="SolenoidBarrelOuterG10_zmax"            value="SolenoidBarrelInnerG10_zmax"/>
     <constant name="SolenoidBarrelCoilFormer_zmax"          value="SolenoidBarrelInnerG10_zmax"/>
-    <constant name="SolenoidBarrelOuterHelium_zmax"         value="SolenoidBarrelInnerHelium_zmax"/>
     <constant name="SolenoidBarrelOuterThermalShield_zmax"  value="SolenoidBarrelInnerThermalShield_zmax"/>
     <constant name="SolenoidBarrelOuterSecondMLILayer_zmax" value="SolenoidBarrelInnerSecondMLILayer_zmax"/>
     <constant name="SolenoidBarrelOuterVacuumVessel_zmax"   value="SolenoidBarrelInnerVacuumVessel_zmax"/>
 
     <constant name="SolenoidEndcapCoilEndSupport_zmin"      value="SolenoidBarrelCoil_zmax"/>
     <constant name="SolenoidEndcapG10_zmin"                 value="SolenoidBarrelInnerG10_zmax"/>
-    <constant name="SolenoidEndcapHelium_zmin"              value="SolenoidBarrelInnerHelium_zmax"/>
     <constant name="SolenoidEndcapFirstMLILayer_zmin"       value="SolenoidBarrelInnerFirstMLILayer_zmax"/>
     <constant name="SolenoidEndcapThermalShield_zmin"       value="SolenoidBarrelInnerThermalShield_zmax"/>
     <constant name="SolenoidEndcapSecondMLILayer_zmin"      value="SolenoidBarrelInnerSecondMLILayer_zmax"/>
@@ -63,9 +57,7 @@
     <constant name="SolenoidBarrelInnerThermalShield_rmax"  value="SolenoidBarrelInnerThermalShield_rmin + SolenoidBarrelInnerThermalShieldThickness"/>
     <constant name="SolenoidBarrelInnerFirstMLILayer_rmin"  value="SolenoidBarrelInnerThermalShield_rmax"/>
     <constant name="SolenoidBarrelInnerFirstMLILayer_rmax"  value="SolenoidBarrelInnerFirstMLILayer_rmin + SolenoidBarrelInnerFirstMLILayerThickness"/>
-    <constant name="SolenoidBarrelInnerHelium_rmin"         value="SolenoidBarrelInnerFirstMLILayer_rmax"/>
-    <constant name="SolenoidBarrelInnerHelium_rmax"         value="SolenoidBarrelInnerHelium_rmin + SolenoidBarrelInnerHeliumThickness"/>
-    <constant name="SolenoidBarrelInnerG10_rmin"            value="SolenoidBarrelInnerHelium_rmax"/>
+    <constant name="SolenoidBarrelInnerG10_rmin"            value="SolenoidBarrelInnerFirstMLILayer_rmax"/>
     <constant name="SolenoidBarrelInnerG10_rmax"            value="SolenoidBarrelInnerG10_rmin + SolenoidBarrelInnerG10Thickness"/>
     <constant name="SolenoidBarrelCoil_rmin"                value="SolenoidBarrelInnerG10_rmax"/>
     <constant name="SolenoidBarrelCoil_rmax"                value="SolenoidBarrelCoil_rmin + SolenoidBarrelCoilThickness"/>
@@ -73,9 +65,7 @@
     <constant name="SolenoidBarrelOuterG10_rmax"            value="SolenoidBarrelOuterG10_rmin + SolenoidBarrelOuterG10Thickness"/>
     <constant name="SolenoidBarrelCoilFormer_rmin"          value="SolenoidBarrelOuterG10_rmax"/>
     <constant name="SolenoidBarrelCoilFormer_rmax"          value="SolenoidBarrelCoilFormer_rmin + SolenoidBarrelCoilFormerThickness"/>
-    <constant name="SolenoidBarrelOuterHelium_rmin"         value="SolenoidBarrelCoilFormer_rmax"/>
-    <constant name="SolenoidBarrelOuterHelium_rmax"         value="SolenoidBarrelOuterHelium_rmin + SolenoidBarrelOuterHeliumThickness"/>
-    <constant name="SolenoidBarrelOuterThermalShield_rmin"  value="SolenoidBarrelOuterHelium_rmax"/>
+    <constant name="SolenoidBarrelOuterThermalShield_rmin"  value="SolenoidBarrelCoilFormer_rmax"/>
     <constant name="SolenoidBarrelOuterThermalShield_rmax"  value="SolenoidBarrelOuterThermalShield_rmin + SolenoidBarrelOuterThermalShieldThickness"/>
     <constant name="SolenoidBarrelOuterSecondMLILayer_rmin" value="SolenoidBarrelOuterThermalShield_rmax"/>
     <constant name="SolenoidBarrelOuterSecondMLILayer_rmax" value="SolenoidBarrelOuterSecondMLILayer_rmin + SolenoidBarrelOuterSecondMLILayerThickness"/>
@@ -91,8 +81,6 @@
     <constant name="SolenoidEndcapCoilEndSupport_rmax" value="SolenoidBarrelCoil_rmax"/>
     <constant name="SolenoidEndcapG10_rmin"            value="SolenoidBarrelInnerG10_rmin"/>
     <constant name="SolenoidEndcapG10_rmax"            value="SolenoidBarrelOuterG10_rmax"/>
-    <constant name="SolenoidEndcapHelium_rmin"         value="SolenoidBarrelInnerHelium_rmin"/>
-    <constant name="SolenoidEndcapHelium_rmax"         value="SolenoidBarrelOuterHelium_rmax"/>
     <constant name="SolenoidEndcapFirstMLILayer_rmin"  value="SolenoidBarrelInnerFirstMLILayer_rmin"/>
     <constant name="SolenoidEndcapFirstMLILayer_rmax"  value="SolenoidBarrelCoilFormer_rmax"/>
     <constant name="SolenoidEndcapThermalShield_rmin"  value="SolenoidBarrelInnerThermalShield_rmin"/>
@@ -141,55 +129,43 @@
         vis="SolenoidCryostatVis">
         <slice material="MylarMLI" thickness="SolenoidBarrelInnerFirstMLILayerThickness"/>
       </layer>
-      <layer id="5" name="InnerHelium"
-        inner_r="SolenoidBarrelInnerHelium_rmin"
-        outer_z="SolenoidBarrelInnerHelium_zmax"
-        vis="SolenoidCryostatVis">
-        <slice material="Helium" thickness="SolenoidBarrelInnerHeliumThickness"/>
-      </layer>
-      <layer id="6" name="InnerG10"
+      <layer id="5" name="InnerG10"
         inner_r="SolenoidBarrelInnerG10_rmin"
         outer_z="SolenoidBarrelInnerG10_zmax"
         vis="SolenoidCryostatVis">
         <slice material="G10" thickness="SolenoidBarrelInnerG10Thickness"/>
       </layer>
-      <layer id="7" name="Coil"
+      <layer id="6" name="Coil"
         inner_r="SolenoidBarrelCoil_rmin"
         outer_z="SolenoidBarrelCoil_zmax"
         vis="SolenoidCryostatVis">
         <slice material="SolenoidCoil" thickness="SolenoidBarrelCoilThickness"/>
       </layer>
-      <layer id="8" name="OuterG10"
+      <layer id="7" name="OuterG10"
         inner_r="SolenoidBarrelOuterG10_rmin"
         outer_z="SolenoidBarrelOuterG10_zmax"
         vis="SolenoidCryostatVis">
         <slice material="G10" thickness="SolenoidBarrelOuterG10Thickness"/>
       </layer>
-      <layer id="9" name="CoilFormer"
+      <layer id="8" name="CoilFormer"
         inner_r="SolenoidBarrelCoilFormer_rmin"
         outer_z="SolenoidBarrelCoilFormer_zmax"
         vis="SolenoidCryostatVis">
         <slice material="Brass" thickness="SolenoidBarrelCoilFormerThickness"/>
       </layer>
-      <layer id="10" name="OuterHelium"
-        inner_r="SolenoidBarrelOuterHelium_rmin"
-        outer_z="SolenoidBarrelOuterHelium_zmax"
-        vis="SolenoidCryostatVis">
-        <slice material="Helium" thickness="SolenoidBarrelOuterHeliumThickness"/>
-      </layer>
-      <layer id="11" name="OuterThermalShield"
+      <layer id="9" name="OuterThermalShield"
         inner_r="SolenoidBarrelOuterThermalShield_rmin"
         outer_z="SolenoidBarrelOuterThermalShield_zmax"
         vis="SolenoidCryostatVis">
         <slice material="Copper" thickness="SolenoidBarrelOuterThermalShieldThickness"/>
       </layer>
-      <layer id="12" name="OuterSecondMLILayer"
+      <layer id="10" name="OuterSecondMLILayer"
         inner_r="SolenoidBarrelOuterSecondMLILayer_rmin"
         outer_z="SolenoidBarrelOuterSecondMLILayer_zmax"
         vis="SolenoidCryostatVis">
         <slice material="MylarMLI" thickness="SolenoidBarrelOuterSecondMLILayerThickness"/>
       </layer>
-      <layer id="13" name="OuterVacuumVessel"
+      <layer id="11" name="OuterVacuumVessel"
         inner_r="SolenoidBarrelOuterVacuumVessel_rmin"
         outer_z="SolenoidBarrelOuterVacuumVessel_zmax"
         vis="SolenoidCryostatVis">
@@ -217,31 +193,25 @@
         outer_r="SolenoidEndcapG10_rmax">
         <slice material="G10" thickness="SolenoidEndcapG10Thickness"/>
       </layer>
-      <layer id="3" name="Helium"
-        inner_z="SolenoidEndcapHelium_zmin"
-        inner_r="SolenoidEndcapHelium_rmin"
-        outer_r="SolenoidEndcapHelium_rmax">
-        <slice material="Helium" thickness="SolenoidEndcapHeliumThickness"/>
-      </layer>
-      <layer id="4" name="FirstMLILayer"
+      <layer id="3" name="FirstMLILayer"
         inner_z="SolenoidEndcapFirstMLILayer_zmin"
         inner_r="SolenoidEndcapFirstMLILayer_rmin"
         outer_r="SolenoidEndcapFirstMLILayer_rmax">
         <slice material="MylarMLI" thickness="SolenoidEndcapFirstMLILayerThickness"/>
       </layer>
-      <layer id="5" name="ThermalShield"
+      <layer id="4" name="ThermalShield"
         inner_z="SolenoidEndcapThermalShield_zmin"
         inner_r="SolenoidEndcapThermalShield_rmin"
         outer_r="SolenoidEndcapThermalShield_rmax">
         <slice material="Aluminum" thickness="SolenoidEndcapThermalShieldThickness"/>
       </layer>
-      <layer id="6" name="SecondMLILayer"
+      <layer id="5" name="SecondMLILayer"
         inner_z="SolenoidEndcapSecondMLILayer_zmin"
         inner_r="SolenoidEndcapSecondMLILayer_rmin"
         outer_r="SolenoidEndcapSecondMLILayer_rmax">
         <slice material="MylarMLI" thickness="SolenoidEndcapSecondMLILayerThickness"/>
       </layer>
-      <layer id="7" name="VacuumVessel"
+      <layer id="6" name="VacuumVessel"
         inner_z="SolenoidEndcapVacuumVessel_zmin"
         inner_r="SolenoidEndcapVacuumVessel_rmin"
         outer_r="SolenoidEndcapVacuumVessel_rmax">
@@ -269,31 +239,25 @@
         outer_r="SolenoidEndcapG10_rmax">
         <slice material="G10" thickness="SolenoidEndcapG10Thickness"/>
       </layer>
-      <layer id="3" name="Helium"
-        inner_z="SolenoidEndcapHelium_zmin"
-        inner_r="SolenoidEndcapHelium_rmin"
-        outer_r="SolenoidEndcapHelium_rmax">
-        <slice material="Helium" thickness="SolenoidEndcapHeliumThickness"/>
-      </layer>
-      <layer id="4" name="FirstMLILayer"
+      <layer id="3" name="FirstMLILayer"
         inner_z="SolenoidEndcapFirstMLILayer_zmin"
         inner_r="SolenoidEndcapFirstMLILayer_rmin"
         outer_r="SolenoidEndcapFirstMLILayer_rmax">
         <slice material="MylarMLI" thickness="SolenoidEndcapFirstMLILayerThickness"/>
       </layer>
-      <layer id="5" name="ThermalShield"
+      <layer id="4" name="ThermalShield"
         inner_z="SolenoidEndcapThermalShield_zmin"
         inner_r="SolenoidEndcapThermalShield_rmin"
         outer_r="SolenoidEndcapThermalShield_rmax">
         <slice material="Aluminum" thickness="SolenoidEndcapThermalShieldThickness"/>
       </layer>
-      <layer id="6" name="SecondMLILayer"
+      <layer id="5" name="SecondMLILayer"
         inner_z="SolenoidEndcapSecondMLILayer_zmin"
         inner_r="SolenoidEndcapSecondMLILayer_rmin"
         outer_r="SolenoidEndcapSecondMLILayer_rmax">
         <slice material="MylarMLI" thickness="SolenoidEndcapSecondMLILayerThickness"/>
       </layer>
-      <layer id="7" name="VacuumVessel"
+      <layer id="6" name="VacuumVessel"
         inner_z="SolenoidEndcapVacuumVessel_zmin"
         inner_r="SolenoidEndcapVacuumVessel_rmin"
         outer_r="SolenoidEndcapVacuumVessel_rmax">


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR updates the ePIC Solenoid (MARCO) to the material specifications provided by the design team located at:

https://wiki.bnl.gov/EPIC/index.php?title=Experimental_Solenoid

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other: Update solenoid material map

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No breaking changes 

### Does this PR change default behavior?

No, it just updates the material budget for the MARCO solenoid.

This PR is a response to a material map run for me by Nicholas Schmidt at ORNL - you can see below that the solenoid is almost an interaction length, when it should be closer to 0.5 interaction lengths according to the designers:

![image](https://github.com/eic/epic/assets/3042746/f724417b-7f82-4b4c-a29c-2819a1edf413)

The new material map reduces the material budget for the solenoid to be a bit closer to what we would expect:

![image](https://github.com/eic/epic/assets/3042746/a9678b41-9147-458e-b938-dda924dac3c9)

![image](https://github.com/eic/epic/assets/3042746/90170d67-b8ab-43d5-a66e-b8497f5d3d5f)

Fully updated based on the material map from Renuka and Valerio dated 17 Sept 2023. The endcaps got a bit thicker, but most of the barrel is essentially the same. I removed the He layers that were in the original based on a comment from Valerio:

"The total volume of helium circulating inside the pipes is just 6000 mm3, corresponding to an uniform layer of Helium of 0.05 mm around the magnet. We neglected it for this reason, but if you think it is important we can add it."

[Material_in_the_magnet_Marco_2T_September.17.2023 (1).xlsx](https://github.com/eic/epic/files/12705405/Material_in_the_magnet_Marco_2T_September.17.2023.1.xlsx)

