### PR TITLE
fixed mpgd endcap readout segmentation

### DIFF
--- a/compact/tracking/mpgd_backward_endcap.xml
+++ b/compact/tracking/mpgd_backward_endcap.xml
@@ -153,8 +153,8 @@
 
   <readouts>
     <readout name="BackwardMPGDEndcapHits">
-      <segmentation type="CartesianGridXY" grid_size_x="sqrt(12)*150*um" grid_size_y="sqrt(12)*150*um" />
-      <id>system:8,layer:2,module:6,sensor:16,x:32:-16,y:-16</id>
+      <segmentation type="CartesianGridXZ" grid_size_x="sqrt(12)*150*um" grid_size_z="sqrt(12)*150*um" />
+      <id>system:8,layer:2,module:6,sensor:16,x:32:-16,z:-16</id>
     </readout>
   </readouts>
 

--- a/compact/tracking/mpgd_forward_endcap.xml
+++ b/compact/tracking/mpgd_forward_endcap.xml
@@ -154,8 +154,8 @@
 
   <readouts>
     <readout name="ForwardMPGDEndcapHits">
-      <segmentation type="CartesianGridXY" grid_size_x="sqrt(12)*150*um" grid_size_y="sqrt(12)*150*um" />
-      <id>system:8,layer:2,module:6,sensor:16,x:32:-16,y:-16</id>
+      <segmentation type="CartesianGridXZ" grid_size_x="sqrt(12)*150*um" grid_size_z="sqrt(12)*150*um" />
+      <id>system:8,layer:2,module:6,sensor:16,x:32:-16,z:-16</id>
     </readout>
   </readouts>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fixes a typo in the readout segmentation for the endcap MPGD disks. Prior to this fix MPGD endcaps only reconstructed hits on the outer radius. This also fixes warning related to MPGD endcap volumes:

`Warning: :CentralTrackerSourceLinker] [warning] Can't convert globalToLocal for hit: vol_id=79186 det_id=82 CellID=844433520145746 x=-1.0392305 y=-284.53473 z=1480.3262`

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No breaking changes, but MPGD disks will now have reconstructed hits across entire volume:

![MPGD_Endcap_fix](https://github.com/eic/epic/assets/2228075/109654e7-6deb-4238-8cee-dfded69f7595)

### Does this PR change default behavior?
You just get the full hits now.
