### PR TITLE
Outer mpgd barrel geoupdate

### DIFF
--- a/compact/tracking/definitions_craterlake.xml
+++ b/compact/tracking/definitions_craterlake.xml
@@ -27,7 +27,7 @@
     <constant name="TrackerEndcapDisk_rmax"         value="43*cm"/>
 
     <comment> Main parameters for the outer MPGD barrel layer </comment>
-    <constant name="MPGDOuterBarrelModule_rmin"      value="72.5"/>
+    <constant name="MPGDOuterBarrelModule_rmin"      value="72.5*cm"/>
     <constant name="MPGDOuterBarrelModule_zmin1"     value="164.5*cm"/>
     <constant name="MPGDOuterBarrelModule_zmin2"     value="174.5*cm"/>
 

--- a/compact/tracking/mpgd_outerbarrel.xml
+++ b/compact/tracking/mpgd_outerbarrel.xml
@@ -149,7 +149,7 @@
 </module>
 <comment> Layout for MPGD DIRC layers </comment>
   <layer module="MPGDOuterBarrelModule" id="0" vis="TrackerSupportVis">
-	  <envelope_tolerance r_min="-50*mm" r_max="0*mm" z_min="0*mm" z_max="0*mm"/>
+          <envelope_tolerance r_min="-50*mm" r_max="0*mm" z_min="0*mm" z_max="0*mm"/>
     <layer_material surface="outer" binning="binPhi,binZ" bins0="MPGDOuterBarrelModule_count" bins1="100" />
     <rphi_layout
           phi_tilt="0"

--- a/compact/tracking/mpgd_outerbarrel.xml
+++ b/compact/tracking/mpgd_outerbarrel.xml
@@ -149,12 +149,12 @@
 <comment> Layout for MPGD DIRC layers </comment>
   <layer module="MPGDOuterBarrelModule" id="0" vis="TrackerSupportVis">
     <envelope_tolerance r_min="-50*mm" r_max="0*mm" z_min="0*mm" z_max="0*mm"/>
-    <layer_material surface="inner" binning="binPhi,binZ" bins0="MPGDOuterBarrelModule_count" bins1="100" />
+    <layer_material surface="outer" binning="binPhi,binZ" bins0="MPGDOuterBarrelModule_count" bins1="100" />
     <rphi_layout
           phi_tilt="0"
           nphi="MPGDOuterBarrelModule_count"
           phi0="0"
-          rc="MPGDOuterBarrelModule_rmin"
+          rc="MPGDOuterBarrelModule_rmin + 0.5*cm"
           dr="0" />
     <z_layout
           dr = "MPGDOuterBarrelModule_roverlap"

--- a/compact/tracking/mpgd_outerbarrel.xml
+++ b/compact/tracking/mpgd_outerbarrel.xml
@@ -13,12 +13,12 @@
 
 <define>
     <comment> Frames </comment>
-    <constant name="MPGDOuterBarrelFrame_width"            value="20*mm"/>
+    <constant name="MPGDOuterBarrelFrame_width"            value="15*mm"/>
     <constant name="MPGDOuterBarrelFrame_thickness"        value="7*mm"/>
 
     <comment> Module constants </comment>
-    <constant name="MPGDOuterBarrelModule_roverlap"                value="1.2*cm"/>
-    <constant name="MPGDOuterBarrelModule_zoverlap"                value="3*MPGDOuterBarrelFrame_width"/>
+    <constant name="MPGDOuterBarrelModule_roverlap"                value="0*cm"/>
+    <constant name="MPGDOuterBarrelModule_zoverlap"                value="0*MPGDOuterBarrelFrame_width"/>
     <constant name="MPGDOuterBarrelModule_count"                   value="12" />
     <constant name="MPGDOuterBarrelModule_allowed_space"           value="2.5*cm"/>
     <constant name="MPGDOuterBarrelModule_rmax"                    value="MPGDOuterBarrelModule_rmin + MPGDOuterBarrelModule_allowed_space" />

--- a/compact/tracking/mpgd_outerbarrel.xml
+++ b/compact/tracking/mpgd_outerbarrel.xml
@@ -22,6 +22,7 @@
     <constant name="MPGDOuterBarrelModule_count"                   value="12" />
     <constant name="MPGDOuterBarrelModule_allowed_space"           value="2.5*cm"/>
     <constant name="MPGDOuterBarrelModule_rmax"                    value="MPGDOuterBarrelModule_rmin + MPGDOuterBarrelModule_allowed_space" />
+    <constant name="MPGDOuterBarrelModule_roffset"                 value="0.5*cm" />
     <constant name="MPGDOuterBarrelModule_width"                   value="34.0*cm"/>
     <constant name="MPGDOuerBarrel_length"                         value="MPGDOuterBarrelModule_zmin1 + MPGDOuterBarrelModule_zmin2"/>
     <constant name="MPGDOuterBarrelModule_length"                  value="0.5*(MPGDOuterBarrelModule_zmin1 + MPGDOuterBarrelModule_zmin2 + MPGDOuterBarrelModule_zoverlap)"/>
@@ -148,13 +149,13 @@
 </module>
 <comment> Layout for MPGD DIRC layers </comment>
   <layer module="MPGDOuterBarrelModule" id="0" vis="TrackerSupportVis">
-    <envelope_tolerance r_min="-50*mm" r_max="0*mm" z_min="0*mm" z_max="0*mm"/>
+	  <envelope_tolerance r_min="-50*mm" r_max="0*mm" z_min="0*mm" z_max="0*mm"/>
     <layer_material surface="outer" binning="binPhi,binZ" bins0="MPGDOuterBarrelModule_count" bins1="100" />
     <rphi_layout
           phi_tilt="0"
           nphi="MPGDOuterBarrelModule_count"
           phi0="0"
-          rc="MPGDOuterBarrelModule_rmin + 0.5*cm"
+          rc="MPGDOuterBarrelModule_rmin + MPGDOuterBarrelModule_roffset"
           dr="0" />
     <z_layout
           dr = "MPGDOuterBarrelModule_roverlap"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Small updates to detector dimensions. Moved ACTS material binning to outer surface.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x ] Other: Update dimentsions

### Please check if this PR fulfills the following:
- [x ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

![OuterMPGD_GeoUpdate](https://github.com/eic/epic/assets/2228075/bdbacf60-14d1-4fd4-8bbe-9e39aac669e9)


### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No