### PR TITLE
HOTFIX: add back HcalBarrel_rmin

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -620,6 +620,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
 
     <constant name="HcalBarrel_thickness"     value="86.18*cm"/>
     <constant name="HcalBarrel_rmin1"         value="183.85*cm"/>
+    <constant name="HcalBarrel_rmin"          value="HcalBarrel_rmin1"/><!--DEPRECATED-->
     <constant name="HcalBarrel_rmin2"         value="HcalBarrel_rmin1 + 10.4*cm"/>
     <constant name="HcalBarrel_rmax"          value="HcalBarrel_rmin1 + HcalBarrel_thickness"/>
     <constant name="HcalBarrelForward_zmax"   value="319.625*cm"/>


### PR DESCRIPTION
I believe, the #588 breaks the CalorimeterTrackProjections by removing `HcalBarrel_rmin` which is referenced in
https://github.com/eic/EICrecon/blob/fcd8c84b14a9f0e5e486329bd9d7b42938ea4f46/src/global/tracking/tracking.cc#L164

I think, the `rmin1`/`rmin2` naming is a bit confusing, would be nice to know what the `10.4*cm` offset stands for, and get some better names.