### PR TITLE
feat - Increase number of W/Sc layers in forward HCal insert from 4 to 10.

### DIFF
--- a/compact/hcal/forward_insert.xml
+++ b/compact/hcal/forward_insert.xml
@@ -49,8 +49,8 @@
              HcalEndcapPInsertAirThickness "
     />
     <constant name="HcalEndcapPInsertBackplateThickness"    value="HcalEndcapPInsertAbsorberThickness"/>
-    <constant name="HcalEndcapPInsertLayer_NTungstenRepeat" value="4"/>
-    <constant name="HcalEndcapPInsertLayer_NSteelRepeat"    value="60"/>
+    <constant name="HcalEndcapPInsertLayer_NTungstenRepeat" value="10"/>
+    <constant name="HcalEndcapPInsertLayer_NSteelRepeat"    value="54"/>
   </define>
 
   <detectors>
@@ -58,7 +58,7 @@
       ### Forward (Positive Z) Endcap Insert for Hadronic Calorimeter
       Insert goes in the middle of the forward endcap HCal -- around the beampipe
 
-      Insert is 1 front layer of Steel/Sc, 4 layers of W/Sc, 60 layers of Steel/Sc + 1 backplate of steel
+      Insert is 1 front layer of Steel/Sc, 10 layers of W/Sc, 54 layers of Steel/Sc + 1 backplate of steel
       Each of the layers (sans backplate) includes air gaps (front and back of each layer),
       ESR foil (front and back of scintillator), a PCB, and an aluminum scitnillator cover
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
There are currently 4 layers of W/Sc in the forward HCal insert to match the layering of the surrounding LFHCAL. The correct layer structure for the HCal insert should be 1 front layer of Steel/Sc, 10 layers of W/Sc, 54 layers of Steel/Sc, 1 back layer of steel.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #546 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
None.
### Does this PR change default behavior?
Only the changes to the HCal insert listed above.