### PR TITLE
ZDC_SiPMonTile.xml: name rotation angle after Y-axis, not Z

### DIFF
--- a/compact/far_forward/ZDC_SiPMonTile.xml
+++ b/compact/far_forward/ZDC_SiPMonTile.xml
@@ -43,8 +43,8 @@
     <constant name="HcalFarForwardZDC_SiPMonTile_length" value= "HcalFarForwardZDC_SiPMonTile_SingleLayerThickness*HcalFarForwardZDC_SiPMonTile_Layer_NSteelRepeat +
            HcalFarForwardZDC_SiPMonTile_BackplateThickness"/>
     <constant name="HcalFarForwardZDC_SiPMonTile_rotateX_angle" value="0*deg"/>
-    <constant name="HcalFarForwardZDC_SiPMonTile_rotateY_angle" value="0*deg"/>
-    <constant name="HcalFarForwardZDC_SiPMonTile_rotateZ_angle" value="ionCrossingAngle"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_rotateY_angle" value="ionCrossingAngle"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_rotateZ_angle" value="0*deg"/>
 
     <constant name="HcalFarForwardZDC_SiPMonTile_r_pos_front_face" value="35.8*m"/>
     <constant name="HcalFarForwardZDC_SiPMonTile_r_pos" value="HcalFarForwardZDC_SiPMonTile_r_pos_front_face + HcalFarForwardZDC_SiPMonTile_length/2.0"/>

--- a/compact/far_forward/ZDC_SiPMonTile.xml
+++ b/compact/far_forward/ZDC_SiPMonTile.xml
@@ -48,9 +48,9 @@
 
     <constant name="HcalFarForwardZDC_SiPMonTile_r_pos_front_face" value="35.8*m"/>
     <constant name="HcalFarForwardZDC_SiPMonTile_r_pos" value="HcalFarForwardZDC_SiPMonTile_r_pos_front_face + HcalFarForwardZDC_SiPMonTile_length/2.0"/>
-    <constant name="HcalFarForwardZDC_SiPMonTile_x_pos" value="sin(HcalFarForwardZDC_SiPMonTile_rotateZ_angle)*HcalFarForwardZDC_SiPMonTile_r_pos"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_x_pos" value="sin(HcalFarForwardZDC_SiPMonTile_rotateY_angle)*HcalFarForwardZDC_SiPMonTile_r_pos"/>
     <constant name="HcalFarForwardZDC_SiPMonTile_y_pos" value="0*m" />
-    <constant name="HcalFarForwardZDC_SiPMonTile_z_pos" value="cos(HcalFarForwardZDC_SiPMonTile_rotateZ_angle)*HcalFarForwardZDC_SiPMonTile_r_pos"/>
+    <constant name="HcalFarForwardZDC_SiPMonTile_z_pos" value="cos(HcalFarForwardZDC_SiPMonTile_rotateY_angle)*HcalFarForwardZDC_SiPMonTile_r_pos"/>
   </define>
 
   <limits>


### PR DESCRIPTION
Corrected which axis the ZDC_SiPMonTile is rotated about.  This axis was set to z accidentally, but this pull request changes this to the y axis.

### Briefly, what does this PR introduce?
Makes the rotation of the ZDC SiPM-on-tile be along the y axis, rather than the z axis

### What kind of change does this PR introduce?
- [X] Bug fix (issue #544)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No breaking changes.  This will modify the output of any code that uses the output of ZDC SiPM-on-tile simulations
### Does this PR change default behavior?
Since the proposed SiPM-on-tile ZDC is not yet a part of the default configuration, this will not change the default behavior
