### PR TITLE
Adjust Barrel ECal geometry according to the geometry database

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -544,7 +544,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="EcalEndcapN_rmin"               value="9.*cm"/>    <!-- Currently fix value hardcoded -->
     <constant name="EcalEndcapN_rmax"               value="63.*cm"/>   <!-- Currently fix value hardcoded -->
 
-    <constant name="EcalBarrelRegion_thickness"     value="35.*cm"/>
+    <constant name="EcalBarrelRegion_thickness"     value="38.*cm"/>
     <constant name="EcalBarrel_rmin"                value="max(81.*cm, CentralTrackingRegion_rmax + BarrelPIDRegion_thickness + BarrelExtraSpace_thickness)"/> <!-- FIXME hardcoded max -->
     <constant name="EcalBarrel_inner_margin"        value="2*cm"/>
     <constant name="EcalBarrel_rmax"                value="EcalBarrel_rmin + EcalBarrelRegion_thickness"/>

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -164,6 +164,7 @@
             dx="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
             dy="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
           />
+          <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
         </stave>
       </layer>
 
@@ -181,7 +182,7 @@
         <stave repeat="6"
                width="EcalBarrel_Stave_width"
                length="EcalBarrel_Stave_length"
-               thickness="EcalBarrel_AstroPix_thickness"
+               thickness="EcalBarrel_Stave_thickness"
                angle="-EcalBarrel_StaveTilt_angle"
                module="AstroPix_Module"
                vis="EcalBarrelStaveVis">
@@ -189,6 +190,7 @@
             dx="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
             dy="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
           />
+          <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
         </stave>
       </layer>
 
@@ -206,7 +208,7 @@
         <stave repeat="7"
                width="EcalBarrel_Stave_width"
                length="EcalBarrel_Stave_length"
-               thickness="EcalBarrel_AstroPix_thickness"
+               thickness="EcalBarrel_Stave_thickness"
                angle="EcalBarrel_StaveTilt_angle"
                module="AstroPix_Module"
                vis="EcalBarrelStaveVis">
@@ -214,6 +216,7 @@
             dx="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
             dy="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
           />
+          <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
         </stave>
       </layer>
     </detector>

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -1,6 +1,7 @@
 <!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
 <!-- Copyright (C) 2022 Whitney Armstrong, Chao Peng, Maria Zurek, Jihee Kim -->
-<!-- Active AstroPix layers: 1-3-5-6 -->
+<!-- Active AstroPix layers: 1-3-4-6 -->
+
 
 <lccdd>
 
@@ -19,11 +20,11 @@
     <!-- Number of imaging layer slots -->
     <constant name="EcalBarrelImagingLayers_nMax"   value="6"/>
     <constant name="EcalBarrel_Calorimeter_zmin"
-      value="min(257*cm, EcalBarrelBackward_zmax)"/>
+      value="min(258.75*cm, EcalBarrelBackward_zmax)"/>
     <constant name="EcalBarrel_Calorimeter_zmax"
-      value="min(177.5*cm, EcalBarrelForward_zmax)"/>
-    <constant name="EcalBarrel_Readout_zmin"        value="272*cm"/>
-    <constant name="EcalBarrel_Readout_zmax"        value="192.5*cm"/>
+      value="min(181.25*cm, EcalBarrelForward_zmax)"/>
+    <constant name="EcalBarrel_Readout_zmin"        value="273.75*cm"/>
+    <constant name="EcalBarrel_Readout_zmax"        value="196.25*cm"/>
     <constant name="EcalBarrel_Calorimeter_length"
       value="EcalBarrel_Calorimeter_zmax + EcalBarrel_Calorimeter_zmin"/>
     <constant name="EcalBarrel_Calorimeter_offset"
@@ -54,10 +55,6 @@
     <constant name="EcalBarrel_StaveTilt_angle"      value="10*degree"/>
     <constant name="EcalBarrel_Stave_ModuleRepeat"   value="floor(EcalBarrel_Calorimeter_length / (EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin))"/>
 
