### PR TITLE
fix: add EcalBarrel vars to template; EcalBarrel_rmin:=81cm; EcalBarrel_thickness:=35cm

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -542,8 +542,8 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="EcalEndcapN_rmin"               value="9.*cm"/>    <!-- Currently fix value hardcoded -->
     <constant name="EcalEndcapN_rmax"               value="63.*cm"/>   <!-- Currently fix value hardcoded -->
 
-    <constant name="EcalBarrelRegion_thickness"     value="61.5*cm"/>
-    <constant name="EcalBarrel_rmin"                value="CentralTrackingRegion_rmax + BarrelPIDRegion_thickness + BarrelExtraSpace_thickness"/>
+    <constant name="EcalBarrelRegion_thickness"     value="35.*cm"/>
+    <constant name="EcalBarrel_rmin"                value="max(81.*cm, CentralTrackingRegion_rmax + BarrelPIDRegion_thickness + BarrelExtraSpace_thickness)"/> <!-- FIXME hardcoded max -->
     <constant name="EcalBarrel_inner_margin"        value="2*cm"/>
     <constant name="EcalBarrel_rmax"                value="EcalBarrel_rmin + EcalBarrelRegion_thickness"/>
     <constant name="EcalBarrelForward_zmax"         value="ForwardRICHRegion_zmin"/> <!-- FIXME currently unable to accommodate actual position -->

--- a/templates/DetectorParameterTable.csv.jinja2
+++ b/templates/DetectorParameterTable.csv.jinja2
@@ -19,9 +19,9 @@ CENTRAL DETECTOR,Barrel HD EMCal Support,Exterior Plate,,,,,,
 CENTRAL DETECTOR,Barrel HD EMCal Support,Support Ring,,,,,,
 CENTRAL DETECTOR,Barrel EMCal,,{{EcalBarrel_length}},{{EcalBarrel_rmin}},{{EcalBarrel_rmax}},,-{{EcalBarrelBackward_zmax}},{{EcalBarrelForward_zmax}}
 CENTRAL DETECTOR,Barrel EMCal,Exterior Cover,,,,,,
-CENTRAL DETECTOR,Barrel EMCal,Imaging Part,,,,,,
-CENTRAL DETECTOR,Barrel EMCal,Sampling Part,,,,,,
-CENTRAL DETECTOR,Barrel EMCal,LD Readout Electronics,,,,,,
+CENTRAL DETECTOR,Barrel EMCal,Imaging Part,{{EcalBarrel_Calorimeter_length}},{{EcalBarrel_rmin}},{{EcalBarrel_rmin+EcalBarrel_ImagingPartThickness}},-{{EcalBarrel_Calorimeter_zmax}},{{EcalBarrel_Calorimeter_zmax}}
+CENTRAL DETECTOR,Barrel EMCal,Sampling Part,{{EcalBarrel_Calorimeter_length}},{{EcalBarrel_rmin+EcalBarrel_ImagingPartThickness}},{{EcalBarrel_rmin+EcalBarrel_ImagingPartThickness+EcalBarrel_ScFiPartThickness}},-{{EcalBarrel_Calorimeter_zmax}},{{EcalBarrel_Calorimeter_zmax}}
+CENTRAL DETECTOR,Barrel EMCal,LD Readout Electronics,,,,,-{{EcalBarrel_Readout_zmax}},-{{EcalBarrel_Readout_zmin}}
 CENTRAL DETECTOR,Barrel EMCal,HD Readout Electronics,,,,,,
 CENTRAL DETECTOR,Barrel LD EMCal Support,,,,,,,
 CENTRAL DETECTOR,Barrel LD EMCal Support,Exterior Plate,,,,,,


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds a number of EcalBarrel variables to the detector parameter table template.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #561)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.