### PR TITLE
Adjust the length of BIC according to the newest baseline

### DIFF
--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -34,7 +34,7 @@
     <constant name="EcalBarrel_Calorimeter_length"
       value="EcalBarrel_Calorimeter_zmax + EcalBarrel_Calorimeter_zmin"/>
     <constant name="EcalBarrel_Calorimeter_offset"
-      value="(EcalBarrel_Calorimeter_zmax - EcalBarrel_Calorimeter_zmin + 6.5)/2.0"/>
+      value="(EcalBarrel_Calorimeter_zmax - EcalBarrel_Calorimeter_zmin)/2.0"/>
 
     <constant name="EcalBarrel_FrontSupportThickness" value="0.5*cm"/>
     <constant name="EcalBarrel_BackSupportThickness" value="3*cm"/>

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -20,11 +20,11 @@
     <!-- Number of imaging layer slots -->
     <constant name="EcalBarrelImagingLayers_nMax"   value="6"/>
     <constant name="EcalBarrel_Calorimeter_zmin"
-      value="min(258.75*cm, EcalBarrelBackward_zmax)"/>
+      value="min(260.25*cm, EcalBarrelBackward_zmax)"/>
     <constant name="EcalBarrel_Calorimeter_zmax"
-      value="min(181.25*cm, EcalBarrelForward_zmax)"/>
-    <constant name="EcalBarrel_Readout_zmin"        value="273.75*cm"/>
-    <constant name="EcalBarrel_Readout_zmax"        value="196.25*cm"/>
+      value="min(176.25*cm, EcalBarrelForward_zmax)"/>
+    <constant name="EcalBarrel_Readout_zmin"        value="275.25*cm"/>
+    <constant name="EcalBarrel_Readout_zmax"        value="191.25*cm"/>
     <constant name="EcalBarrel_Calorimeter_length"
       value="EcalBarrel_Calorimeter_zmax + EcalBarrel_Calorimeter_zmin"/>
     <constant name="EcalBarrel_Calorimeter_offset"

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -19,6 +19,12 @@
     </comment>
     <!-- Number of imaging layer slots -->
     <constant name="EcalBarrelImagingLayers_nMax"   value="6"/>
+    <comment>
+      Active part of the calorimeter is 
+      215 cm long in e-going
+      221.5 cm long in p-going
+      -38.75 cm offset
+    </comment> 
     <constant name="EcalBarrel_Calorimeter_zmin"
       value="min(260.25*cm, EcalBarrelBackward_zmax)"/>
     <constant name="EcalBarrel_Calorimeter_zmax"
@@ -28,7 +34,7 @@
     <constant name="EcalBarrel_Calorimeter_length"
       value="EcalBarrel_Calorimeter_zmax + EcalBarrel_Calorimeter_zmin"/>
     <constant name="EcalBarrel_Calorimeter_offset"
-      value="(EcalBarrel_Calorimeter_zmax - EcalBarrel_Calorimeter_zmin)/2.0"/>
+      value="(EcalBarrel_Calorimeter_zmax - EcalBarrel_Calorimeter_zmin + 6.5)/2.0"/>
 
     <constant name="EcalBarrel_FrontSupportThickness" value="0.5*cm"/>
     <constant name="EcalBarrel_BackSupportThickness" value="3*cm"/>

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -20,11 +20,11 @@
     <!-- Number of imaging layer slots -->
     <constant name="EcalBarrelImagingLayers_nMax"   value="6"/>
     <comment>
-      Active part of the calorimeter is 
+      Active part of the calorimeter is
       215 cm long in e-going
       221.5 cm long in p-going
       -38.75 cm offset
-    </comment> 
+    </comment>
     <constant name="EcalBarrel_Calorimeter_zmin"
       value="min(260.25*cm, EcalBarrelBackward_zmax)"/>
     <constant name="EcalBarrel_Calorimeter_zmax"

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -23,7 +23,7 @@
       Active part of the calorimeter is
       215 cm long in e-going
       221.5 cm long in p-going
-      -38.75 cm offset
+      -42 cm offset
     </comment>
     <constant name="EcalBarrel_Calorimeter_zmin"
       value="min(260.25*cm, EcalBarrelBackward_zmax)"/>
@@ -34,7 +34,7 @@
     <constant name="EcalBarrel_Calorimeter_length"
       value="EcalBarrel_Calorimeter_zmax + EcalBarrel_Calorimeter_zmin"/>
     <constant name="EcalBarrel_Calorimeter_offset"
-      value="(EcalBarrel_Calorimeter_zmax - EcalBarrel_Calorimeter_zmin + 6.5)/2.0"/>
+      value="(EcalBarrel_Calorimeter_zmax - EcalBarrel_Calorimeter_zmin)/2.0"/>
 
     <constant name="EcalBarrel_FrontSupportThickness" value="0.5*cm"/>
     <constant name="EcalBarrel_BackSupportThickness" value="3*cm"/>

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -34,7 +34,7 @@
     <constant name="EcalBarrel_Calorimeter_length"
       value="EcalBarrel_Calorimeter_zmax + EcalBarrel_Calorimeter_zmin"/>
     <constant name="EcalBarrel_Calorimeter_offset"
-      value="(EcalBarrel_Calorimeter_zmax - EcalBarrel_Calorimeter_zmin)/2.0"/>
+      value="(EcalBarrel_Calorimeter_zmax - EcalBarrel_Calorimeter_zmin + 6.5)/2.0"/>
 
     <constant name="EcalBarrel_FrontSupportThickness" value="0.5*cm"/>
     <constant name="EcalBarrel_BackSupportThickness" value="3*cm"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce? 
Updated dimensions of the Barrel ECal:
 
Length w/o EoSB (end of sector box): 436.5 cm
Total length w/ EoSB: 466.5 cm
 
Length in h-going direction: 215 cm (Sector) + 15 cm (EoSB)
Length in e-going direction: 221.5 cm + 15 cm (EoSB)
 
Center offset: -38.75 cm
 
h-going: +176.25 cm
h-going + box: +191.25 cm
 
e-going: -260.25 cm
e-going + box: -275.25 cm


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @wdconinc @veprbl 

### Does this PR introduce breaking changes? What changes might users need to make to their code?

no

### Does this PR change default behavior?

yes