### PR TITLE
configurations/full.yml: switch to craterlake.xml

### DIFF
--- a/configurations/full.yml
+++ b/configurations/full.yml
@@ -1,13 +1,17 @@
+ebeam: 5
+pbeam: 41
 features:
   beampipe:
   tracking:
-    definitions:
+    definitions_craterlake:
     vertex_barrel:
     silicon_barrel:
     mpgd_barrel:
-    mpgd_dirc:
+    support_service_craterlake:
+    mpgd_outerbarrel:
+    mpgd_forward_endcap:
+    mpgd_backward_endcap:
     silicon_disks:
-    support_service_assembly:
     tof_barrel:
     tof_endcap:
   pid:


### PR DESCRIPTION
Fixes the default to use craterlake configuration.

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
The current full.xml based on arches.xml serves no practical purpose in ePIC.

### Does this PR change default behavior?
Yes.