### PR TITLE
add default material map binning for approach 2 

### DIFF
--- a/compact/far_forward/B0_tracker.xml
+++ b/compact/far_forward/B0_tracker.xml
@@ -120,7 +120,8 @@
         <ring phi0="-B0TrackerLayerSmallMod_phi0" dphi="B0TrackerModOpeningAngle"
           r="B0TrackerMod1Inner_r+B0TrackerMod1Small_y/2.0" zstart="0.0*mm"
           nmodules="B0TrackerLayerSmallMod_nModules" dz="0 * mm" module="SmallModule1" />
-        <layer_material surface="inner" binning="binPhi,binR" bins0="20*(B0TrackerLayerSmallMod_nModules)" bins1="256"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="2*(B0TrackerLayerSmallMod_nModules)" bins1="12"/>
+        <layer_material surface="outer" binning="binPhi,binR" bins0="2*(B0TrackerLayerSmallMod_nModules)" bins1="12"/>
       </layer>
       <layer id="2" >
         <envelope vis="FFTrackerLayerVis" rmin_tolerance="0*mm" rmax_tolerance="0*mm"
@@ -132,7 +133,8 @@
         <ring phi0="-B0TrackerLayerSmallMod_phi0" dphi="B0TrackerModOpeningAngle"
           r="B0TrackerMod1Inner_r+B0TrackerMod2Small_y/2.0" zstart="0.0*mm"
           nmodules="B0TrackerLayerSmallMod_nModules" dz="0 * mm" module="SmallModule2" />
-        <layer_material surface="inner" binning="binPhi,binR" bins0="20*(B0TrackerLayerSmallMod_nModules)" bins1="256"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="2*(B0TrackerLayerSmallMod_nModules)" bins1="12"/>
+        <layer_material surface="outer" binning="binPhi,binR" bins0="2*(B0TrackerLayerSmallMod_nModules)" bins1="12"/>
       </layer>
       <layer id="3" >
         <envelope vis="FFTrackerLayerVis" rmin_tolerance="0*mm" rmax_tolerance="0*mm"
@@ -144,7 +146,8 @@
         <ring phi0="-B0TrackerLayerSmallMod_phi0" dphi="B0TrackerModOpeningAngle"
           r="B0TrackerMod1Inner_r+B0TrackerMod3Small_y/2.0" zstart="0.0*mm"
           nmodules="B0TrackerLayerSmallMod_nModules" dz="0 * mm" module="SmallModule3" />
-        <layer_material surface="inner" binning="binPhi,binR" bins0="20*(B0TrackerLayerSmallMod_nModules)" bins1="256"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="2*(B0TrackerLayerSmallMod_nModules)" bins1="12"/>
+        <layer_material surface="outer" binning="binPhi,binR" bins0="2*(B0TrackerLayerSmallMod_nModules)" bins1="12"/>
       </layer>
       <layer id="4" >
         <envelope vis="FFTrackerLayerVis" rmin_tolerance="0*mm" rmax_tolerance="0*mm"
@@ -156,7 +159,8 @@
         <ring phi0="-B0TrackerLayerSmallMod_phi0" dphi="B0TrackerModOpeningAngle"
           r="B0TrackerMod1Inner_r+B0TrackerMod4Small_y/2.0" zstart="0.0*mm"
           nmodules="B0TrackerLayerSmallMod_nModules" dz="0 * mm" module="SmallModule4" />
-        <layer_material surface="inner" binning="binPhi,binR" bins0="20*(B0TrackerLayerSmallMod_nModules)" bins1="256"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="2*(B0TrackerLayerSmallMod_nModules)" bins1="12"/>
+        <layer_material surface="outer" binning="binPhi,binR" bins0="2*(B0TrackerLayerSmallMod_nModules)" bins1="12"/>
       </layer>
     </detector>
 

--- a/compact/tracking/mpgd_barrel.xml
+++ b/compact/tracking/mpgd_barrel.xml
@@ -82,6 +82,7 @@
           z_length="InnerMPGDBarrelLayer_length"
           z0="InnerMPGDBarrel_zoffset"/>
         <layer_material surface="inner" binning="binPhi,binZ" bins0="MPGDBarrelStave_count" bins1="100" />
