### PR TITLE
Zdc SiPM-on-tile

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -274,7 +274,7 @@ The unused IDs below are saved for future use.
     <constant name="ZDCHcal_ID"              value="164"/>
     -->
     <constant name="ZDC_SiPMonTile_ID"                value="167"/>
-    
+
     <constant name="VacuumMagnetElement_1_ID"        value="168"/>
     <constant name="B0ECal_ID" value="169"/>
 

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -273,7 +273,7 @@ The unused IDs below are saved for future use.
     <constant name="ZDCEcal_ID"              value="163"/>
     <constant name="ZDCHcal_ID"              value="164"/>
     -->
-    <constant name="ZDC_SiPMonTile_ID"                value="167"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_ID"                value="167"/>
 
     <constant name="VacuumMagnetElement_1_ID"        value="168"/>
     <constant name="B0ECal_ID" value="169"/>

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -273,7 +273,8 @@ The unused IDs below are saved for future use.
     <constant name="ZDCEcal_ID"              value="163"/>
     <constant name="ZDCHcal_ID"              value="164"/>
     -->
-
+    <constant name="ZDC_SiPMonTile_ID"                value="167"/>
+    
     <constant name="VacuumMagnetElement_1_ID"        value="168"/>
     <constant name="B0ECal_ID" value="169"/>
 

--- a/compact/far_forward/ZDC_SiPMonTile.xml
+++ b/compact/far_forward/ZDC_SiPMonTile.xml
@@ -40,11 +40,14 @@
 
     <constant name="HcalFarForwardZDC_SiPMonTile_width" value= "60*cm"/>
     <constant name="HcalFarForwardZDC_SiPMonTile_height" value= "60*cm"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_length" value= "HcalFarForwardZDC_SiPMonTile_SingleLayerThickness*HcalFarForwardZDC_SiPMonTile_Layer_NSteelRepeat +
+           HcalFarForwardZDC_SiPMonTile_BackplateThickness"/>
     <constant name="HcalFarForwardZDC_SiPMonTile_rotateX_angle" value="0*deg"/>
     <constant name="HcalFarForwardZDC_SiPMonTile_rotateY_angle" value="0*deg"/>
     <constant name="HcalFarForwardZDC_SiPMonTile_rotateZ_angle" value="ionCrossingAngle"/>
 
-    <constant name="HcalFarForwardZDC_SiPMonTile_r_pos" value="35.8*m"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_r_pos_front_face" value="35.8*m"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_r_pos" value="HcalFarForwardZDC_SiPMonTile_r_pos_front_face + HcalFarForwardZDC_SiPMonTile_length/2.0"/>
     <constant name="HcalFarForwardZDC_SiPMonTile_x_pos" value="sin(HcalFarForwardZDC_SiPMonTile_rotateZ_angle)*HcalFarForwardZDC_SiPMonTile_r_pos"/>
     <constant name="HcalFarForwardZDC_SiPMonTile_y_pos" value="0*m" />
     <constant name="HcalFarForwardZDC_SiPMonTile_z_pos" value="cos(HcalFarForwardZDC_SiPMonTile_rotateZ_angle)*HcalFarForwardZDC_SiPMonTile_r_pos"/>
@@ -78,8 +81,7 @@
       <dimensions
         x="HcalFarForwardZDC_SiPMonTile_width"
         y="HcalFarForwardZDC_SiPMonTile_height"
-        z="HcalFarForwardZDC_SiPMonTile_SingleLayerThickness*HcalFarForwardZDC_SiPMonTile_Layer_NSteelRepeat +
-           HcalFarForwardZDC_SiPMonTile_BackplateThickness"
+        z="HcalFarForwardZDC_SiPMonTile_length"
       />
       <comment> Slices will be ordered according to the slice order listed here </comment>
       <comment> Steel/Sc layers </comment>

--- a/compact/far_forward/ZDC_SiPMonTile.xml
+++ b/compact/far_forward/ZDC_SiPMonTile.xml
@@ -94,7 +94,7 @@
         <slice name="Air_slice" material="Air" thickness="ZDC_SiPMonTile_AirThickness"/>
       </layer>
       <comment> Final layer of steel </comment>
-      <layer repeat="1" thickness = "ZDC_SiPMonTile_BackplateThickness">
+      <layer repeat="1" thickness="ZDC_SiPMonTile_BackplateThickness">
         <slice name="Absorber_slice" material="Steel235" thickness="ZDC_SiPMonTile_BackplateThickness" vis="AnlGray"/>
       </layer>
     </detector>

--- a/compact/far_forward/ZDC_SiPMonTile.xml
+++ b/compact/far_forward/ZDC_SiPMonTile.xml
@@ -13,41 +13,41 @@
     <documentation>
       #### Material Thicknesses
     </documentation>
-    <constant name="ZDC_SiPMonTile_AirThickness"                  value="0.02*cm"/>
-    <constant name="ZDC_SiPMonTile_AbsorberThickness"             value="2*cm"/>
-    <constant name="ZDC_SiPMonTile_ScintillatorCoverThickness"    value="0.04*cm"/>
-    <constant name="ZDC_SiPMonTile_PolystyreneThickness"          value="0.30*cm"/>
-    <constant name="ZDC_SiPMonTile_PCBThickness"                  value="0.08*cm"/>
-    <constant name="ZDC_SiPMonTile_ESRFoilThickness"              value="0.015*cm"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_AirThickness"                  value="0.02*cm"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_AbsorberThickness"             value="2*cm"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_ScintillatorCoverThickness"    value="0.04*cm"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_PolystyreneThickness"          value="0.30*cm"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_PCBThickness"                  value="0.08*cm"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_ESRFoilThickness"              value="0.015*cm"/>
 
     <documentation>
       - ZDC N Layers and computed Thickness
     </documentation>
 
 
