### PR TITLE
[DONTMERGE] definitions.xml: set EcalEndcapP_rmax to 172 cm

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -516,7 +516,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="EcalEndcapP_zmax"               value="EcalEndcapP_zmin + EcalEndcapP_length"/>
     <constant name="EcalEndcapP_rmin"               value="200.0*mm" />
     <comment> extra 50cm rmax that "protrudes" into the HCAL</comment>
-    <constant name="EcalEndcapP_rmax"               value="195.0*cm"/>
+    <constant name="EcalEndcapP_rmax"               value="172.0*cm"/>
     <constant name="EcalEndcapP_numLayers"          value="1"/>
 
     <constant name="EcalEndcapPInsert_zmin"           value="EcalEndcapP_zmin"/>


### PR DESCRIPTION
Allegedly, the calorimeter in simulation is larger than in engineering. This number was picked during a meeting from Alexander Bazilevski (of the top of his head).

(172 doesn't divide by 2.5, also it is not supported by the current menagerie https://eic.jlab.org/Geometry/Detector/Detector-20240117135224.html where it's still 195)