-    <constant name="EcalBarrel_ImagingFirstLayerThickness"
-      value="EcalBarrel_AstroPix_thickness
-      + EcalBarrel_CarbonThickness"/>
-
     <constant name="EcalBarrel_LayerSpacing"         value="10.0*mm"/>
     <constant name="EcalBarrel_FiberRadius"          value="0.5*mm"/>
     <constant name="EcalBarrel_FiberXSpacing"        value="1.34*mm"/>
@@ -84,18 +81,15 @@
 
     <constant name="EcalBarrelImagingLayers_num"
         value="min(EcalBarrelImagingLayers_nMax,
-               floor((EcalBarrel_AvailThickness-EcalBarrel_ImagingFirstLayerThickness)/
-                     (EcalBarrel_ImagingLayerThickness + EcalBarrel_ScFiLayerThickness +
-                      EcalBarrel_SpaceBetween)))"/>
+               floor(EcalBarrel_AvailThickness/(EcalBarrel_ImagingLayerThickness + EcalBarrel_ScFiLayerThickness + EcalBarrel_SpaceBetween)))"/>
     <comment>
       Adjusting size of the ScFi back chunk to match number of imaging layers
       and ~17.1 radiation lengths in total
     </comment>
-    <constant name="EcalBarrel_FiberBulkLayers_num" value = "EcalBarrel_TotalFiberLayers_num-EcalBarrelImagingLayers_num+1"/>
+    <constant name="EcalBarrel_FiberBulkLayers_num" value = "EcalBarrel_TotalFiberLayers_num-EcalBarrelImagingLayers_num"/>
 
     <constant name="EcalBarrel_ImagingPartThickness"
-        value="(EcalBarrelImagingLayers_num-1)*(EcalBarrel_ImagingLayerThickness + EcalBarrel_ScFiLayerThickness + EcalBarrel_SpaceBetween)
-              + EcalBarrel_ImagingFirstLayerThickness + EcalBarrel_SpaceBetween"/>
+        value="(EcalBarrelImagingLayers_num)*(EcalBarrel_ImagingLayerThickness + EcalBarrel_ScFiLayerThickness + EcalBarrel_SpaceBetween)"/>
     <constant name="EcalBarrel_ScFiPartThickness_max"
         value="max(0, EcalBarrel_AvailThickness-EcalBarrel_ImagingPartThickness)"/>
     <constant name="EcalBarrel_ScFiPartThickness"
@@ -134,29 +128,6 @@
         rmin="EcalBarrel_rmin"
         z="EcalBarrel_Calorimeter_length"/>
       <sectors vis="EcalBarrelSectorVis"/>
-
-      <module name="AstroPix_Module_FirstLayer"
-              vis="EcalBarrelModuleVis">
-        <module_component name="AstroPix_Chip"
-                          material="Silicon"
-                          width="EcalBarrel_AstroPix_width"
-                          length="EcalBarrel_AstroPix_length"
-                          thickness="EcalBarrel_AstroPix_thickness"
-                          vis="EcalBarrelModuleVis">
-          <slice material="Silicon" thickness="EcalBarrel_SiliconThickness"     vis="EcalBarrelSliceVis" sensitive="yes" limits="cal_limits"/>
-          <slice material="Silicon" thickness="EcalBarrel_ElectronicsThickness" vis="EcalBarrelSliceVis"/>
-          <slice material="Copper" thickness="EcalBarrel_CopperThickness"       vis="EcalBarrelSliceVis"/>
-          <slice material="Kapton" thickness="EcalBarrel_KaptonThickness"       vis="EcalBarrelSliceVis"/>
-          <slice material="Epoxy" thickness="EcalBarrel_EpoxyThickness"         vis="EcalBarrelSliceVis"/>
-        </module_component>
-        <module_component name="AstroPix_Support"
-                          material="CarbonFiber"
-                          width="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
-                          length="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
-                          thickness="EcalBarrel_CarbonThickness"
-                          vis="EcalBarrelSliceVis">
-        </module_component>
-      </module>
 
       <module name="AstroPix_Module"
               vis="EcalBarrelModuleVis">

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -86,10 +86,10 @@
       Adjusting size of the ScFi back chunk to match number of imaging layers
       and ~17.1 radiation lengths in total
     </comment>