+        <layer_material surface="outer" binning="binPhi,binZ" bins0="MPGDBarrelStave_count" bins1="100" />
         <rphi_layout phi_tilt="0" nphi="MPGDBarrelStave_count" phi0="0.0" rc="(InnerMPGDBarrelLayer_rmin + InnerMPGDBarrelLayer_rmax)/2.0" dr="0.0 * mm"/>
         <z_layout dr="0.0 * mm" z0="0.0 * mm" nz="1"/>
       </layer>

--- a/compact/tracking/mpgd_innerbarrel.xml
+++ b/compact/tracking/mpgd_innerbarrel.xml
@@ -120,6 +120,7 @@
           z_length="InnerMPGDBarrelLayer1_length"
           z0="0" />
         <layer_material surface="inner" binning="binPhi,binZ" bins0="MPGDBarrelStave_count" bins1="100" />
+        <layer_material surface="outer" binning="binPhi,binZ" bins0="MPGDBarrelStave_count" bins1="100" />
         <rphi_layout phi_tilt="0" nphi="MPGDBarrelStave_count" phi0="0.0" rc="InnerMPGDBarrelMod1_rmin" dr="0.0 * mm"/>
         <z_layout dr="0.0 * mm" z0="0" nz="1"/>
     </layer>
@@ -146,6 +147,7 @@
           z_length="InnerMPGDBarrelLayer2_length"
           z0="-InnerMPGDBarrelMod2_zpos"/>
         <layer_material surface="inner" binning="binPhi,binZ" bins0="MPGDBarrelStave_count" bins1="100" />
+        <layer_material surface="outer" binning="binPhi,binZ" bins0="MPGDBarrelStave_count" bins1="100" />
         <rphi_layout phi_tilt="0" nphi="MPGDBarrelStave_count" phi0="0.0" rc="InnerMPGDBarrelMod2_rmin" dr="0.0 * mm"/>
         <z_layout dr="0.0 * mm" z0="0" nz="1"/>
       </layer>
@@ -172,6 +174,7 @@
           z_length="InnerMPGDBarrelLayer3_length"
           z0="InnerMPGDBarrelMod3_zpos"/>
         <layer_material surface="inner" binning="binPhi,binZ" bins0="MPGDBarrelStave_count" bins1="100" />
+        <layer_material surface="outer" binning="binPhi,binZ" bins0="MPGDBarrelStave_count" bins1="100" />
         <rphi_layout phi_tilt="0" nphi="MPGDBarrelStave_count" phi0="0.0" rc="InnerMPGDBarrelMod3_rmin" dr="0.0 * mm"/>
         <z_layout dr="0.0 * mm" z0="0" nz="1"/>
        </layer>

--- a/compact/tracking/mpgd_outerbarrel.xml
+++ b/compact/tracking/mpgd_outerbarrel.xml
@@ -150,7 +150,8 @@
 <comment> Layout for MPGD DIRC layers </comment>
   <layer module="MPGDOuterBarrelModule" id="0" vis="TrackerSupportVis">
           <envelope_tolerance r_min="-50*mm" r_max="0*mm" z_min="0*mm" z_max="0*mm"/>
-    <layer_material surface="outer" binning="binPhi,binZ" bins0="MPGDOuterBarrelModule_count" bins1="100" />
+    <layer_material surface="inner" binning="binPhi,binZ" bins0="MPGDOuterBarrelModule_count*10" bins1="100" />
+    <layer_material surface="outer" binning="binPhi,binZ" bins0="MPGDOuterBarrelModule_count*10" bins1="100" />
     <rphi_layout
           phi_tilt="0"
           nphi="MPGDOuterBarrelModule_count"

--- a/compact/tracking/silicon_barrel.xml
+++ b/compact/tracking/silicon_barrel.xml
@@ -90,8 +90,8 @@
           inner_r="SiBarrelLayer1_rmin-0.5*mm"
           outer_r="SiBarrelLayer1_rmax"
           z_length="SiBarrelLayer1_length" />
