### PR TITLE
Update vacuum default density to 1e-15 g/cms to reflect RHIC vacuum - currently set to 100k mbar worse vacuum

### DIFF
--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -13,9 +13,9 @@
     <fraction n="0.234" ref="O"/>
     <fraction n="0.012" ref="Ar"/>
   </material>
-  <!-- We model vacuum just as very thin air -->
+  <!-- default RHIC vacuum is 1e-9 mbar == 1e-15 g/cm3 -->
   <material name="Vacuum">
-    <D type="density" unit="g/cm3" value="0.0000000001"/>
+    <D type="density" unit="g/cm3" value="0.000000000000001"/>
     <fraction n="0.754" ref="N"/>
     <fraction n="0.234" ref="O"/>
     <fraction n="0.012" ref="Ar"/>

--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -15,7 +15,7 @@
   </material>
   <!-- default RHIC vacuum is 1e-9 mbar == 1e-15 g/cm3 -->
   <material name="Vacuum">
-    <D type="density" unit="g/cm3" value="0.000000000000001"/>
+    <D type="density" unit="g/cm3" value="1e-15"/>
     <fraction n="0.754" ref="N"/>
     <fraction n="0.234" ref="O"/>
     <fraction n="0.012" ref="Ar"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Corrects default vacuum value to 1e-9 mbar

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No.

### Does this PR change default behavior?

Yes, less secondaries should be produced for FF protons and neutrons in the beam pipe vacuum.