### PR TITLE
fix: EcalEndcapN_zmin:=175cm

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -529,7 +529,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="EcalEndcapPInsert_hole_yposition" value="0.0*cm"/>
 
     <!-- <constant name="EcalEndcapN_zmin"               value="BackwardPIDRegion_zmin + BackwardInnerEndcapRegion_length"/> -->
-    <constant name="EcalEndcapN_zmin"               value="174*cm"/>   <!-- Currently fix value hardcoded -->
+    <constant name="EcalEndcapN_zmin"               value="175*cm"/>   <!-- Currently fix value hardcoded -->
     <constant name="EcalEndcapN_length"             value="60*cm" />   <!-- Currently fix value hardcoded -->
     <constant name="EcalEndcapN_zmax"               value="EcalEndcapN_zmin + EcalEndcapN_length"/>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
And we start to address the mismatches in https://github.com/eic/epic/pull/553. This one should be fairly harmless.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: EcalEndcapN_zmin := 175cm, shift backwards by 1 cm)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @johnny8266

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.