-    <constant name="ZDC_SiPMonTile_SingleLayerThickness"
-      value="ZDC_SiPMonTile_AbsorberThickness +
-             ZDC_SiPMonTile_PolystyreneThickness +
-             ZDC_SiPMonTile_PCBThickness+ZDC_SiPMonTile_ESRFoilThickness*2+
-             2*ZDC_SiPMonTile_AirThickness+ZDC_SiPMonTile_ScintillatorCoverThickness"
+    <constant name="HcalFarForwardZDC_SiPMonTile_SingleLayerThickness"
+      value="HcalFarForwardZDC_SiPMonTile_AbsorberThickness +
+             HcalFarForwardZDC_SiPMonTile_PolystyreneThickness +
+             HcalFarForwardZDC_SiPMonTile_PCBThickness+HcalFarForwardZDC_SiPMonTile_ESRFoilThickness*2+
+             2*HcalFarForwardZDC_SiPMonTile_AirThickness+HcalFarForwardZDC_SiPMonTile_ScintillatorCoverThickness"
       />
 
-    <constant name="ZDC_SiPMonTile_BackplateThickness" value="ZDC_SiPMonTile_AbsorberThickness"/>
-    <constant name="ZDC_SiPMonTile_Layer_NSteelRepeat" value="64"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_BackplateThickness" value="HcalFarForwardZDC_SiPMonTile_AbsorberThickness"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_Layer_NSteelRepeat" value="64"/>
 
-    <constant name="ZDC_SiPMonTile_HexSideLength" value="31.3*mm"/>
-    <constant name="ZDC_SiPMonTile_stagger" value="2"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_HexSideLength" value="31.3*mm"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_stagger" value="2"/>
 
-    <constant name="ZDC_SiPMonTile_width" value= "60*cm"/>
-    <constant name="ZDC_SiPMonTile_height" value= "60*cm"/>
-    <constant name="ZDC_SiPMonTile_rotateX_angle" value="0*deg"/>
-    <constant name="ZDC_SiPMonTile_rotateY_angle" value="0*deg"/>
-    <constant name="ZDC_SiPMonTile_rotateZ_angle" value="ionCrossingAngle"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_width" value= "60*cm"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_height" value= "60*cm"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_rotateX_angle" value="0*deg"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_rotateY_angle" value="0*deg"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_rotateZ_angle" value="ionCrossingAngle"/>
 
-    <constant name="ZDC_SiPMonTile_r_pos" value="35.8*m"/>
-    <constant name="ZDC_SiPMonTile_x_pos" value="sin(ZDC_SiPMonTile_rotateZ_angle)*ZDC_SiPMonTile_r_pos"/>
-    <constant name="ZDC_SiPMonTile_y_pos" value="0*m" />
-    <constant name="ZDC_SiPMonTile_z_pos" value="cos(ZDC_SiPMonTile_rotateZ_angle)*ZDC_SiPMonTile_r_pos"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_r_pos" value="35.8*m"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_x_pos" value="sin(HcalFarForwardZDC_SiPMonTile_rotateZ_angle)*HcalFarForwardZDC_SiPMonTile_r_pos"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_y_pos" value="0*m" />
+    <constant name="HcalFarForwardZDC_SiPMonTile_z_pos" value="cos(HcalFarForwardZDC_SiPMonTile_rotateZ_angle)*HcalFarForwardZDC_SiPMonTile_r_pos"/>
   </define>
 
   <limits>
@@ -68,34 +68,34 @@
 
     </documentation>
     <detector
-      id="ZDC_SiPMonTile_ID"
+      id="HcalFarForwardZDC_SiPMonTile_ID"
       name="ZDC SiPM-on-Tile Hcal"
       type="ZeroDegreeCalorimeterSiPMonTile"
       readout="HcalFarForwardZDCHits"
     >
-      <position x="ZDC_SiPMonTile_x_pos"         y="ZDC_SiPMonTile_y_pos"         z="ZDC_SiPMonTile_z_pos"/>
-      <rotation x="ZDC_SiPMonTile_rotateX_angle" y="ZDC_SiPMonTile_rotateY_angle" z="ZDC_SiPMonTile_rotateZ_angle"/>
+      <position x="HcalFarForwardZDC_SiPMonTile_x_pos"         y="HcalFarForwardZDC_SiPMonTile_y_pos"         z="HcalFarForwardZDC_SiPMonTile_z_pos"/>
+      <rotation x="HcalFarForwardZDC_SiPMonTile_rotateX_angle" y="HcalFarForwardZDC_SiPMonTile_rotateY_angle" z="HcalFarForwardZDC_SiPMonTile_rotateZ_angle"/>
       <dimensions
-        x="ZDC_SiPMonTile_width"
-        y="ZDC_SiPMonTile_height"
-        z="ZDC_SiPMonTile_SingleLayerThickness*ZDC_SiPMonTile_Layer_NSteelRepeat +
-           ZDC_SiPMonTile_BackplateThickness"
+        x="HcalFarForwardZDC_SiPMonTile_width"
+        y="HcalFarForwardZDC_SiPMonTile_height"
+        z="HcalFarForwardZDC_SiPMonTile_SingleLayerThickness*HcalFarForwardZDC_SiPMonTile_Layer_NSteelRepeat +
+           HcalFarForwardZDC_SiPMonTile_BackplateThickness"
       />
       <comment> Slices will be ordered according to the slice order listed here </comment>
       <comment> Steel/Sc layers </comment>
