### PR TITLE
fix: mv evaluated templates during build into CMAKE_CURRENT_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,6 @@ target_link_libraries(${a_lib_name}
 
 #-----------------------------------------------------------------------------------
 # Parse jinja templates: once by default, and once for all yml files
-#
-# FIXME: should not write rendered templates to ${CMAKE_CURRENT_SOURCE_DIR}
-
 set(TEMPLATE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/templates)
 set(TEMPLATE_XML ${PROJECT_NAME}.xml.jinja2)
 
@@ -76,15 +73,15 @@ foreach(config_yml ${CONFIG_YMLS})
                 --dir ${TEMPLATE_DIR}
                 --template ${TEMPLATE_XML}
                 --config ${config_yml}
-                --output ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}_${config}.xml
+                --output ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_${config}.xml
         COMMENT "Creating configuration ${config} for ${PROJECT_NAME}"
         )
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}_${config}.xml
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_${config}.xml
         DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/
         )
 endforeach()
 
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}_full.xml
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_full.xml
     DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/
     RENAME ${PROJECT_NAME}.xml
     )


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The build system writes the evaluated jinja templates (entrypoint xml files) into the source directory instead of a build directory. This PR moves these temporary build artifacts into the build directory instead.

TODO:
- [x] fix common_bench to do a proper install into a prefix instead of a build into the source directory

### What kind of change does this PR introduce?
- [x] Bug fix (issue #54)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, no more xml files will be written to the source directory; `make install` or bust.