### PR TITLE
linux-eic-shell.yml: remove workflow_dispatch functionality

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -8,6 +8,7 @@ on:
       - '*'
   pull_request:
   merge_group:
+  workflow_dispatch: # allow manual triggering
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -8,18 +8,6 @@ on:
       - '*'
   pull_request:
   merge_group:
-  workflow_dispatch:
-    inputs:
-      github_repository:
-        description: 'Submitting GitHub repository'
-        required: false
-        default: ''
-        type: string
-      github_sha:
-        description: 'Submitting GitHub sha'
-        required: false
-        default: ''
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -442,8 +430,8 @@ jobs:
           DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
           DETECTOR_VERSION=${{ github.event.pull_request.head.ref || github.ref_name }}
           DETECTOR_CONFIG=${{ matrix.detector_config }}
-          GITHUB_REPOSITORY=${{ inputs.github_repository || github.repository }}
-          GITHUB_SHA=${{ inputs.github_sha || github.event.pull_request.head.sha || github.sha }}
+          GITHUB_REPOSITORY=${{ github.repository }}
+          GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
     - run: |
         gh api \
            --method POST \


### PR DESCRIPTION
Should be unused, since we don't have reverse dependencies (like ip6 repo) on GitHub anymore.