### PR TITLE
forward service gap length in compliance with latest parameter table

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -491,7 +491,7 @@ Examples:
 Service gaps in FW direction (before endcapP ECAL) and BW direction (before endcapN HCAL)
     </documentation>
     <constant name="ForwardInnerEndcapRegionExtraSpace_length" value="4.6*cm"/>
-    <constant name="ForwardServiceGap_length"     value="13.6*cm"/>
+    <constant name="ForwardServiceGap_length"     value="9.6*cm"/>
     <constant name="ForwardServiceGap_zmin"       value="ForwardPIDRegion_zmin + ForwardInnerEndcapRegion_length + ForwardInnerEndcapRegionExtraSpace_length"/>
     <constant name="ForwardServiceGap_zmax"       value="ForwardServiceGap_zmin + ForwardServiceGap_length"/>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The latest table https://eic.jlab.org/Geometry/Detector/Detector-20231031150001.html has a shorter service gap. This should have a knock-on effect on all forward detectors that ultimately depend on `ForwardServiceGap_zmin`

### What kind of change does this PR introduce?
- [x] Bug fix (issue #572 , #571 , possibly more)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes
