### PR TITLE
Update Outer MPGD barrel to match detector parameter table

### DIFF
--- a/compact/tracking/definitions_craterlake.xml
+++ b/compact/tracking/definitions_craterlake.xml
@@ -27,9 +27,9 @@
     <constant name="TrackerEndcapDisk_rmax"         value="43*cm"/>
 
     <comment> Main parameters for the outer MPGD barrel layer </comment>
-    <constant name="MPGDOuterBarrelModule_rmin"      value="68.25"/>
-    <constant name="MPGDOuterBarrelModule_zmin1"     value="167.5*cm"/>
-    <constant name="MPGDOuterBarrelModule_zmin2"     value="174.0*cm"/>
+    <constant name="MPGDOuterBarrelModule_rmin"      value="72.5"/>
+    <constant name="MPGDOuterBarrelModule_zmin1"     value="164.5*cm"/>
+    <constant name="MPGDOuterBarrelModule_zmin2"     value="174.5*cm"/>
 
     <comment> Inner MPGD unsegmented barrel </comment>
     <constant name="InnerMPGDBarrel_rmin"            value="51.25*cm"/>

--- a/compact/tracking/mpgd_outerbarrel.xml
+++ b/compact/tracking/mpgd_outerbarrel.xml
@@ -17,14 +17,15 @@
     <constant name="MPGDOuterBarrelFrame_thickness"        value="7*mm"/>
 
     <comment> Module constants </comment>
+    <constant name="MPGDOuterBarrelModule_roverlap"                value="1.2*cm"/>
+    <constant name="MPGDOuterBarrelModule_zoverlap"                value="3*MPGDOuterBarrelFrame_width"/>
     <constant name="MPGDOuterBarrelModule_count"                   value="12" />
     <constant name="MPGDOuterBarrelModule_allowed_space"           value="2.5*cm"/>
-    <constant name="MPGDOuterBarrelModule_rmax"                    value="MPGDOuterBarrelModule_rmin + MPGDOuterBarrelModule_allowed_space/2.0" />
+    <constant name="MPGDOuterBarrelModule_rmax"                    value="MPGDOuterBarrelModule_rmin + MPGDOuterBarrelModule_allowed_space" />
     <constant name="MPGDOuterBarrelModule_width"                   value="34.0*cm"/>
-    <constant name="MPGDOuterBarrelModule_length"                  value="0.5*(MPGDOuterBarrelModule_zmin1 + MPGDOuterBarrelModule_zmin2 + 2*MPGDOuterBarrelModule_allowed_space)"/>
+    <constant name="MPGDOuerBarrel_length"                         value="MPGDOuterBarrelModule_zmin1 + MPGDOuterBarrelModule_zmin2"/>
+    <constant name="MPGDOuterBarrelModule_length"                  value="0.5*(MPGDOuterBarrelModule_zmin1 + MPGDOuterBarrelModule_zmin2 + MPGDOuterBarrelModule_zoverlap)"/>
     <constant name="MPGDOuterBarrelModule_offset"                  value="(MPGDOuterBarrelModule_zmin2 - MPGDOuterBarrelModule_zmin1)/2.0"/>
-    <constant name="MPGDOuterBarrelModule_roverlap"                value="1.2*cm"/>
-    <constant name="MPGDOuterBarrelModule_zoverlap"                value="2*MPGDOuterBarrelFrame_width"/>
 
 
     <comment> Layer parameters </comment>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Updates the outer MPGD barrel layer (the one integrated with the DIRC) to match the detector parameter table

### What kind of change does this PR introduce?
- [x ] Bug fix (issue #568 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
This will probably cause an overlap with the DIRC volume, since the updated DIRC volume is not accounted for in this branch. 
### Does this PR change default behavior?
Will likely trigger overlap errors between the DIRC and MPGD layer