-      <layer repeat="ZDC_SiPMonTile_Layer_NSteelRepeat" thickness="ZDC_SiPMonTile_SingleLayerThickness" vis="InvisibleWithDaughters">
-        <slice name="Absorber_slice" material="Steel235" thickness="ZDC_SiPMonTile_AbsorberThickness" vis="AnlGray"/>
-        <slice name="Air_slice" material="Air" thickness="ZDC_SiPMonTile_AirThickness"/>
-        <slice name="ScintCover_slice" material="Aluminum" thickness="ZDC_SiPMonTile_ScintillatorCoverThickness"/>
-        <slice name="ESRFoil_slice" material="Polystyrene" thickness="ZDC_SiPMonTile_ESRFoilThickness"/>
-        <slice name="Scintillator_slice" material="Polystyrene" thickness="ZDC_SiPMonTile_PolystyreneThickness" vis="AnlOrange" sensitive="true"/>
-        <slice name="ESRFoil_slice" material="Polystyrene" thickness="ZDC_SiPMonTile_ESRFoilThickness"/>
-        <slice name="PCB_slice" material="Fr4" thickness="ZDC_SiPMonTile_PCBThickness"/>
-        <slice name="Air_slice" material="Air" thickness="ZDC_SiPMonTile_AirThickness"/>
+      <layer repeat="HcalFarForwardZDC_SiPMonTile_Layer_NSteelRepeat" thickness="HcalFarForwardZDC_SiPMonTile_SingleLayerThickness" vis="InvisibleWithDaughters">
+        <slice name="Absorber_slice" material="Steel235" thickness="HcalFarForwardZDC_SiPMonTile_AbsorberThickness" vis="AnlGray"/>
+        <slice name="Air_slice" material="Air" thickness="HcalFarForwardZDC_SiPMonTile_AirThickness"/>
+        <slice name="ScintCover_slice" material="Aluminum" thickness="HcalFarForwardZDC_SiPMonTile_ScintillatorCoverThickness"/>
+        <slice name="ESRFoil_slice" material="Polystyrene" thickness="HcalFarForwardZDC_SiPMonTile_ESRFoilThickness"/>
+        <slice name="Scintillator_slice" material="Polystyrene" thickness="HcalFarForwardZDC_SiPMonTile_PolystyreneThickness" vis="AnlOrange" sensitive="true"/>
+        <slice name="ESRFoil_slice" material="Polystyrene" thickness="HcalFarForwardZDC_SiPMonTile_ESRFoilThickness"/>
+        <slice name="PCB_slice" material="Fr4" thickness="HcalFarForwardZDC_SiPMonTile_PCBThickness"/>
+        <slice name="Air_slice" material="Air" thickness="HcalFarForwardZDC_SiPMonTile_AirThickness"/>
       </layer>
       <comment> Final layer of steel </comment>
-      <layer repeat="1" thickness="ZDC_SiPMonTile_BackplateThickness">
-        <slice name="Absorber_slice" material="Steel235" thickness="ZDC_SiPMonTile_BackplateThickness" vis="AnlGray"/>
+      <layer repeat="1" thickness="HcalFarForwardZDC_SiPMonTile_BackplateThickness">
+        <slice name="Absorber_slice" material="Steel235" thickness="HcalFarForwardZDC_SiPMonTile_BackplateThickness" vis="AnlGray"/>
       </layer>
     </detector>
   </detectors>
@@ -104,8 +104,8 @@
     <readout name="HcalFarForwardZDCHits">
       <segmentation
         type="HexGrid"
-        side_length="ZDC_SiPMonTile_HexSideLength"
-        stagger="ZDC_SiPMonTile_stagger"
+        side_length="HcalFarForwardZDC_SiPMonTile_HexSideLength"
+        stagger="HcalFarForwardZDC_SiPMonTile_stagger"
         />
       <id>system:8,layer:8,slice:5,x:32:-16,y:-16</id>
     </readout>

--- a/compact/far_forward/ZDC_SiPMonTile.xml
+++ b/compact/far_forward/ZDC_SiPMonTile.xml
@@ -107,7 +107,7 @@
         side_length="ZDC_SiPMonTile_HexSideLength"
         stagger="ZDC_SiPMonTile_stagger"
         />
-      <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>
+      <id>system:8,layer:8,slice:5,x:32:-16,y:-16</id>
     </readout>
   </readouts>
 

--- a/compact/far_forward/ZDC_SiPMonTile.xml
+++ b/compact/far_forward/ZDC_SiPMonTile.xml
@@ -75,6 +75,7 @@
       name="ZDC SiPM-on-Tile Hcal"
       type="ZeroDegreeCalorimeterSiPMonTile"
       readout="HcalFarForwardZDCHits"
+      vis="InvisibleWithDaughters"
     >
       <position x="HcalFarForwardZDC_SiPMonTile_x_pos"         y="HcalFarForwardZDC_SiPMonTile_y_pos"         z="HcalFarForwardZDC_SiPMonTile_z_pos"/>
       <rotation x="HcalFarForwardZDC_SiPMonTile_rotateX_angle" y="HcalFarForwardZDC_SiPMonTile_rotateY_angle" z="HcalFarForwardZDC_SiPMonTile_rotateZ_angle"/>