-	<layer_material surface="inner" binning="binPhi,binZ" bins0="SiBarrelStave1_count" bins1="100" />
-	<layer_material surface="outer" binning="binPhi,binZ" bins0="SiBarrelStave1_count" bins1="100" />
+        <layer_material surface="inner" binning="binPhi,binZ" bins0="SiBarrelStave1_count" bins1="100" />
+        <layer_material surface="outer" binning="binPhi,binZ" bins0="SiBarrelStave1_count" bins1="100" />
         <comment>
           phi0     : Starting phi of first module.
           phi_tilt : Phi tilt of a module.
@@ -151,7 +151,7 @@
           z_length="SiBarrelLayer2_length" />
         <layer_material surface="inner" binning="binPhi,binZ" bins0="128" bins1="100" />
         <layer_material surface="outer" binning="binPhi,binZ" bins0="128" bins1="100" />
-	<comment>
+        <comment>
           phi0     : Starting phi of first module.
           phi_tilt : Phi tilt of a module.
           rc       : Radius of the module center.

--- a/compact/tracking/silicon_barrel.xml
+++ b/compact/tracking/silicon_barrel.xml
@@ -90,7 +90,8 @@
           inner_r="SiBarrelLayer1_rmin-0.5*mm"
           outer_r="SiBarrelLayer1_rmax"
           z_length="SiBarrelLayer1_length" />
-        <layer_material surface="inner" binning="binPhi,binZ" bins0="SiBarrelStave1_count" bins1="100" />
+	<layer_material surface="inner" binning="binPhi,binZ" bins0="SiBarrelStave1_count" bins1="100" />
+	<layer_material surface="outer" binning="binPhi,binZ" bins0="SiBarrelStave1_count" bins1="100" />
         <comment>
           phi0     : Starting phi of first module.
           phi_tilt : Phi tilt of a module.
@@ -149,7 +150,8 @@
           outer_r="SiBarrelLayer2_rmax"
           z_length="SiBarrelLayer2_length" />
         <layer_material surface="inner" binning="binPhi,binZ" bins0="128" bins1="100" />
-        <comment>
+        <layer_material surface="outer" binning="binPhi,binZ" bins0="128" bins1="100" />
+	<comment>
           phi0     : Starting phi of first module.
           phi_tilt : Phi tilt of a module.
           rc       : Radius of the module center.

--- a/compact/tracking/silicon_disks.xml
+++ b/compact/tracking/silicon_disks.xml
@@ -222,7 +222,7 @@
           length="SiTrackerEndcapLayer_thickness"
           zstart="TrackerEndcapPLayer1_zmin" />
         <layer_material surface="inner" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
-        <layer_material surface="inner" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
+        <layer_material surface="outer" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <ring
           r="TrackerEndcapPMod1_rmin + TrackerEndcapPMod1_y/2"
           zstart="0"
@@ -252,7 +252,7 @@
           length="SiTrackerEndcapLayer_thickness"
           zstart="TrackerEndcapNLayer1_zmin" />
         <layer_material surface="inner" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
-        <layer_material surface="inner" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
+        <layer_material surface="outer" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <ring
           r="TrackerEndcapNMod1_rmin + TrackerEndcapNMod1_y/2"
           zstart="0"

--- a/compact/tracking/tof_barrel.xml
+++ b/compact/tracking/tof_barrel.xml
@@ -123,7 +123,8 @@
           outer_r="BarrelTOF_rmax"
           z_length="BarrelTOF_length+2*BarrelTOF_zOffset"
           z0="BarrelTOF_zoffset"/>
-
+         <layer_material surface="inner" binning="binPhi,binZ" bins0="BarrelTOF_Module_nphi" bins1="100" />
+         <layer_material surface="outer" binning="binPhi,binZ" bins0="BarrelTOF_Module_nphi" bins1="100" />
         <rphi_layout phi_tilt="BarrelTOF_Module_tiltangle" nphi="BarrelTOF_Module_nphi" phi0="0.0" rc="BarrelTOF_radius" dr="0.0*mm"/>
         <z_layout dr="0.0*mm" z0="BarrelTOF_zOffset" nz="BarrelTOF_Module_nz"/>
       </layer>

--- a/compact/tracking/tof_endcap.xml
+++ b/compact/tracking/tof_endcap.xml
@@ -252,7 +252,7 @@
           length="3*cm"
           zstart="ForwardTOF_zmin" />
         <layer_material surface="inner" binning="binPhi,binR" bins0="30" bins1="30"/>
