### PR TITLE
fix: rotate DRICH by 30 degrees

### DIFF
--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -346,7 +346,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
       continue;
 
     // sector rotation about z axis
-    RotationZ   sectorRotation(isec * 2 * M_PI / nSectors);
+    RotationZ   sectorRotation((isec + 0.5) * 2 * M_PI / nSectors);
     std::string secName = "sec" + std::to_string(isec);
 
     // BUILD MIRRORS ====================================================================


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR rotates the DRICH by 30 degrees. Per Marco's slides at https://indico.bnl.gov/event/22417/, e.g. slides 9 and 10, the DRICH has a readout box at the top, bottom, and at 2 and 4 o'clock, and 8 and 10 o'clock. That's different from where we had it before which was 0 degrees in phi, i.e. X axis, which is 9 o'clock. For an interaction region with a crossing angle, this matters, of course.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, it rotates the DRICH by 30 degrees.