--- a/compact/far_forward/ZDC_SiPMonTile.xml
+++ b/compact/far_forward/ZDC_SiPMonTile.xml
@@ -6,7 +6,7 @@
         url="https://github.com/sebouh137"
         status="development"
         version="1.0"
-	  ><comment/></info>
+          ><comment/></info>
 
   <define>
     <documentation>
@@ -18,19 +18,19 @@
     <constant name="ZDC_SiPMonTile_PolystyreneThickness"          value="0.30*cm"/>
     <constant name="ZDC_SiPMonTile_PCBThickness"                  value="0.08*cm"/>
     <constant name="ZDC_SiPMonTile_ESRFoilThickness"              value="0.015*cm"/>
-    
+
     <documentation>
       - ZDC N Layers and computed Thickness
     </documentation>
-    
-    
-    <constant name="ZDC_SiPMonTile_SingleLayerThickness" 
-      value="ZDC_SiPMonTile_AbsorberThickness + 
+
+
+    <constant name="ZDC_SiPMonTile_SingleLayerThickness"
+      value="ZDC_SiPMonTile_AbsorberThickness +
              ZDC_SiPMonTile_PolystyreneThickness +
              ZDC_SiPMonTile_PCBThickness+ZDC_SiPMonTile_ESRFoilThickness*2+
-	     2*ZDC_SiPMonTile_AirThickness+ZDC_SiPMonTile_ScintillatorCoverThickness"
+             2*ZDC_SiPMonTile_AirThickness+ZDC_SiPMonTile_ScintillatorCoverThickness"
       />
-    
+
     <constant name="ZDC_SiPMonTile_BackplateThickness" value="ZDC_SiPMonTile_AbsorberThickness"/>
     <constant name="ZDC_SiPMonTile_Layer_NSteelRepeat" value="64"/>
 
@@ -42,7 +42,7 @@
     <constant name="ZDC_SiPMonTile_rotateX_angle" value="0*deg"/>
     <constant name="ZDC_SiPMonTile_rotateY_angle" value="0*deg"/>
     <constant name="ZDC_SiPMonTile_rotateZ_angle" value="ionCrossingAngle"/>
-    
+
     <constant name="ZDC_SiPMonTile_r_pos" value="35.8*m"/>
     <constant name="ZDC_SiPMonTile_x_pos" value="sin(ZDC_SiPMonTile_rotateZ_angle)*ZDC_SiPMonTile_r_pos"/>
     <constant name="ZDC_SiPMonTile_y_pos" value="0*m" />
@@ -61,20 +61,20 @@
   <detectors>
       <documentation>
       ### SiPM-on-tile Zero-Degree Calorimeter Hcal
-      
+
       Each of the layers includes air gaps (front and back of each layer),
       ESR foil (front and back of scintillator), a PCB, and an aluminum scitnillator cover
-      
+
     </documentation>
     <detector
-      id="ZDC_SiPMonTile_ID" 
-      name="ZDC SiPM-on-Tile Hcal" 
+      id="ZDC_SiPMonTile_ID"
+      name="ZDC SiPM-on-Tile Hcal"
       type="ZeroDegreeCalorimeterSiPMonTile"
       readout="ZDC_SiPMonTile_Hits"
     >
       <position x="ZDC_SiPMonTile_x_pos"         y="ZDC_SiPMonTile_y_pos"         z="ZDC_SiPMonTile_z_pos"/>
       <rotation x="ZDC_SiPMonTile_rotateX_angle" y="ZDC_SiPMonTile_rotateY_angle" z="ZDC_SiPMonTile_rotateZ_angle"/>
-      <dimensions 
+      <dimensions
         x="ZDC_SiPMonTile_width"
         y="ZDC_SiPMonTile_height"
         z="ZDC_SiPMonTile_SingleLayerThickness*ZDC_SiPMonTile_Layer_NSteelRepeat +
@@ -85,8 +85,8 @@
       <layer repeat="ZDC_SiPMonTile_Layer_NSteelRepeat" thickness = "ZDC_SiPMonTile_SingleLayerThickness">
         <slice name="Absorber_slice" material="Steel235" thickness="ZDC_SiPMonTile_AbsorberThickness" vis="AnlGray"/>
         <slice name="Air_slice" material="Air" thickness="ZDC_SiPMonTile_AirThickness"/>
-        <slice name="ScintCover_slice" material="Aluminum" thickness="ZDC_SiPMonTile_ScintillatorCoverThickness"/> 
-        <slice name="ESRFoil_slice" material="Polystyrene" thickness="ZDC_SiPMonTile_ESRFoilThickness"/> 
+        <slice name="ScintCover_slice" material="Aluminum" thickness="ZDC_SiPMonTile_ScintillatorCoverThickness"/>
+        <slice name="ESRFoil_slice" material="Polystyrene" thickness="ZDC_SiPMonTile_ESRFoilThickness"/>
         <slice name="Scintillator_slice" material="Polystyrene" thickness="ZDC_SiPMonTile_PolystyreneThickness" vis="AnlOrange" sensitive="true"/>
         <slice name="ESRFoil_slice" material="Polystyrene" thickness="ZDC_SiPMonTile_ESRFoilThickness"/>
         <slice name="PCB_slice" material="Fr4" thickness="ZDC_SiPMonTile_PCBThickness"/>
