### PR TITLE
update parameters for DIRC 

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -424,7 +424,7 @@ Examples:
 
     </documentation>
 
-    <constant name="CentralTrackingRegion_rmax"   value="700.0*mm" />
+    <constant name="CentralTrackingRegion_rmax"   value="755.0*mm" />
     <constant name="CentralTrackingRegionP_zmax"  value="1800.0*mm" />
     <constant name="CentralTrackingRegionN_zmax"  value="1235.0*mm" />
     <constant name="CentralTrackingRegion_length" value="CentralTrackingRegionP_zmax + CentralTrackingRegionN_zmax" />
@@ -558,12 +558,16 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
       ## Special DIRC parameters (depend on the ECAL setup)
     </documentation>
     <constant name="DIRCReadout_length"         value="30*cm"/>
+    <comment> Leave 1.9 cm space from the end of mirror to the end of bar box in +z </comment>
+    <constant name="DIRCMirror_thickness"       value="1 * mm"/>
+    <constant name="DIRCBarbox_space_z"         value="1.9*cm"/>
+    <constant name="DIRCLens_thickness"         value="12 * mm"/>
     <constant name="DIRCForward_length"         value="0*cm"/>
     <constant name="DIRCForward_zmax"           value="CentralTrackingRegionP_zmax + 5*cm"/>
-    <constant name="DIRCBackward_zmax"          value="287*cm"/>
-    <constant name="DIRC_thickness"             value="3*cm"/>
+    <constant name="DIRCBackward_zmax"          value="303*cm"/>
+    <constant name="DIRC_thickness"             value="3.1*cm"/>
     <constant name="DIRC_length"                value="DIRCForward_zmax + DIRCBackward_zmax"/>
-    <constant name="DIRC_offset"                value="(DIRCForward_zmax - DIRCBackward_zmax)/2"/>
+    <constant name="DIRC_offset"                value="(DIRCForward_zmax - DIRCBackward_zmax - DIRCMirror_thickness - DIRCBarbox_space_z + DIRCLens_thickness + DIRCReadout_length)/2"/>
     <comment>
       The DIRC_rmin/rmax values are defined at the center of each stave, such that
       the DIRC_rmax can also be used as the OuterBarrelMPGD_rmin value.

--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -1,5 +1,5 @@
 <!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
-<!-- Copyright (C) 2022 Dmitry Romanov, Whitney Armstrong, Sylvester Joosten, Wouter Deconinck -->
+<!-- Copyright (C) 2022,2023 Dmitry Romanov, Whitney Armstrong, Sylvester Joosten, Wouter Deconinck, Nilanga Wickramaarachchi -->
 
 <lccdd>
 
@@ -15,6 +15,7 @@
       - DIRC_length
       - DIRC_offset
       - DIRC_rmin
+      - DIRC_rmax
       - DIRCBox_count  (12 full dirc, 1 - a single module)
 
     When DIRC_length is set, it affects bars length (all other lengths are fixed)
@@ -42,10 +43,8 @@
     <!-- Mirror -->
     <constant name="DIRCMirror_height"      value="20 * mm"/>
     <constant name="DIRCMirror_width"       value="DIRCPrism_width"/>
-    <constant name="DIRCMirror_thickness"   value="1 * mm"/>
 
     <!-- Lens -->
-    <constant name="DIRCLens_thickness"     value="12 * mm"/>
     <constant name="DIRCLens_r1"            value="62 * mm"/>
     <constant name="DIRCLens_r2"            value="36 * mm"/>
     <constant name="DIRCLens_height"        value="50 * mm"/>
@@ -59,12 +58,13 @@
 
     <!-- Bar - Each DIRC box consists of N "bars" -->
     <!-- BarAssembly - Bars + Glue -->
-    <constant name="DIRCBarAssm_length"     value="DIRC_length - DIRCPrism_length - DIRCMirror_thickness - DIRCLens_thickness - DIRCMCP_thickness" comment="Length of bars+glue assembly"/>
+    <constant name="DIRCBarAssm_length"     value="DIRC_length - DIRCPrism_length - DIRCBarbox_space_z - DIRCMirror_thickness - DIRCLens_thickness - DIRCMCP_thickness" comment="Length of bars+glue assembly"/>
     <constant name="DIRCBar_gap"            value="0.15 * mm"/>
     <constant name="DIRCBar_height"         value="17 * mm"/>
     <constant name="DIRCBar_width"          value="(DIRCPrism_width - (DIRCBar_count_y - 1) * DIRCBar_gap) / DIRCBar_count_y"/>
     <constant name="DIRCGlue_thickness"     value="0.05 * mm"/>
     <constant name="DIRCBar_length"         value="(DIRCBarAssm_length - 4 * DIRCGlue_thickness)/4"/>
+    <constant name="DIRCBar_center"         value="(DIRC_rmin + DIRC_rmax)/2" comment="Radial position of center of bar"/>
 
   </define>
 
@@ -108,7 +108,7 @@
 
   <detectors>
     <detector id="BarrelDIRC_ID" name="cb_DIRC" type="epic_DIRC" readout="DIRCBarHits" vis="DIRCTube">
-      <dimensions rmin="DIRC_rmin" rmax="DIRC_rmin + DIRCBar_height" length="DIRC_length"/>
+      <dimensions rmin="DIRCBar_center - DIRCBar_height/2" rmax="DIRCBar_center + DIRCBar_height/2" length="DIRC_length"/>
       <position x="0" y="0" z="DIRC_offset"/>
       <module name="DIRCBox" repeat="DIRCBox_count" width="DIRCPrism_width + 1*mm" height="DIRCPrism_height*2" length="DIRCBarAssm_length + 550*mm" vis="DIRCBox">
         <!-- Mirror (at the end of the module) -->


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This implements following parameters for DIRC.
- Inner radius of 75.5 cm and outer radius of 78.6 cm for the DIRC bar box. The center of bar is at the average of those two values (r = 77.05 cm).
![dirc_r](https://github.com/eic/epic/assets/23059941/c9c46b40-949b-45f1-b4d8-07194b3ffeac)

- DIRC readout starts at z = -303 cm. 
- Bar box ends at z = 185 cm. DIRC bar ends at z = 183 cm.
![dirc_z](https://github.com/eic/epic/assets/23059941/664a9ca1-c809-4621-a005-0185ad18557b)

### What kind of change does this PR introduce?
- [x] Bug fix (issue #568)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
