### PR TITLE
Update ZDC_Crystal_LYSO.xml:  Use readout name EcalFarForwardZDCHits

### DIFF
--- a/compact/far_forward/ZDC_Crystal_LYSO.xml
+++ b/compact/far_forward/ZDC_Crystal_LYSO.xml
@@ -41,7 +41,7 @@
         name="ZDC_Crystal"
         type="ZDC_Crystal"
         vis="ZDC_Crystal_Vis"
-        readout="ZDCEcalHits">
+        readout="EcalFarForwardZDCHits">
       <position x="ZDC_Crystal_x_pos"         y="ZDC_Crystal_y_pos"         z="ZDC_Crystal_z_pos"/>
       <rotation x="ZDC_Crystal_rotateX_angle" y="ZDC_Crystal_rotateY_angle" z="ZDC_Crystal_rotateZ_angle"/>
       <dimensions x="ZDC_Crystal_nx * (ZDC_Crystal_cell_width + ZDC_Crystal_frame_thickness) + ZDC_Crystal_frame_thickness"

--- a/compact/far_forward/ZDC_Crystal_LYSO.xml
+++ b/compact/far_forward/ZDC_Crystal_LYSO.xml
@@ -61,7 +61,7 @@
   </detectors>
 
   <readouts>
-    <readout name="ZDCEcalHits">
+    <readout name="EcalFarForwardZDCHits">
       <segmentation type="NoSegmentation"/>
       <id>system:8,module:2,crystal:12</id>
     </readout>


### PR DESCRIPTION
Changed name of hits to EcalFarForwardZDCHits, as requested by @veprbl when reviewing pull request 1221 in EICrecon.

### Briefly, what does this PR introduce?
Changes the name of the output bank for the LYSO section of the ZDC in order to match the convention used for the SiPM-on-tile section

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other:  Changing the name of output banks to match the 
Change of the name of the readout output of the ZDC LYSO

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Users will need to change their code to use the new name of the ZDC Crystal LYSO detector, which is EcalFarForwardZDCHits
### Does this PR change default behavior?
yes