### PR TITLE
Update the ZDC position and configuration.

### DIFF
--- a/compact/far_forward/ZDC.xml
+++ b/compact/far_forward/ZDC.xml
@@ -11,12 +11,14 @@
       Zero Degree Calorimeter General Parameters
       -------------------------------------------
     </comment>
-    <constant name="ZDC_r_pos"         value="3550.0 * cm"/> <!-- Make it match to the CAD figure 22/Nov/22 -->
+    <constant name="ZDC_r_pos"         value="3579.0 * cm"/> <!-- Make it match to the CAD design, with front-surface center of PbWO4 at 35.8m from IP 05/Oct/23 -->
     <constant name="ZDC_y_pos"         value="0.0 * cm"/>
     <constant name="ZDC_rotateX_angle" value="0.0 * rad"/>
     <constant name="ZDC_rotateY_angle" value="ionCrossingAngle"/>
     <constant name="ZDC_rotateZ_angle" value="0.0 * rad"/>
-    <constant name="ZDC_width"         value="60.0 * cm"/>
+    <constant name="ZDC_height"        value="54.0 * cm"/>
+    <constant name="ZDC_width"         value="56.0 * cm"/>
+    <constant name="ZDC_Pb_width"      value="60.0 * cm"/>
     <constant name="ZDC_length"        value="200.0 * cm"/>
 
     <comment>
@@ -41,7 +43,7 @@
     <constant name="ZDC_Crystal_rotateZ_angle"   value="ZDC_rotateZ_angle"/>
     <constant name="ZDC_Crystal_width"           value="ZDC_width"/>
 
-    <constant name="ZDC_WSi_r_pos"               value="ZDC_r_pos + 23*cm"/>
+    <constant name="ZDC_WSi_r_pos"               value="ZDC_r_pos + 19.8*cm"/>
     <constant name="ZDC_WSi_z_pos"               value="ZDC_WSi_r_pos * cos(ionCrossingAngle)"/>
     <constant name="ZDC_WSi_x_pos"               value="ZDC_WSi_r_pos * sin(ionCrossingAngle)"/>
     <constant name="ZDC_WSi_y_pos"               value="ZDC_y_pos"/>
@@ -49,7 +51,7 @@
     <constant name="ZDC_WSi_rotateY_angle"       value="ZDC_rotateY_angle"/>
     <constant name="ZDC_WSi_rotateZ_angle"       value="ZDC_rotateZ_angle"/>
     <constant name="ZDC_WSi_nblocks"             value="2"/>
-    <constant name="ZDC_WSi_pad_nlayers_per_block"         value="10"/>
+    <constant name="ZDC_WSi_pad_nlayers_per_block"         value="5"/>
 
     <constant name="ZDC_PbSi_r_pos"               value="ZDC_r_pos + 59. *cm"/>
     <constant name="ZDC_PbSi_z_pos"               value="ZDC_PbSi_r_pos * cos(ionCrossingAngle)"/>
@@ -60,32 +62,31 @@
     <constant name="ZDC_PbSi_rotateZ_angle"       value="ZDC_rotateZ_angle"/>
     <constant name="ZDC_PbSi_nlayers"             value="12"/>
 
-    <constant name="ZDC_PbSci_r_pos"               value="ZDC_r_pos + 137. *cm"/>
+    <constant name="ZDC_PbSci_r_pos"               value="ZDC_r_pos + 108.9 *cm"/>
     <constant name="ZDC_PbSci_z_pos"               value="ZDC_PbSci_r_pos * cos(ionCrossingAngle)"/>
     <constant name="ZDC_PbSci_x_pos"               value="ZDC_PbSci_r_pos * sin(ionCrossingAngle)"/>
     <constant name="ZDC_PbSci_y_pos"               value="ZDC_y_pos"/>
     <constant name="ZDC_PbSci_rotateX_angle"       value="ZDC_rotateX_angle"/>
     <constant name="ZDC_PbSci_rotateY_angle"       value="ZDC_rotateY_angle"/>
     <constant name="ZDC_PbSci_rotateZ_angle"       value="ZDC_rotateZ_angle"/>
-    <constant name="ZDC_PbSci_nbox"                value="2"/>
-    <constant name="ZDC_PbSci_nlayers_per_box"     value="15"/>
+    <constant name="ZDC_PbSci_nbox"                value="3"/>
+    <constant name="ZDC_PbSci_nlayers_per_box"     value="38"/>
     <constant name="ZDC_PbSci_box_gap"             value="5.*cm"/>
 
     <constant name="ZDC_pad_thickness"           value="320.0 * um"/>
     <constant name="ZDC_pixel_thickness"         value="300.0 * um"/>
     <constant name="ZDC_glue_thickness"          value="0.11 * mm"/>
     <constant name="ZDC_PCB_thickness"           value="1.6 * mm"/>
