### PR TITLE
Change pfRICH outer radius

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -463,7 +463,7 @@ Examples:
     <constant name="BackwardPIDRegion_length"     value="45.0*cm" />
     <constant name="BackwardPIDRegion_zmin"       value="CentralTrackingRegionN_zmax" />
     <constant name="BackwardPIDRegion_zmax"       value="BackwardPIDRegion_zmin + BackwardPIDRegion_length" />
-    <constant name="BackwardPIDRegion_rmax"       value="63.0*cm" /> <!-- FIXME hardcoded, was CentralTrackingRegion_rmax -->
+    <constant name="BackwardPIDRegion_rmax"       value="65.0*cm" /> <!-- FIXME hardcoded, was CentralTrackingRegion_rmax -->
     <constant name="BackwardPIDRegion_tan"        value="CentralTrackingRegionN_tan * 0.92" />
 
     <comment> Backward RICH region </comment>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Change the outer radius to 65 cm as communicated by Alex Enslinger. Hold merge until geometry table is updated (and documented in the commit. message)

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No, it fixes problems with the latest (proposed) pfRICH implementation

### Does this PR change default behavior?
Shouldn't.
