### PR TITLE
feat: define and add inner detector barrel support cylinder (1 cm CF)

### DIFF
--- a/compact/tracking/mpgd_outerbarrel.xml
+++ b/compact/tracking/mpgd_outerbarrel.xml
@@ -24,7 +24,7 @@
     <constant name="MPGDOuterBarrelModule_rmax"                    value="MPGDOuterBarrelModule_rmin + MPGDOuterBarrelModule_allowed_space" />
     <constant name="MPGDOuterBarrelModule_roffset"                 value="0.5*cm" />
     <constant name="MPGDOuterBarrelModule_width"                   value="36.0*cm"/>
-    <constant name="MPGDOuerBarrel_length"                         value="MPGDOuterBarrelModule_zmin1 + MPGDOuterBarrelModule_zmin2"/>
+    <constant name="MPGDOuterBarrel_length"                        value="MPGDOuterBarrelModule_zmin1 + MPGDOuterBarrelModule_zmin2"/>
     <constant name="MPGDOuterBarrelModule_length"                  value="0.5*(MPGDOuterBarrelModule_zmin1 + MPGDOuterBarrelModule_zmin2 + MPGDOuterBarrelModule_zoverlap)"/>
     <constant name="MPGDOuterBarrelModule_offset"                  value="(MPGDOuterBarrelModule_zmin2 - MPGDOuterBarrelModule_zmin1)/2.0"/>
 

--- a/compact/tracking/support_service_craterlake.xml
+++ b/compact/tracking/support_service_craterlake.xml
@@ -168,13 +168,13 @@
     <constant name="TrackerSupportCylN_thickness2B"        value="TrackerSupportCylAlN_thickness2B + TrackerSupportCylCF_thickness2 + TrackerSupportCylAlN_thickness2SiCone+TrackerSupportCylAlN_thickness2SiDisk" />
     <constant name="TrackerSupportCylN_thickness2C"        value="TrackerSupportCylAlN_thickness2C + TrackerSupportCylCF_thickness2 + TrackerSupportCylAlN_thickness2SiCone+TrackerSupportCylAlN_thickness2SiDisk" />
 
-      <comment> Outer MPGD barrel support cylinder </comment>
-    <constant name="MPGDOuterBarrelSupportCylCF_thickness"    value="1.0*cm" />
-    <constant name="MPGDOuterBarrelSupportCylCF_zmin1"        value="MPGDOuterBarrelModule_zmin1" />
-    <constant name="MPGDOuterBarrelSupportCylCF_zmin2"        value="MPGDOuterBarrelModule_zmin2" />
-    <constant name="MPGDOuterBarrelSupportCylCF_length"       value="MPGDOuterBarrelSupportCylCF_zmin1 + MPGDOuterBarrelSupportCylCF_zmin2" />
-    <constant name="MPGDOuterBarrelSupportCylCF_offset"       value="(MPGDOuterBarrelSupportCylCF_zmin2 - MPGDOuterBarrelSupportCylCF_zmin1)/2.0"/>
-    <constant name="MPGDOuterBarrelSupportCylCF_rmin"         value="MPGDOuterBarrelModule_rmin - MPGDOuterBarrelSupportCylCF_thickness" />
+      <comment> Inner detector support cylinder </comment>
+    <constant name="InnerDetectorBarrelSupportCylCF_thickness"    value="1.0*cm" />
+    <constant name="InnerDetectorBarrelSupportCylCF_zmin1"        value="MPGDOuterBarrelModule_zmin1" />
+    <constant name="InnerDetectorBarrelSupportCylCF_zmin2"        value="MPGDOuterBarrelModule_zmin2" />
+    <constant name="InnerDetectorBarrelSupportCylCF_length"       value="InnerDetectorBarrelSupportCylCF_zmin1 + InnerDetectorBarrelSupportCylCF_zmin2" />
+    <constant name="InnerDetectorBarrelSupportCylCF_offset"       value="(InnerDetectorBarrelSupportCylCF_zmin2 - InnerDetectorBarrelSupportCylCF_zmin1)/2.0"/>
+    <constant name="InnerDetectorBarrelSupportCylCF_rmin"         value="MPGDOuterBarrelModule_rmin - InnerDetectorBarrelSupportCylCF_thickness" />
 
   </define>
 
@@ -373,15 +373,15 @@
           <component material="CarbonFiber" thickness="TrackerSupportCylCF_thickness2" name="Support" vis="TrackerSupportVis"/>
       </support>
 
-      <comment> MPGD outer barrel </comment>
+      <comment> Inner detector support barrel </comment>
       <support type="Cylinder"
-        name="MPGDOuterBarrelSupportCyl"
+        name="InnerDetectorBarrelSupportCyl"
         vis="TrackerSupportVis"
