### PR TITLE
fix: add `prefix/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ acts2.txt
 materials-map.cbor
 
 # local install directories
+prefix/
 lib/
 share/
 setup.sh


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Now that we have caused (#669) the default install directory to be `prefix/`, we should add it to the `.gitignore` so no one accidentally adds it to the repo. This PR adds `prefix/` to the project-wide `.gitignore` listing.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.