### PR TITLE
fix: rename detector to HcalFarForwardZDC_SiPMonTile

### DIFF
--- a/compact/far_forward/ZDC_SiPMonTile.xml
+++ b/compact/far_forward/ZDC_SiPMonTile.xml
@@ -72,7 +72,7 @@
     </documentation>
     <detector
       id="HcalFarForwardZDC_SiPMonTile_ID"
-      name="ZDC SiPM-on-Tile Hcal"
+      name="HcalFarForwardZDC_SiPMonTile"
       type="ZeroDegreeCalorimeterSiPMonTile"
       readout="HcalFarForwardZDCHits"
       vis="InvisibleWithDaughters"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR renames the HcalFarForwardZDC_SiPMonTile detector from a previous name with spaces and dashes.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: non-compliant name)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added: a workflow test is coming in a different context that doesn't like this name
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No. This name is not used for output collection names etc.