### PR TITLE
reduced vessel rmax2 to 180 cm

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -442,7 +442,7 @@ Examples:
     <comment> Global PID regions with suballocations for TOF and RICH detectors </comment>
     <constant name="ForwardPIDRegion_zmin"        value="CentralTrackingRegionP_zmax" />
     <constant name="ForwardPIDRegion_length"      value="135.0*cm" />
-    <constant name="ForwardPIDRegion_rmax"        value="185.0*cm" />
+    <constant name="ForwardPIDRegion_rmax"        value="180.0*cm" /> <!--Changed from 185.00 cm to 180.00 cm the dRICH vessel  -->
     <constant name="ForwardTOFRegion_length"      value="15.0*cm" />
 
     <comment> Forward RICH region </comment>

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -442,7 +442,7 @@ Examples:
     <comment> Global PID regions with suballocations for TOF and RICH detectors </comment>
     <constant name="ForwardPIDRegion_zmin"        value="CentralTrackingRegionP_zmax" />
     <constant name="ForwardPIDRegion_length"      value="135.0*cm" />
-    <constant name="ForwardPIDRegion_rmax"        value="180.0*cm" /> <!--Changed from 185.00 cm to 180.00 cm the dRICH vessel  -->
+    <constant name="ForwardPIDRegion_rmax"        value="180.0*cm" />
     <constant name="ForwardTOFRegion_length"      value="15.0*cm" />
 
     <comment> Forward RICH region </comment>

--- a/compact/pid/drich.xml
+++ b/compact/pid/drich.xml
@@ -23,7 +23,7 @@
 <!-- sensor boxes: extrusions of the tank, to hold the sensors and their services -->
 <constant name="DRICH_sensorbox_length"   value="10.0*cm"/>  <!-- z-length of the extrusion -->
 <constant name="DRICH_sensorbox_rmin"     value="DRICH_rmax1 + 2*cm"/>  <!-- lower radial limit of the extrusion -->
-<constant name="DRICH_sensorbox_rmax"     value="DRICH_rmax2"/>  <!-- upper radial limit of the extrusion -->
+<constant name="DRICH_sensorbox_rmax"     value="DRICH_rmax2 + 5*cm"/>  <!-- upper radial limit of the extrusion -->
 <!-- aerogel+filter geometry -->
 <constant name="DRICH_aerogel_thickness"  value="4.0*cm"/>  <!-- aerogel thickness -->
 <constant name="DRICH_airgap_thickness"   value="0.01*mm"/> <!-- air gap between aerogel and filter -->

--- a/compact/pid/drich.xml
+++ b/compact/pid/drich.xml
@@ -21,7 +21,7 @@
 <!-- tank geometry: cylinder, holding the majority of detector components -->
 <constant name="DRICH_rmax2"              value="ForwardPIDRegion_rmax"/>  <!-- cylinder radius -->
 <!-- sensor boxes: extrusions of the tank, to hold the sensors and their services -->
-<constant name="DRICH_sensorbox_length"   value="10.0*cm"/>  <!-- z-length of the extrusion -->
+<constant name="DRICH_sensorbox_length"   value="50.0*cm"/>  <!-- z-length of the extrusion -->
 <constant name="DRICH_sensorbox_rmin"     value="DRICH_rmax1 + 2*cm"/>  <!-- lower radial limit of the extrusion -->
 <constant name="DRICH_sensorbox_rmax"     value="DRICH_rmax2 + 5*cm"/>  <!-- upper radial limit of the extrusion -->
 <!-- aerogel+filter geometry -->

--- a/compact/pid/drich.xml
+++ b/compact/pid/drich.xml
@@ -329,7 +329,7 @@ photodetector unit (PDU) assembly diagram: matrix of SiPMs with services
 <sphericalpatch
   phiw="30*degree"
   rmin="111.0*cm"
-  rmax="179.0*cm"
+  rmax="174.0*cm"
   zmin="DRICH_snout_length + 4.0*cm"
   />
 

--- a/compact/pid/drich.xml
+++ b/compact/pid/drich.xml
@@ -329,7 +329,7 @@ photodetector unit (PDU) assembly diagram: matrix of SiPMs with services
 <sphericalpatch
   phiw="30*degree"
   rmin="111.0*cm"
-  rmax="174.0*cm"
+  rmax="179.0*cm"
   zmin="DRICH_snout_length + 4.0*cm"
   />
 

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -214,7 +214,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   UnionSolid gasvolUnion0(gasvolTank, gasvolSnout, Position(0., 0., -vesselLength / 2. + windowThickness));
 
   // union: add sensorbox
-  UnionSolid vesselUnion(vesselUnion0, vesselSensorboxTube, Position(0., 0., -(snoutLength + sensorboxLength) / 2.));
+  UnionSolid vesselUnion(vesselUnion0, vesselSensorboxTube, Position(0., 0., -(snoutLength + sensorboxLength - 0.6) / 2.));
   UnionSolid gasvolUnion(gasvolUnion0, gasvolSensorboxTube, Position(0., 0., -(snoutLength + sensorboxLength) / 2. + windowThickness));
 
   //  extra solids for `debugOptics` only

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -214,8 +214,8 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   UnionSolid gasvolUnion0(gasvolTank, gasvolSnout, Position(0., 0., -vesselLength / 2. + windowThickness));
 
   // union: add sensorbox
-  UnionSolid vesselUnion(vesselUnion0, vesselSensorboxTube, Position(0., 0., -(tankLength + sensorboxLength) / 2.));
-  UnionSolid gasvolUnion(gasvolUnion0, gasvolSensorboxTube, Position(0., 0., -(tankLength + sensorboxLength) / 2. + windowThickness));
+  UnionSolid vesselUnion(vesselUnion0, vesselSensorboxTube, Position(0., 0., -(snoutLength + sensorboxLength) / 2.));
+  UnionSolid gasvolUnion(gasvolUnion0, gasvolSensorboxTube, Position(0., 0., -(snoutLength + sensorboxLength) / 2. + windowThickness));
 
   //  extra solids for `debugOptics` only
   Box vesselBox(1001, 1001, 1001);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The updated geometry table requires the vessel rmax2 to be at 180 cm, but the designed communicated by Marco Contalbrigo requires the sensor box extended up to 185 cm. Also it requires the dRICH vessel length to be 122 cm (currently not implemented) . 
Marco is in communication with Tanja et al. to make sure the parameters are fine and afterwards this draft PR will be changed to the final PR.  

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X ] Changes have been communicated to collaborators
     Marco Contalbrigo and @c-dilks are communicated 
### Does this PR introduce breaking changes? What changes might users need to make to their code?
It should not make any difference. But if the barrel calorimeters are pushed downwards the overlap tests may fail. 
### Does this PR change default behavior?
It should not make any difference. But if the barrel calorimeters are pushed downwards the overlap tests may fail. Other than this the dRICH performance should not change. 