-    <constant name="ZDC_Si_Air_thickness"        value="5. *mm"/>
-    <constant name="ZDC_Tungsten_thickness"      value="3.5 *mm"/>
-    <constant name="ZDC_Lead_thickness"          value="3. *cm"/>
-    <constant name="ZDC_Sci_thickness"           value="2.* mm"/>
+    <constant name="ZDC_Si_Air_thickness"        value="5. * mm"/>
+    <constant name="ZDC_Tungsten_thickness"      value="7. * mm"/>
+    <constant name="ZDC_Lead_thickness"          value="10. * mm"/>
+    <constant name="ZDC_Sci_thickness"           value="2.5 * mm"/>
 
   </define>
 
   <include ref="ZDC_1stSilicon.xml"/>
   <include ref="ZDC_Crystal.xml"/>
   <include ref="ZDC_WSi.xml"/>
-  <include ref="ZDC_PbSi.xml"/>
   <include ref="ZDC_PbScinti.xml"/>
 
 </lccdd>

--- a/compact/far_forward/ZDC_1stSilicon.xml
+++ b/compact/far_forward/ZDC_1stSilicon.xml
@@ -11,7 +11,7 @@
 
   <define>
     <constant name="ZDC_1stSilicon_x"       value="ZDC_width"/>
-    <constant name="ZDC_1stSilicon_y"       value="ZDC_width"/>
+    <constant name="ZDC_1stSilicon_y"       value="ZDC_height"/>
     <constant name="ZDC_1stSilicon_z"       value="ZDC_pixel_thickness + ZDC_glue_thickness + ZDC_PCB_thickness + ZDC_Si_Air_thickness"/>
   </define>
 
@@ -36,7 +36,7 @@
 
   <readouts>
     <readout name="ZDC_SiliconPix_Hits">
-      <segmentation type="CartesianGridXY" grid_size_x="3.*mm" grid_size_y="3.*mm"/>
+      <segmentation type="CartesianGridXY" grid_size_x="4.*mm" grid_size_y="3.*mm"/>
       <id>system:8,silicon:6,x:24:-12,y:-12</id>
     </readout>
   </readouts>

--- a/compact/far_forward/ZDC_Crystal.xml
+++ b/compact/far_forward/ZDC_Crystal.xml
@@ -10,13 +10,14 @@
   </comment>
 
   <define>
-    <constant name="ZDC_Crystal_cell_width"     value="3.*cm"/>
+    <constant name="ZDC_Crystal_cell_height"    value="3.*cm"/>
+    <constant name="ZDC_Crystal_cell_width"     value="4.*cm"/>
     <constant name="ZDC_Crystal_cell_length"    value="7.*cm"/>
     <constant name="ZDC_Crystal_frame_thickness"  value="0.3*mm"/>
     <constant name="ZDC_Crystal_active_x"       value="ZDC_width"/>
-    <constant name="ZDC_Crystal_active_y"       value="ZDC_width"/>
+    <constant name="ZDC_Crystal_active_y"       value="ZDC_height"/>
     <constant name="ZDC_Crystal_nx"             value="ZDC_Crystal_active_x/ZDC_Crystal_cell_width"/>
-    <constant name="ZDC_Crystal_ny"             value="ZDC_Crystal_active_y/ZDC_Crystal_cell_width"/>
+    <constant name="ZDC_Crystal_ny"             value="ZDC_Crystal_active_y/ZDC_Crystal_cell_height"/>
     <constant name="ZDC_Crystal_APD_socket_z"   value="2.5*mm"/>
     <constant name="ZDC_Crystal_space"          value="2.8*cm"/>
   </define>
@@ -31,14 +32,14 @@
       <position x="ZDC_Crystal_x_pos"         y="ZDC_Crystal_y_pos"         z="ZDC_Crystal_z_pos"/>
       <rotation x="ZDC_Crystal_rotateX_angle" y="ZDC_Crystal_rotateY_angle" z="ZDC_Crystal_rotateZ_angle"/>
       <dimensions x="ZDC_Crystal_nx * (ZDC_Crystal_cell_width + ZDC_Crystal_frame_thickness) + ZDC_Crystal_frame_thickness"
-                  y="ZDC_Crystal_ny * (ZDC_Crystal_cell_width + ZDC_Crystal_frame_thickness) + ZDC_Crystal_frame_thickness"
+                  y="ZDC_Crystal_ny * (ZDC_Crystal_cell_height + ZDC_Crystal_frame_thickness) + ZDC_Crystal_frame_thickness"
                   z="ZDC_Crystal_cell_length + ZDC_Crystal_space"/>
       <module name="tower" nx="ZDC_Crystal_nx" ny="ZDC_Crystal_ny">
         <tower name="crystal"
