### PR TITLE
one of the FF dipoles had the wrong sign defined - fixed

### DIFF
--- a/compact/fields/beamline_10x100.xml
+++ b/compact/fields/beamline_10x100.xml
@@ -35,7 +35,7 @@
     <constant name="B0PF_GradientMax"  value="-8.12238283*tesla/m"/>
     <constant name="B0APF_GradientMax" value="0.0*tesla/m"/>
     <constant name="Q1APF_GradientMax" value="-44.08979*tesla/m"/>
-    <constant name="Q1BPF_GradientMax" value="0.0*tesla/m"/> <!-- need to check with Scott on this one -->
+    <constant name="Q1BPF_GradientMax" value="0.0*tesla/m"/> 
     <constant name="Q2PF_GradientMax"  value="12.7764668*tesla/m"/>
     <constant name="B1PF_GradientMax"  value="0.0*tesla/m"/>
     <constant name="B1APF_GradientMax" value="0.0*tesla/m"/>
@@ -44,7 +44,7 @@
     <constant name="Q1EF_GradientMax"  value="2.127596364*tesla/m"/>
 
     <constant name="B0PF_Bmax"  value="1.1840539*tesla"/>
-    <constant name="B0APF_Bmax" value="-1.1588921*tesla"/> <!-- need to check with Scott on this one -->
+    <constant name="B0APF_Bmax" value="-1.1588921*tesla"/>
     <constant name="Q1APF_Bmax" value="0.0*tesla"/>
     <constant name="Q1BPF_Bmax" value="0.0*tesla"/>
     <constant name="Q2PF_Bmax"  value="0.0*tesla"/>

--- a/compact/fields/beamline_10x100.xml
+++ b/compact/fields/beamline_10x100.xml
@@ -44,7 +44,7 @@
     <constant name="Q1EF_GradientMax"  value="2.127596364*tesla/m"/>
 
     <constant name="B0PF_Bmax"  value="1.1840539*tesla"/>
-    <constant name="B0APF_Bmax" value="1.1588921*tesla"/> <!-- need to check with Scott on this one -->
+    <constant name="B0APF_Bmax" value="-1.1588921*tesla"/> <!-- need to check with Scott on this one -->
     <constant name="Q1APF_Bmax" value="0.0*tesla"/>
     <constant name="Q1BPF_Bmax" value="0.0*tesla"/>
     <constant name="Q2PF_Bmax"  value="0.0*tesla"/>

--- a/compact/fields/beamline_10x100.xml
+++ b/compact/fields/beamline_10x100.xml
@@ -35,7 +35,7 @@
     <constant name="B0PF_GradientMax"  value="-8.12238283*tesla/m"/>
     <constant name="B0APF_GradientMax" value="0.0*tesla/m"/>
     <constant name="Q1APF_GradientMax" value="-44.08979*tesla/m"/>
-    <constant name="Q1BPF_GradientMax" value="0.0*tesla/m"/> 
+    <constant name="Q1BPF_GradientMax" value="0.0*tesla/m"/>
     <constant name="Q2PF_GradientMax"  value="12.7764668*tesla/m"/>
     <constant name="B1PF_GradientMax"  value="0.0*tesla/m"/>
     <constant name="B1APF_GradientMax" value="0.0*tesla/m"/>

--- a/compact/fields/beamline_5x100.xml
+++ b/compact/fields/beamline_5x100.xml
@@ -35,7 +35,7 @@
     <constant name="B0PF_GradientMax"  value="-8.12238283*tesla/m"/>
     <constant name="B0APF_GradientMax" value="0.0*tesla/m"/>
     <constant name="Q1APF_GradientMax" value="-44.08979*tesla/m"/>
-    <constant name="Q1BPF_GradientMax" value="0.0*tesla/m"/> <!-- need to check with Scott on this one -->
+    <constant name="Q1BPF_GradientMax" value="0.0*tesla/m"/> 
     <constant name="Q2PF_GradientMax"  value="12.7764668*tesla/m"/>
     <constant name="B1PF_GradientMax"  value="0.0*tesla/m"/>
     <constant name="B1APF_GradientMax" value="0.0*tesla/m"/>
@@ -44,7 +44,7 @@
     <constant name="Q1EF_GradientMax"  value="2.127596364*tesla/m"/>
 
     <constant name="B0PF_Bmax"  value="1.1840539*tesla"/>
-    <constant name="B0APF_Bmax" value="-1.1588921*tesla"/> <!-- need to check with Scott on this one -->
+    <constant name="B0APF_Bmax" value="-1.1588921*tesla"/>
     <constant name="Q1APF_Bmax" value="0.0*tesla"/>
     <constant name="Q1BPF_Bmax" value="0.0*tesla"/>
     <constant name="Q2PF_Bmax"  value="0.0*tesla"/>

--- a/compact/fields/beamline_5x100.xml
+++ b/compact/fields/beamline_5x100.xml
@@ -44,7 +44,7 @@
     <constant name="Q1EF_GradientMax"  value="2.127596364*tesla/m"/>
 
     <constant name="B0PF_Bmax"  value="1.1840539*tesla"/>
-    <constant name="B0APF_Bmax" value="1.1588921*tesla"/> <!-- need to check with Scott on this one -->
+    <constant name="B0APF_Bmax" value="-1.1588921*tesla"/> <!-- need to check with Scott on this one -->
     <constant name="Q1APF_Bmax" value="0.0*tesla"/>
     <constant name="Q1BPF_Bmax" value="0.0*tesla"/>
     <constant name="Q2PF_Bmax"  value="0.0*tesla"/>

--- a/compact/fields/beamline_5x100.xml
+++ b/compact/fields/beamline_5x100.xml
@@ -35,7 +35,7 @@
     <constant name="B0PF_GradientMax"  value="-8.12238283*tesla/m"/>
     <constant name="B0APF_GradientMax" value="0.0*tesla/m"/>
     <constant name="Q1APF_GradientMax" value="-44.08979*tesla/m"/>
-    <constant name="Q1BPF_GradientMax" value="0.0*tesla/m"/> 
+    <constant name="Q1BPF_GradientMax" value="0.0*tesla/m"/>
     <constant name="Q2PF_GradientMax"  value="12.7764668*tesla/m"/>
     <constant name="B1PF_GradientMax"  value="0.0*tesla/m"/>
     <constant name="B1APF_GradientMax" value="0.0*tesla/m"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Fixes the sign on a FF dipole which was incorrectly set.

### What kind of change does this PR introduce?
- [ x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No, it corrects the transport for 100 GeV FF protons.

### Does this PR change default behavior?

Yes.