-    <constant name="EcalBarrel_FiberBulkLayers_num" value = "EcalBarrel_TotalFiberLayers_num-EcalBarrelImagingLayers_num"/>
+    <constant name="EcalBarrel_FiberBulkLayers_num" value = "EcalBarrel_TotalFiberLayers_num-EcalBarrelImagingLayers_num+1"/>
 
     <constant name="EcalBarrel_ImagingPartThickness"
-        value="(EcalBarrelImagingLayers_num)*(EcalBarrel_ImagingLayerThickness + EcalBarrel_ScFiLayerThickness + EcalBarrel_SpaceBetween)"/>
+        value="EcalBarrelImagingLayers_num*(EcalBarrel_ImagingLayerThickness + EcalBarrel_ScFiLayerThickness + EcalBarrel_SpaceBetween)-EcalBarrel_ScFiLayerThickness"/>
     <constant name="EcalBarrel_ScFiPartThickness_max"
         value="max(0, EcalBarrel_AvailThickness-EcalBarrel_ImagingPartThickness)"/>
     <constant name="EcalBarrel_ScFiPartThickness"

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -164,7 +164,6 @@
             dx="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
             dy="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
           />
-          <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
         </stave>
       </layer>
 
@@ -190,7 +189,6 @@
             dx="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
             dy="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
           />
-          <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
         </stave>
       </layer>
 
@@ -216,7 +214,6 @@
             dx="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
             dy="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
           />
-          <slice material="CarbonFiber" thickness="EcalBarrel_CarbonThickness" vis="EcalBarrelSliceVis"/>
         </stave>
       </layer>
     </detector>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
 This PR related to the issue https://github.com/eic/epic/issues/552, and implements small changes in the Barrel ECal geometry to make it more realistic. The following changes has been implemented:
 
- SciFi/Pb z_min and z_max (and accordingly the full length) has been implemented according to https://eic.jlab.org/Geometry/Detector/Detector-20231031150001.html. 
- The total depth (envelope) of the calorimeter has been increased to 38 cm (from fixed 35 cm). 38 cm envelope is the correct one and fits both the SciFi and the 3 cm back Al plate.
- ~~In every AstroPix stave a carbon fiber slice has been added to mimic a bit better the material of the staves~~


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #552)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?

Calorimeter (SciFi/Pb matrix) length, offset, and z_min z_max are in agreement with the geometry database:

Output of `npdet_info dump $DETECTOR_PATH/epic_craterlake.xml | grep EcalBarrel`

```
EcalBarrel_AvailThickness      =       35.000 = EcalBarrelRegion_thickness - EcalBarrel_Support_thickness
EcalBarrel_Calorimeter_length  =      440.000 = EcalBarrel_Calorimeter_zmax + EcalBarrel_Calorimeter_zmin
EcalBarrel_Calorimeter_offset  =      -38.750 = (EcalBarrel_Calorimeter_zmax - EcalBarrel_Calorimeter_zmin)/2.0
EcalBarrel_Calorimeter_zmax    =      181.250 = min(181.25*cm, EcalBarrelForward_zmax)
EcalBarrel_Calorimeter_zmin    =      258.750 = min(258.75*cm, EcalBarrelBackward_zmax)
```

Now calorimeter has proper depth (together with back plate)
![SciFi part of the Calo. 12th layer has now proper width.](https://github.com/eic/epic/assets/33816222/70384133-39c5-4fb6-a19c-c5c5fbc1093b)
![Zoom on AstroPix part of the Calo](https://github.com/eic/epic/assets/33816222/f11b6e6d-8a06-430b-93f0-b3ff8c5273e4)

Not included in this PR because of the problem with overlaps

Below you can see the Carbon Fiber slice added to each stave. 
![AstroPix part of the sector](https://github.com/eic/epic/assets/33816222/d3edbe40-14eb-46de-9908-454f46d5d30d)
![Zoom on one layer with modules](https://github.com/eic/epic/assets/33816222/a127bc45-79ca-479f-887f-a325e1a263b9)

