### PR TITLE
fix: require dd4hep 1.27 because of HexGrid segmentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 include(GNUInstallDirs)
 
 # Dependencies
-find_package(DD4hep 1.21 REQUIRED COMPONENTS DDCore DDRec)
+find_package(DD4hep 1.27 REQUIRED COMPONENTS DDCore DDRec)
 find_package(fmt REQUIRED)
 
 #-----------------------------------------------------------------------------------


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR sets the required version of DD4hep to 1.27 since we use HexGrid, added in https://github.com/AIDASoft/DD4hep/commit/03a54fdb313fb507448327269712851bc809b3ca.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://chat.epic-eic.org/main/pl/jn5eodrdhpg3dxchy5iiritxyo)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No; if you were on an older version of DD4hep, it wasn't compiling anyway.