### PR TITLE
fix: tell dd4hep_configure_output which install prefix to use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ find_package(fmt REQUIRED)
 #-----------------------------------------------------------------------------------
 set(a_lib_name ${PROJECT_NAME})
 
-dd4hep_configure_output()
+dd4hep_configure_output(INSTALL ${CMAKE_INSTALL_PREFIX}))
 dd4hep_set_compiler_flags()
 
 file(GLOB sources CONFIGURE_DEPENDS src/*.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ find_package(fmt REQUIRED)
 #-----------------------------------------------------------------------------------
 set(a_lib_name ${PROJECT_NAME})
 
-dd4hep_configure_output(INSTALL ${CMAKE_INSTALL_PREFIX}))
+dd4hep_configure_output(INSTALL ${CMAKE_INSTALL_PREFIX})
 dd4hep_set_compiler_flags()
 
 file(GLOB sources CONFIGURE_DEPENDS src/*.cpp)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR prevents [dd4hep_configure_output](https://github.com/AIDASoft/DD4hep/blob/e52af7f770ec3e51460d832428f2cca214678e2a/cmake/DD4hepBuild.cmake#L328-L331) from overriding the `CMAKE_INSTALL_PREFIX` that we just set in case the user doesn't define it.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: setup.sh has path that does not match with actual install location)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes. The default install prefix (if not specified) will change from `${CMAKE_SOURCE_DIR}` to `${CMAKE_SOURCE_DIR}/prefix`.