@@ -102,11 +102,11 @@
   <readouts>
     <readout name="ZDC_SiPMonTile_Hits">
       <segmentation
-	type="HexGrid"
-	side_length="ZDC_SiPMonTile_HexSideLength"
-	stagger="ZDC_SiPMonTile_stagger"
-	/>
-      <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>  
+        type="HexGrid"
+        side_length="ZDC_SiPMonTile_HexSideLength"
+        stagger="ZDC_SiPMonTile_stagger"
+        />
+      <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>
     </readout>
   </readouts>
 

--- a/compact/far_forward/ZDC_SiPMonTile.xml
+++ b/compact/far_forward/ZDC_SiPMonTile.xml
@@ -1,0 +1,119 @@
+<lccdd>
+
+  <info name="ZDC_SiPMonTile.xml"
+        title="SiPM-on-Tile Zero-Degree Calorimeter Hcal, Fe/Sc"
+        author="@sebouh137"
+        url="https://github.com/sebouh137"
+        status="development"
+        version="1.0"
+	  ><comment/></info>
+
+  <define>
+    <documentation>
+      #### Material Thicknesses
+    </documentation>
+    <constant name="ZDC_SiPMonTile_AirThickness"                  value="0.02*cm"/>
+    <constant name="ZDC_SiPMonTile_AbsorberThickness"             value="2*cm"/>
+    <constant name="ZDC_SiPMonTile_ScintillatorCoverThickness"    value="0.04*cm"/>
+    <constant name="ZDC_SiPMonTile_PolystyreneThickness"          value="0.30*cm"/>
+    <constant name="ZDC_SiPMonTile_PCBThickness"                  value="0.08*cm"/>
+    <constant name="ZDC_SiPMonTile_ESRFoilThickness"              value="0.015*cm"/>
+    
+    <documentation>
+      - ZDC N Layers and computed Thickness
+    </documentation>
+    
+    
+    <constant name="ZDC_SiPMonTile_SingleLayerThickness" 
+      value="ZDC_SiPMonTile_AbsorberThickness + 
+             ZDC_SiPMonTile_PolystyreneThickness +
+             ZDC_SiPMonTile_PCBThickness+ZDC_SiPMonTile_ESRFoilThickness*2+
+	     2*ZDC_SiPMonTile_AirThickness+ZDC_SiPMonTile_ScintillatorCoverThickness"
+      />
+    
+    <constant name="ZDC_SiPMonTile_BackplateThickness" value="ZDC_SiPMonTile_AbsorberThickness"/>
+    <constant name="ZDC_SiPMonTile_Layer_NSteelRepeat" value="64"/>
+
+    <constant name="ZDC_SiPMonTile_HexSideLength" value="31.3*mm"/>
+    <constant name="ZDC_SiPMonTile_stagger" value="2"/>
+
+    <constant name="ZDC_SiPMonTile_width" value= "60*cm"/>
+    <constant name="ZDC_SiPMonTile_height" value= "60*cm"/>
+    <constant name="ZDC_SiPMonTile_rotateX_angle" value="0*deg"/>
+    <constant name="ZDC_SiPMonTile_rotateY_angle" value="0*deg"/>
+    <constant name="ZDC_SiPMonTile_rotateZ_angle" value="ionCrossingAngle"/>
+    
+    <constant name="ZDC_SiPMonTile_r_pos" value="35.8*m"/>
+    <constant name="ZDC_SiPMonTile_x_pos" value="sin(ZDC_SiPMonTile_rotateZ_angle)*ZDC_SiPMonTile_r_pos"/>
+    <constant name="ZDC_SiPMonTile_y_pos" value="0*m" />
+    <constant name="ZDC_SiPMonTile_z_pos" value="cos(ZDC_SiPMonTile_rotateZ_angle)*ZDC_SiPMonTile_r_pos"/>
+  </define>
+
+  <limits>
+  </limits>
+
+  <regions>
+  </regions>
+
+  <display>
+  </display>
+
+  <detectors>
+      <documentation>
+      ### SiPM-on-tile Zero-Degree Calorimeter Hcal
+      
+      Each of the layers includes air gaps (front and back of each layer),
+      ESR foil (front and back of scintillator), a PCB, and an aluminum scitnillator cover
+      
+    </documentation>
+    <detector
+      id="ZDC_SiPMonTile_ID" 
+      name="ZDC SiPM-on-Tile Hcal" 
+      type="ZeroDegreeCalorimeterSiPMonTile"
+      readout="ZDC_SiPMonTile_Hits"
+    >
+      <position x="ZDC_SiPMonTile_x_pos"         y="ZDC_SiPMonTile_y_pos"         z="ZDC_SiPMonTile_z_pos"/>
+      <rotation x="ZDC_SiPMonTile_rotateX_angle" y="ZDC_SiPMonTile_rotateY_angle" z="ZDC_SiPMonTile_rotateZ_angle"/>
+      <dimensions 
+        x="ZDC_SiPMonTile_width"
+        y="ZDC_SiPMonTile_height"
+        z="ZDC_SiPMonTile_SingleLayerThickness*ZDC_SiPMonTile_Layer_NSteelRepeat +
+           ZDC_SiPMonTile_BackplateThickness"
+      />
+      <comment> Slices will be ordered according to the slice order listed here </comment>
+      <comment> Steel/Sc layers </comment>
+      <layer repeat="ZDC_SiPMonTile_Layer_NSteelRepeat" thickness = "ZDC_SiPMonTile_SingleLayerThickness">
+        <slice name="Absorber_slice" material="Steel235" thickness="ZDC_SiPMonTile_AbsorberThickness" vis="AnlGray"/>
+        <slice name="Air_slice" material="Air" thickness="ZDC_SiPMonTile_AirThickness"/>
+        <slice name="ScintCover_slice" material="Aluminum" thickness="ZDC_SiPMonTile_ScintillatorCoverThickness"/> 
+        <slice name="ESRFoil_slice" material="Polystyrene" thickness="ZDC_SiPMonTile_ESRFoilThickness"/> 
+        <slice name="Scintillator_slice" material="Polystyrene" thickness="ZDC_SiPMonTile_PolystyreneThickness" vis="AnlOrange" sensitive="true"/>
+        <slice name="ESRFoil_slice" material="Polystyrene" thickness="ZDC_SiPMonTile_ESRFoilThickness"/>
+        <slice name="PCB_slice" material="Fr4" thickness="ZDC_SiPMonTile_PCBThickness"/>
+        <slice name="Air_slice" material="Air" thickness="ZDC_SiPMonTile_AirThickness"/>
+      </layer>
+      <comment> Final layer of steel </comment>
+      <layer repeat="1" thickness = "ZDC_SiPMonTile_BackplateThickness">
+        <slice name="Absorber_slice" material="Steel235" thickness="ZDC_SiPMonTile_BackplateThickness" vis="AnlGray"/>
+      </layer>
+    </detector>
+  </detectors>
+
+  <readouts>
+    <readout name="ZDC_SiPMonTile_Hits">
+      <segmentation
+	type="HexGrid"
+	side_length="ZDC_SiPMonTile_HexSideLength"
+	stagger="ZDC_SiPMonTile_stagger"
+	/>
+      <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>  
+    </readout>
+  </readouts>
+
+  <plugins>
+  </plugins>
+
+  <fields>
+  </fields>
+
+</lccdd>