-        <layer_material surface="inner" binning="binPhi,binR" bins0="30" bins1="30"/>
+        <layer_material surface="outer" binning="binPhi,binR" bins0="30" bins1="30"/>
         <y_layout dr="0.0*mm" z0="EndcapTOF_zOffset" nz="EndcapTOF_Module_nz"/>
         <z_layout z0="ForwardTOF_zmin"/>
       </layer>

--- a/compact/tracking/vertex_barrel.xml
+++ b/compact/tracking/vertex_barrel.xml
@@ -105,7 +105,7 @@
           z_length="VertexBarrelLayer_length" />
         <layer_material surface="inner" binning="binPhi,binZ" bins0="VertexBarrelStave_count1" bins1="100" />
         <layer_material surface="outer" binning="binPhi,binZ" bins0="VertexBarrelStave_count1" bins1="100" />
-	<comment>
+        <comment>
           phi0     : Starting phi of first module.
           phi_tilt : Phi tilt of a module.
           rc       : Radius of the module center.
@@ -125,7 +125,7 @@
           z_length="VertexBarrelLayer_length" />
         <layer_material surface="inner" binning="binPhi,binZ" bins0="VertexBarrelStave_count2" bins1="100" />
         <layer_material surface="outer" binning="binPhi,binZ" bins0="VertexBarrelStave_count2" bins1="100" />
-	<rphi_layout phi_tilt="0.0*degree" nphi="VertexBarrelStave_count2" phi0="0.0*degree" rc="VertexBarrelMod2_rmin" dr="0.0 * mm"/>
+        <rphi_layout phi_tilt="0.0*degree" nphi="VertexBarrelStave_count2" phi0="0.0*degree" rc="VertexBarrelMod2_rmin" dr="0.0 * mm"/>
         <z_layout dr="0.0 * mm" z0="0.0 * mm" nz="1"/>
       </layer>
       <layer module="Module3" id="4" vis="VertexLayerVis">
@@ -135,7 +135,7 @@
           z_length="VertexBarrelLayer_length" />
         <layer_material surface="inner" binning="binPhi,binZ" bins0="VertexBarrelStave_count3" bins1="100" />
         <layer_material surface="outer" binning="binPhi,binZ" bins0="VertexBarrelStave_count3" bins1="100" />
-	<rphi_layout phi_tilt="0.0*degree" nphi="VertexBarrelStave_count3" phi0="0.0" rc="VertexBarrelMod3_rmin" dr="0.0 * mm"/>
+        <rphi_layout phi_tilt="0.0*degree" nphi="VertexBarrelStave_count3" phi0="0.0" rc="VertexBarrelMod3_rmin" dr="0.0 * mm"/>
         <z_layout dr="0.0 * mm" z0="0.0 * mm" nz="1"/>
       </layer>
     </detector>

--- a/compact/tracking/vertex_barrel.xml
+++ b/compact/tracking/vertex_barrel.xml
@@ -46,10 +46,12 @@
       due to ACTS limitations.
       FIXME: this shouldn't be needed anymore, need to update the cylindrical plugin.
     </comment>
-    <constant name="VertexBarrelStave_count"       value="128"/>
-    <constant name="VertexBarrelStave1_width"      value="2*VertexBarrelMod1_rmin * tan(180*degree/VertexBarrelStave_count)"/>
-    <constant name="VertexBarrelStave2_width"      value="2*VertexBarrelMod2_rmin * tan(180*degree/VertexBarrelStave_count)"/>
-    <constant name="VertexBarrelStave3_width"      value="2*VertexBarrelMod3_rmin * tan(180*degree/VertexBarrelStave_count)"/>
+    <constant name="VertexBarrelStave_count1"       value="128"/>
+    <constant name="VertexBarrelStave_count2"       value="128"/>
+    <constant name="VertexBarrelStave_count3"       value="128"/>
+    <constant name="VertexBarrelStave1_width"      value="2*VertexBarrelMod1_rmin * tan(180*degree/VertexBarrelStave_count1)"/>
+    <constant name="VertexBarrelStave2_width"      value="2*VertexBarrelMod2_rmin * tan(180*degree/VertexBarrelStave_count2)"/>
+    <constant name="VertexBarrelStave3_width"      value="2*VertexBarrelMod3_rmin * tan(180*degree/VertexBarrelStave_count3)"/>
   </define>
 
   <detectors>
