### PR TITLE
fix: BackwardServiceGap_length:=124cm, HcalEndcapN_length:=45cm

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -500,8 +500,8 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="ForwardServiceGap_rmin"       value="ForwardPIDRegion_rmax"/>
     <constant name="ForwardServiceGap_rmax"       value="ForwardServiceGap_rmin + ForwardServiceGap_thickness"/>
 
-    <constant name="BackwardServiceGap_length"    value="10.0 * cm"/>
-    <constant name="BackwardServiceGap_zmin"      value="320.0 * cm"/> <!-- FIXME hardcoded -->
+    <constant name="BackwardServiceGap_length"    value="124.0 * cm"/>
+    <constant name="BackwardServiceGap_zmin"      value="316.0 * cm"/> <!-- FIXME hardcoded -->
     <constant name="BackwardServiceGap_zmax"      value="BackwardServiceGap_zmin + BackwardServiceGap_length"/>
 
 
@@ -590,10 +590,10 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
 
     <constant name="HcalEndcapN_CaloSides"      value="60"/>
     <constant name="HcalEndcapN_zmin"     value="BackwardServiceGap_zmax"/>
-    <constant name="HcalEndcapN_length"   value="44.0*cm"/>
+    <constant name="HcalEndcapN_length"   value="45.0*cm"/>
     <constant name="HcalEndcapN_zmax"     value="HcalEndcapN_zmin + HcalEndcapN_length"/>
     <comment> HcalEndcapN needs to clear the straight beampipe with 1 * crossing angle + its radius of 22.25 mm </comment>
-    <constant name="HcalEndcapN_rmin"     value="max((HcalEndcapN_zmin + HcalEndcapN_length) * tan(abs(CrossingAngle)) + 22.25 * mm, 11 * cm)"/>
+    <constant name="HcalEndcapN_rmin"     value="max((HcalEndcapN_zmin + HcalEndcapN_length) * tan(abs(CrossingAngle)) + 22.25 * mm, 12.4 * cm)"/>
 
     <constant name="HcalBarrel_thickness" value="93.0*cm"/> <!-- ref: as-built CAD, plus a little room for the longer half-plates -->
     <constant name="HcalBarrel_rmin"      value="Solenoid_rmax"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
And we start to address the mismatches in https://github.com/eic/epic/pull/553. This one should be mostly isolate from other parts.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: BackwardServiceGap_length is larger)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @lkosarz 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.