--- a/compact/far_forward/ZDC_SiPMonTile.xml
+++ b/compact/far_forward/ZDC_SiPMonTile.xml
@@ -1,5 +1,6 @@
+<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
+<!-- Copyright (C) 2023 Sebouh J. Paul -->
 <lccdd>
-
   <info name="ZDC_SiPMonTile.xml"
         title="SiPM-on-Tile Zero-Degree Calorimeter Hcal, Fe/Sc"
         author="@sebouh137"

--- a/compact/far_forward/ZDC_SiPMonTile.xml
+++ b/compact/far_forward/ZDC_SiPMonTile.xml
@@ -83,7 +83,7 @@
       />
       <comment> Slices will be ordered according to the slice order listed here </comment>
       <comment> Steel/Sc layers </comment>
-      <layer repeat="ZDC_SiPMonTile_Layer_NSteelRepeat" thickness = "ZDC_SiPMonTile_SingleLayerThickness">
+      <layer repeat="ZDC_SiPMonTile_Layer_NSteelRepeat" thickness="ZDC_SiPMonTile_SingleLayerThickness" vis="InvisibleWithDaughters">
         <slice name="Absorber_slice" material="Steel235" thickness="ZDC_SiPMonTile_AbsorberThickness" vis="AnlGray"/>
         <slice name="Air_slice" material="Air" thickness="ZDC_SiPMonTile_AirThickness"/>
         <slice name="ScintCover_slice" material="Aluminum" thickness="ZDC_SiPMonTile_ScintillatorCoverThickness"/>

--- a/compact/far_forward/ZDC_SiPMonTile.xml
+++ b/compact/far_forward/ZDC_SiPMonTile.xml
@@ -71,7 +71,7 @@
       id="ZDC_SiPMonTile_ID"
       name="ZDC SiPM-on-Tile Hcal"
       type="ZeroDegreeCalorimeterSiPMonTile"
-      readout="ZDC_SiPMonTile_Hits"
+      readout="HcalFarForwardZDCHits"
     >
       <position x="ZDC_SiPMonTile_x_pos"         y="ZDC_SiPMonTile_y_pos"         z="ZDC_SiPMonTile_z_pos"/>
       <rotation x="ZDC_SiPMonTile_rotateX_angle" y="ZDC_SiPMonTile_rotateY_angle" z="ZDC_SiPMonTile_rotateZ_angle"/>
@@ -101,7 +101,7 @@
   </detectors>
 
   <readouts>
-    <readout name="ZDC_SiPMonTile_Hits">
+    <readout name="HcalFarForwardZDCHits">
       <segmentation
         type="HexGrid"
         side_length="ZDC_SiPMonTile_HexSideLength"

--- a/configurations/zdc_sipm_on_tile_only.yml
+++ b/configurations/zdc_sipm_on_tile_only.yml
@@ -1,0 +1,3 @@
+features:
+  far_forward:
+    far_forward/ZDC_SiPMonTile:

--- a/src/ZeroDegreeCalorimeterSiPMonTile_geo.cpp
+++ b/src/ZeroDegreeCalorimeterSiPMonTile_geo.cpp
@@ -18,18 +18,18 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
 
   xml_dim_t  dim        = detElem.dimensions();
   double     width      = dim.x(); // Size along x-axis
-  double     height     = dim.y(); // Size along y-axis 
+  double     height     = dim.y(); // Size along y-axis
   double     length     = dim.z(); // Size along z-axis
 
   xml_dim_t  pos        = detElem.position(); // Position in global coordinates
 
   Material   air        = desc.material("Air");