@@ -101,8 +103,9 @@
           inner_r="VertexBarrelLayer1_rmin"
           outer_r="VertexBarrelLayer1_rmax"
           z_length="VertexBarrelLayer_length" />
-        <layer_material surface="inner" binning="binPhi,binZ" bins0="VertexBarrelStave_count" bins1="100" />
-        <comment>
+        <layer_material surface="inner" binning="binPhi,binZ" bins0="VertexBarrelStave_count1" bins1="100" />
+        <layer_material surface="outer" binning="binPhi,binZ" bins0="VertexBarrelStave_count1" bins1="100" />
+	<comment>
           phi0     : Starting phi of first module.
           phi_tilt : Phi tilt of a module.
           rc       : Radius of the module center.
@@ -112,7 +115,7 @@
           nz       : Number of modules to place in z.
           dr       : Radial displacement parameter, of every other module.
         </comment>
-        <rphi_layout phi_tilt="0.0*degree" nphi="VertexBarrelStave_count" phi0="0.0" rc="VertexBarrelMod1_rmin" dr="0.0 * mm"/>
+        <rphi_layout phi_tilt="0.0*degree" nphi="VertexBarrelStave_count1" phi0="0.0" rc="VertexBarrelMod1_rmin" dr="0.0 * mm"/>
         <z_layout dr="0.0 * mm" z0="0.0 * mm" nz="1"/>
       </layer>
       <layer module="Module2" id="2" vis="VertexLayerVis">
@@ -120,8 +123,9 @@
           inner_r="VertexBarrelLayer2_rmin"
           outer_r="VertexBarrelLayer2_rmax"
           z_length="VertexBarrelLayer_length" />
-        <layer_material surface="inner" binning="binPhi,binZ" bins0="VertexBarrelStave_count" bins1="100" />
-        <rphi_layout phi_tilt="0.0*degree" nphi="VertexBarrelStave_count" phi0="0.0" rc="VertexBarrelMod2_rmin" dr="0.0 * mm"/>
+        <layer_material surface="inner" binning="binPhi,binZ" bins0="VertexBarrelStave_count2" bins1="100" />
+        <layer_material surface="outer" binning="binPhi,binZ" bins0="VertexBarrelStave_count2" bins1="100" />
+	<rphi_layout phi_tilt="0.0*degree" nphi="VertexBarrelStave_count2" phi0="0.0*degree" rc="VertexBarrelMod2_rmin" dr="0.0 * mm"/>
         <z_layout dr="0.0 * mm" z0="0.0 * mm" nz="1"/>
       </layer>
       <layer module="Module3" id="4" vis="VertexLayerVis">
@@ -129,8 +133,9 @@
           inner_r="VertexBarrelLayer3_rmin"
           outer_r="VertexBarrelLayer3_rmax"
           z_length="VertexBarrelLayer_length" />
-        <layer_material surface="inner" binning="binPhi,binZ" bins0="VertexBarrelStave_count" bins1="100" />
-        <rphi_layout phi_tilt="0.0*degree" nphi="VertexBarrelStave_count" phi0="0.0" rc="VertexBarrelMod3_rmin" dr="0.0 * mm"/>
+        <layer_material surface="inner" binning="binPhi,binZ" bins0="VertexBarrelStave_count3" bins1="100" />
+        <layer_material surface="outer" binning="binPhi,binZ" bins0="VertexBarrelStave_count3" bins1="100" />
+	<rphi_layout phi_tilt="0.0*degree" nphi="VertexBarrelStave_count3" phi0="0.0" rc="VertexBarrelMod3_rmin" dr="0.0 * mm"/>
         <z_layout dr="0.0 * mm" z0="0.0 * mm" nz="1"/>
       </layer>
     </detector>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
add default material map binning for approach 2 in tracking detectors

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
N/A
### Does this PR change default behavior?
N/A