-               cellx="ZDC_Crystal_cell_width" celly="ZDC_Crystal_cell_width" thickness="ZDC_Crystal_cell_length"
+               cellx="ZDC_Crystal_cell_width" celly="ZDC_Crystal_cell_height" thickness="ZDC_Crystal_cell_length"
                material="PbWO4" vis="AnlGold" sensitive="true"/>
         <socket name="socket"
-                cellx="ZDC_Crystal_cell_width" celly="ZDC_Crystal_cell_width" thickness="ZDC_Crystal_APD_socket_z"
+                cellx="ZDC_Crystal_cell_width" celly="ZDC_Crystal_cell_height" thickness="ZDC_Crystal_APD_socket_z"
                 material="ZDC_Polyethylene" vis="AnlTeal" />
       </module>
       <support  material="CarbonFiber" vis="AnlLight_Gray" sizez="ZDC_Crystal_cell_length" thickness="ZDC_Crystal_frame_thickness"/>

--- a/compact/far_forward/ZDC_PbScinti.xml
+++ b/compact/far_forward/ZDC_PbScinti.xml
@@ -11,8 +11,8 @@
 
   <define>
     <constant name="ZDC_PbSci_layer_thickness" value="ZDC_Lead_thickness + ZDC_Sci_thickness"/>
-    <constant name="ZDC_PbSci_x"       value="ZDC_width"/>
-    <constant name="ZDC_PbSci_y"       value="ZDC_width"/>
+    <constant name="ZDC_PbSci_x"       value="ZDC_Pb_width"/>
+    <constant name="ZDC_PbSci_y"       value="ZDC_Pb_width"/>
     <constant name="ZDC_PbSci_z"
               value="ZDC_PbSci_nbox * (ZDC_PbSci_nlayers_per_box * ZDC_PbSci_layer_thickness + ZDC_PbSci_box_gap)"/>
   </define>
@@ -39,7 +39,7 @@
   <readouts>
     <readout name="ZDCHcalHits">
       <segmentation type="CartesianGridXY" grid_size_x="10.*cm" grid_size_y="10.*cm"/>
-      <id>system:8,scinti:6,x:24:-12,y:-12</id>
+      <id>system:8,scinti:8,x:24:-12,y:-12</id>
     </readout>
   </readouts>
 

--- a/compact/far_forward/ZDC_WSi.xml
+++ b/compact/far_forward/ZDC_WSi.xml
@@ -11,7 +11,7 @@
 
   <define>
     <constant name="ZDC_WSi_x"       value="ZDC_width"/>
-    <constant name="ZDC_WSi_y"       value="ZDC_width"/>
+    <constant name="ZDC_WSi_y"       value="ZDC_height"/>
     <constant name="ZDC_WSi_pix_nlayers" value="ZDC_WSi_nblocks + 1"/>
     <constant name="ZDC_WSi_pad_nlayers" value="ZDC_WSi_nblocks * ZDC_WSi_pad_nlayers_per_block"/>
     <constant name="ZDC_WSi_pad_layerthickness"

--- a/compact/far_forward/ZDC_WSi.xml
+++ b/compact/far_forward/ZDC_WSi.xml
@@ -72,9 +72,9 @@
   <readouts>
     <readout name="ZDC_WSi_Hits">
       <segmentation type="MultiSegmentation" key="silicon">
-        <segmentation name="WSi_Pixel1" type="CartesianGridXY" key_value="1" grid_size_x="3.*mm" grid_size_y="3.*mm"/>
-        <segmentation name="WSi_Pixel2" type="CartesianGridXY" key_value="12" grid_size_x="3.*mm" grid_size_y="3.*mm"/>
-        <segmentation name="WSi_Pixel3" type="CartesianGridXY" key_value="23" grid_size_x="3.*mm" grid_size_y="3.*mm"/>
+        <segmentation name="WSi_Pixel1" type="CartesianGridXY" key_value="1" grid_size_x="4.*mm" grid_size_y="3.*mm"/>
+        <segmentation name="WSi_Pixel2" type="CartesianGridXY" key_value="12" grid_size_x="4.*mm" grid_size_y="3.*mm"/>
+        <segmentation name="WSi_Pixel3" type="CartesianGridXY" key_value="23" grid_size_x="4.*mm" grid_size_y="3.*mm"/>
         <segmentation name="WSi_Pad1"   type="CartesianGridXY" key_min="2" key_max="11" grid_size_x="1.*cm" grid_size_y="1.*cm"/>
         <segmentation name="WSi_Pad2"   type="CartesianGridXY" key_min="13" key_max="22" grid_size_x="1.*cm" grid_size_y="1.*cm"/>
       </segmentation>


### PR DESCRIPTION
### Briefly, what does this PR introduce?

ZDC position and setup are updated:

1. The front-surface center of PbWO4 is at 35.8m from IP
2. Crystal, W/Si, and Pb/Scint modules are modified. The Pb/Sci module has been removed. 


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

The Pb/Si module is removed and therefore the signals from it can not be read.

### Does this PR change default behavior?

No.