-  
+
   // Defining envelope
   Box envelope(width / 2.0, height / 2.0, length / 2.0);
-    
+
   // Defining envelope volume
-  Volume envelopeVol(detName, envelope, air); 
+  Volume envelopeVol(detName, envelope, air);
   // Setting envelope attributes
   envelopeVol.setAttributes(
     desc,
@@ -43,14 +43,14 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
   double z_distance_traversed = 0.;
 
   int layer_num = 1;
-  
+
   // Looping through all the different layer sections
   for(xml_coll_t c(detElem,_U(layer)); c; ++c)
   {
     xml_comp_t x_layer = c;
-    int repeat = x_layer.repeat();  
+    int repeat = x_layer.repeat();
     double layer_thickness = x_layer.thickness();
-    
+
     // Looping through the number of repeated layers in each section
     for(int i = 0; i < repeat; i++)
     {
@@ -64,25 +64,25 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
       double slice_z = -layer_thickness / 2.; // Keeps track of slices' z locations in each layer
 
       // Looping over each layer's slices
-      for(xml_coll_t l(x_layer,_U(slice)); l; ++l) 
+      for(xml_coll_t l(x_layer,_U(slice)); l; ++l)
       {
         xml_comp_t x_slice = l;
         double slice_thickness = x_slice.thickness();
         std::string slice_name = layer_name + _toString(slice_num, "slice%d");
-        Material slice_mat = desc.material(x_slice.materialStr());		
+        Material slice_mat = desc.material(x_slice.materialStr());
         slice_z += slice_thickness/2.; // Going to slice halfway point
 
         Box slice(width/2., height/2., slice_thickness/2.);
-        
+
         Volume slice_vol (slice_name, slice, slice_mat);
-        
+
         // Setting appropriate slices as sensitive
         if(x_slice.isSensitive())
         {
           sens.setType("calorimeter");
           slice_vol.setSensitiveDetector(sens);
         }
-        
+
         // Setting slice attributes
         slice_vol.setAttributes(
           desc,
@@ -113,7 +113,7 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
       layer_vol.setAttributes(
         desc,
         x_layer.regionStr(),
-        x_layer.limitsStr(), 
+        x_layer.limitsStr(),
         x_layer.visStr()
       );
       // Placing each layer inside the envelope volume
@@ -140,9 +140,9 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
     }
   }
 
-  DetElement   det(detName, detID);  
+  DetElement   det(detName, detID);
   Volume motherVol = desc.pickMotherVolume(det);
-  
+
   // Placing ZDC in world volume
   auto tr = Transform3D(Position(pos.x(), pos.y(), pos.z() + length / 2.));
   PlacedVolume phv = motherVol.placeVolume(envelopeVol, tr);

--- a/src/ZeroDegreeCalorimeterSiPMonTile_geo.cpp
+++ b/src/ZeroDegreeCalorimeterSiPMonTile_geo.cpp
@@ -1,0 +1,154 @@
+//==========================================================================
+//  Implementation of Zero-Degree Calorimeter SiPM-on-tile
+//--------------------------------------------------------------------------
+//  Author: Sebouh J. Paul (UCR)
+//==========================================================================
+
+#include "DD4hep/DetFactoryHelper.h"
+#include <XML/Helper.h>
+#include <XML/Layering.h>
+
+using namespace dd4hep;
+
+static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens)
+{
+  xml_det_t     detElem = handle;
+  std::string   detName = detElem.nameStr();
+  int           detID   = detElem.id();
+
+  xml_dim_t  dim        = detElem.dimensions();
+  double     width      = dim.x(); // Size along x-axis
+  double     height     = dim.y(); // Size along y-axis 
+  double     length     = dim.z(); // Size along z-axis
+
+  xml_dim_t  pos        = detElem.position(); // Position in global coordinates
+
+  Material   air        = desc.material("Air");
+  
+  // Defining envelope
+  Box envelope(width / 2.0, height / 2.0, length / 2.0);
+    
+  // Defining envelope volume
+  Volume envelopeVol(detName, envelope, air); 
+  // Setting envelope attributes
+  envelopeVol.setAttributes(
+    desc,
+    detElem.regionStr(),
+    detElem.limitsStr(),
+    detElem.visStr()
+  );
+
+  PlacedVolume pv;
+
+  double z_distance_traversed = 0.;
+
+  int layer_num = 1;
+  
+  // Looping through all the different layer sections
+  for(xml_coll_t c(detElem,_U(layer)); c; ++c)
+  {
+    xml_comp_t x_layer = c;
+    int repeat = x_layer.repeat();  
+    double layer_thickness = x_layer.thickness();
+    
+    // Looping through the number of repeated layers in each section
+    for(int i = 0; i < repeat; i++)
+    {
+      std::string layer_name = detName + _toString(layer_num, "_layer%d");
+
+      Box layer(width / 2., height / 2., layer_thickness / 2.);
+
+      Volume layer_vol(layer_name, layer, air);
+
+      int slice_num = 1;
+      double slice_z = -layer_thickness / 2.; // Keeps track of slices' z locations in each layer
+
+      // Looping over each layer's slices
+      for(xml_coll_t l(x_layer,_U(slice)); l; ++l) 
+      {
+        xml_comp_t x_slice = l;
+        double slice_thickness = x_slice.thickness();
+        std::string slice_name = layer_name + _toString(slice_num, "slice%d");
+        Material slice_mat = desc.material(x_slice.materialStr());		
+        slice_z += slice_thickness/2.; // Going to slice halfway point
+
+        Box slice(width/2., height/2., slice_thickness/2.);
+        
+        Volume slice_vol (slice_name, slice, slice_mat);
+        
+        // Setting appropriate slices as sensitive
+        if(x_slice.isSensitive())
+        {
+          sens.setType("calorimeter");
+          slice_vol.setSensitiveDetector(sens);
+        }
+        
+        // Setting slice attributes
+        slice_vol.setAttributes(
+          desc,
+          x_slice.regionStr(),
+          x_slice.limitsStr(),
+          x_slice.visStr()
+        );
+
+        // Placing slice within layer
+        pv = layer_vol.placeVolume(
+          slice_vol,
+          Transform3D(
+            RotationZYX(0, 0, 0),
+            Position(
+              0.,
+              0.,
+              slice_z
+            )
+          )
+        );
+        pv.addPhysVolID("slice", slice_num);
+        slice_z += slice_thickness/2.;
+        z_distance_traversed += slice_thickness;
+        ++slice_num;
+      }
+
+      // Setting layer attributes
+      layer_vol.setAttributes(
+        desc,
+        x_layer.regionStr(),
+        x_layer.limitsStr(), 
+        x_layer.visStr()
+      );
+      // Placing each layer inside the envelope volume
+      // -length/2. is front of detector in global coordinate system
+      // + (z_distance_traversed - layer_thickness) goes to the front of each layer
+      // + layer_thickness/2. places layer in correct spot
+      // Example: After placement of slices in first layer, z_distance_traversed = layer_thickness
+      //          Subtracting layer_thickness goes back to the front of the first slice (Now, z = -length/2)
+      //          Adding layer_thickness/2. goes to half the first layer thickness (proper place to put layer)
+      //          Each loop over repeat will increases z_distance_traversed by layer_thickness
+      pv = envelopeVol.placeVolume(
+        layer_vol,
+        Transform3D(
+          RotationZYX(0, 0, 0),
+          Position(
+            0.,
+            0.,
+            -length/2.  + (z_distance_traversed - layer_thickness) + layer_thickness/2.
+          )
+        )
+      );
+      pv.addPhysVolID("layer", layer_num);
+      layer_num++;
+    }
+  }
+
+  DetElement   det(detName, detID);  
+  Volume motherVol = desc.pickMotherVolume(det);
+  
+  // Placing ZDC in world volume
+  auto tr = Transform3D(Position(pos.x(), pos.y(), pos.z() + length / 2.));
+  PlacedVolume phv = motherVol.placeVolume(envelopeVol, tr);
+  phv.addPhysVolID("system", detID);
+  det.setPlacement(phv);
+
+  return det;
+}
+DECLARE_DETELEMENT(ZeroDegreeCalorimeterSiPMonTile, createDetector)

--- a/src/ZeroDegreeCalorimeterSiPMonTile_geo.cpp
+++ b/src/ZeroDegreeCalorimeterSiPMonTile_geo.cpp
@@ -2,7 +2,7 @@
 // Copyright (C) 2023 Sebouh J. Paul
 
 //==========================================================================
-//  Implementation of SiPM-on-tile Zero-Degree Calorimeter 
+//  Implementation of SiPM-on-tile Zero-Degree Calorimeter
 //--------------------------------------------------------------------------
 //  Author: Sebouh J. Paul (UCR)
 //==========================================================================

--- a/src/ZeroDegreeCalorimeterSiPMonTile_geo.cpp
+++ b/src/ZeroDegreeCalorimeterSiPMonTile_geo.cpp
@@ -1,5 +1,8 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023 Sebouh J. Paul
+
 //==========================================================================
-//  Implementation of Zero-Degree Calorimeter SiPM-on-tile
+//  Implementation of SiPM-on-tile Zero-Degree Calorimeter 
 //--------------------------------------------------------------------------
 //  Author: Sebouh J. Paul (UCR)
 //==========================================================================

--- a/src/ZeroDegreeCalorimeterSiPMonTile_geo.cpp
+++ b/src/ZeroDegreeCalorimeterSiPMonTile_geo.cpp
@@ -25,6 +25,7 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
   double     length     = dim.z(); // Size along z-axis
 
   xml_dim_t  pos        = detElem.position(); // Position in global coordinates
+  xml_dim_t rot         = detElem.rotation();
 
   Material   air        = desc.material("Air");
 
@@ -147,7 +148,7 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
   Volume motherVol = desc.pickMotherVolume(det);
 
   // Placing ZDC in world volume
-  auto tr = Transform3D(Position(pos.x(), pos.y(), pos.z() + length / 2.));
+  auto tr = Transform3D(RotationZYX(rot.z(), rot.y(), rot.x()),Position(pos.x(), pos.y(), pos.z()));
   PlacedVolume phv = motherVol.placeVolume(envelopeVol, tr);
   phv.addPhysVolID("system", detID);
   det.setPlacement(phv);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Adds an SiPM-on-tile implementation of the ZDC Hcal, using similar technology to the forward calorimeter insert.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #530)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No, it does not introduce breaking changes

### Does this PR change default behavior?

No, it does not change default behavior


To test this geometry,
Follow instructions in README.md to install epic and run source install/setup.sh
Run ./run_sim_hepmc_zdc inside the attached test_suite.zip in order to run a quick simulation of events in the proposed detector.
[test_suite.zip](https://github.com/eic/epic/files/12708021/test_suite.zip)

