### PR TITLE
linux-eic-shell.yml: use all available cores for cmake build

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -90,7 +90,7 @@ jobs:
         platform-release: "jug_xl:nightly"
         run: |
           CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-          cmake --build build -- -k -j 2 install
+          cmake --build build -- -k -j $(getconf _NPROCESSORS_ONLN) install
     - uses: actions/upload-artifact@v4
       with:
         name: build-${{ matrix.CC }}-full-eic-shell


### PR DESCRIPTION
[Should benefit us since we have 4 cores available](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)