### PR TITLE
fix: re-enable optical materials in hpDIRC

### DIFF
--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -69,22 +69,6 @@
   </define>
 
   <materials>
-    <comment>
-      Only non optical material variants are here.
-      See optical_materials.xml for optical ones
-      -
-    </comment>
-    <material name="EpotekOptical">
-      <D type="density" value="1.2" unit="g/cm3"/>
-      <composite n="5" ref="H"/>
-      <composite n="3" ref="C"/>
-      <composite n="2" ref="O"/>
-    </material>
-    <material name="Nlak33a">
-      <D type="density" value="4.220" unit="g/cm3"/>
-      <composite n="1" ref="Si"/>
-      <composite n="2" ref="O"/>
-    </material>
   </materials>
 
   <limits>

--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -74,7 +74,7 @@
       See optical_materials.xml for optical ones
       -
     </comment>
-    <material name="Epotek">
+    <material name="EpotekOptical">
       <D type="density" value="1.2" unit="g/cm3"/>
       <composite n="5" ref="H"/>
       <composite n="3" ref="C"/>
@@ -129,13 +129,13 @@
           repeat_y="DIRCBar_count_y"
           repeat_z="DIRCBar_count_z"
           gap="DIRCBar_gap"
-          material="Quartz"
+          material="QuartzOptical"
           vis="DIRCBar"
         />
 
         <glue
           thickness="DIRCGlue_thickness"
-          material="Epotek"
+          material="EpotekOptical"
           vis="DIRCGlue"
         />
 
@@ -147,9 +147,9 @@
           thickness="DIRCLens_thickness"
           r1="DIRCLens_r1"
           r2="DIRCLens_r2"
-          material1="Quartz"
-          material2="Sapphire"
-          material3="Quartz"
+          material1="QuartzOptical"
+          material2="SapphireOptical"
+          material3="QuartzOptical"
           vis1="DIRCLens1"
           vis2="DIRCLens2"
           vis3="DIRCLens3"
@@ -161,7 +161,7 @@
           angle="DIRCPrism_angle"
           long_edge="DIRCPrism_long_edge"
           short_edge="DIRCPrism_short_edge"
-          material="Quartz"
+          material="QuartzOptical"
           vis="DIRCPrism"
         />
 
@@ -169,7 +169,7 @@
           height="DIRCMCP_height"
           width="DIRCMCP_width"
           thickness="DIRCMCP_thickness"
-          material="Quartz"
+          material="QuartzOptical"
           vis="DIRCMCP"
         />
       </module>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR re-enable optical materials in hpDIRC in anticipation of better control over optical photon propagation in the hpDIRC in npsim itself.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, optical photons enabled by default (but disabled by default in ddsim, and will in npsim).