### PR TITLE
Update B0 ECAL geometry

### DIFF
--- a/compact/far_forward/B0_ECal.xml
+++ b/compact/far_forward/B0_ECal.xml
@@ -49,7 +49,7 @@
             sizey="B0ECal_CrystalModule_width"
             sizez="B0ECal_CrystalModule_length"
             vis="GreenVis"
-            material="PbWO4"/>
+            material="LYSO"/>
           <wrapper
             thickness="B0ECal_CrystalModule_wrap"
             material="Epoxy"

--- a/compact/far_forward/B0_ECal.xml
+++ b/compact/far_forward/B0_ECal.xml
@@ -4,10 +4,10 @@
 <lccdd>
   <define>
     <constant name="B0ECal_rotation" value="ionCrossingAngle"/>
-    <constant name="B0ECal_IP_distance" value="683*cm"/>
+    <constant name="B0ECal_IP_distance" value="688*cm"/>
     <constant name="B0ECal_xcenter" value="B0ECal_IP_distance*sin(ionCrossingAngle)"/>
     <constant name="B0ECal_zcenter" value="B0ECal_IP_distance*cos(ionCrossingAngle)"/>
-    <constant name="B0ECal_length" value="10*cm"/>
+    <constant name="B0ECal_length" value="20*cm"/>
     <constant name="B0ECal_CrystalModule_width" value="2*cm"/>
     <constant name="B0ECal_CrystalModule_length" value="B0ECal_length"/>
     <constant name="B0ECal_CrystalModule_wrap" value="0.50*mm"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Following the discussion at the Far-Fowrard working group meeting, the B0 Crystal length is now set to 20cm instead of 10cm. The Crystal material was changed from PbOW4 to LYSO.

More information is available here: https://indico.bnl.gov/event/21778/#20-updated-studies-on-b0-emcal

For now, the default choice is LYSO, while the final choice will be made in spring 2024 ([TIC meeting 3 Apr](https://indico.bnl.gov/event/22321/#11-planning-for-tdr-effort-ff))

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Update geometry

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators (https://indico.bnl.gov/event/21709/)

### Does this PR introduce breaking changes? What changes might users need to make to their code?
The energy containment of the B0 Crystal detector will be improved from 60% -> 90%

### Does this PR change default behavior?
no

The overlap of the crystals with the magnet bore were checked.

![image](https://github.com/eic/epic/assets/25157357/d836ef35-22b7-4857-981d-718a6c1fe11f)