-        rmin="MPGDOuterBarrelSupportCylCF_rmin"
-        length="MPGDOuterBarrelSupportCylCF_length"
-        thickness="MPGDOuterBarrelSupportCylCF_thickness">
-          <position x="0*cm" y="0*cm" z="MPGDOuterBarrelSupportCylCF_offset" />
-          <component material="CarbonFiber" thickness="MPGDOuterBarrelSupportCylCF_thickness" name="Support" vis="TrackerSupportVis"/>
+        rmin="InnerDetectorBarrelSupportCylCF_rmin"
+        length="InnerDetectorBarrelSupportCylCF_length"
+        thickness="InnerDetectorBarrelSupportCylCF_thickness">
+          <position x="0*cm" y="0*cm" z="InnerDetectorBarrelSupportCylCF_offset" />
+          <component material="CarbonFiber" thickness="InnerDetectorBarrelSupportCylCF_thickness" name="Support" vis="TrackerSupportVis"/>
       </support>
     </detector>
   </detectors>

--- a/compact/tracking/support_service_craterlake.xml
+++ b/compact/tracking/support_service_craterlake.xml
@@ -168,6 +168,14 @@
     <constant name="TrackerSupportCylN_thickness2B"        value="TrackerSupportCylAlN_thickness2B + TrackerSupportCylCF_thickness2 + TrackerSupportCylAlN_thickness2SiCone+TrackerSupportCylAlN_thickness2SiDisk" />
     <constant name="TrackerSupportCylN_thickness2C"        value="TrackerSupportCylAlN_thickness2C + TrackerSupportCylCF_thickness2 + TrackerSupportCylAlN_thickness2SiCone+TrackerSupportCylAlN_thickness2SiDisk" />
 
+      <comment> Outer MPGD barrel support cylinder </comment>
+    <constant name="MPGDOuterBarrelSupportCylCF_thickness"    value="1.0*cm" />
+    <constant name="MPGDOuterBarrelSupportCylCF_zmin1"        value="MPGDOuterBarrelModule_zmin1" />
+    <constant name="MPGDOuterBarrelSupportCylCF_zmin2"        value="MPGDOuterBarrelModule_zmin2" />
+    <constant name="MPGDOuterBarrelSupportCylCF_length"       value="MPGDOuterBarrelSupportCylCF_zmin1 + MPGDOuterBarrelSupportCylCF_zmin2" />
+    <constant name="MPGDOuterBarrelSupportCylCF_offset"       value="(MPGDOuterBarrelSupportCylCF_zmin2 - MPGDOuterBarrelSupportCylCF_zmin1)/2.0"/>
+    <constant name="MPGDOuterBarrelSupportCylCF_rmin"         value="MPGDOuterBarrelModule_rmin - MPGDOuterBarrelSupportCylCF_thickness" />
+
   </define>
 
   <detectors>
@@ -363,6 +371,17 @@
           <position x="0*cm" y="0*cm" z="TrackerSupportCylEndcapP_z2E" />
           <component material="Aluminum" thickness="TrackerSupportCylAlP_thickness2E" name="Services" vis="TrackerServiceVis" />
           <component material="CarbonFiber" thickness="TrackerSupportCylCF_thickness2" name="Support" vis="TrackerSupportVis"/>
+      </support>
+
+      <comment> MPGD outer barrel </comment>
+      <support type="Cylinder"
+        name="MPGDOuterBarrelSupportCyl"
+        vis="TrackerSupportVis"
+        rmin="MPGDOuterBarrelSupportCylCF_rmin"
+        length="MPGDOuterBarrelSupportCylCF_length"
+        thickness="MPGDOuterBarrelSupportCylCF_thickness">
+          <position x="0*cm" y="0*cm" z="MPGDOuterBarrelSupportCylCF_offset" />
+          <component material="CarbonFiber" thickness="MPGDOuterBarrelSupportCylCF_thickness" name="Support" vis="TrackerSupportVis"/>
       </support>
     </detector>
   </detectors>

--- a/compact/tracking/support_service_craterlake.xml
+++ b/compact/tracking/support_service_craterlake.xml
@@ -174,7 +174,7 @@
     <constant name="InnerDetectorBarrelSupportCylCF_zmin2"        value="MPGDOuterBarrelModule_zmin2" />
     <constant name="InnerDetectorBarrelSupportCylCF_length"       value="InnerDetectorBarrelSupportCylCF_zmin1 + InnerDetectorBarrelSupportCylCF_zmin2" />
     <constant name="InnerDetectorBarrelSupportCylCF_offset"       value="(InnerDetectorBarrelSupportCylCF_zmin2 - InnerDetectorBarrelSupportCylCF_zmin1)/2.0"/>
-    <constant name="InnerDetectorBarrelSupportCylCF_rmin"         value="MPGDOuterBarrelModule_rmin - InnerDetectorBarrelSupportCylCF_thickness" />
+    <constant name="InnerDetectorBarrelSupportCylCF_rmin"         value="MPGDOuterBarrelModule_rmin - InnerDetectorBarrelSupportCylCF_thickness - 2*mm" />
 
   </define>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds the outer MPGD barrel support cylinder, which is 1 cm thick carbon fiber. Absent better info, it is defined here as sitting just inside the MPGD rmin, for the full length and offset of the outer MPGD barrel.

TODO:
- [x] fix overlaps with current dimensions,
- [ ] verify dimensions with engineers,
- [ ] fix overlaps with new dimensions.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, more material in front of outer MPGD barrel and barrel imaging calorimeter.