### PR TITLE
feat: dRICH sensor boxes in more realistic sector segments

### DIFF
--- a/compact/pid/drich.xml
+++ b/compact/pid/drich.xml
@@ -24,6 +24,7 @@
 <constant name="DRICH_sensorbox_length"   value="50.0*cm"/>  <!-- z-length of the extrusion -->
 <constant name="DRICH_sensorbox_rmin"     value="DRICH_rmax1 + 2*cm"/>  <!-- lower radial limit of the extrusion -->
 <constant name="DRICH_sensorbox_rmax"     value="DRICH_rmax2 + 5*cm"/>  <!-- upper radial limit of the extrusion -->
+<constant name="DRICH_sensorbox_dphi"     value="48*degree"/>  <!-- azimuthal width of the extrusion -->
 <!-- aerogel+filter geometry -->
 <constant name="DRICH_aerogel_thickness"  value="4.0*cm"/>  <!-- aerogel thickness -->
 <constant name="DRICH_airgap_thickness"   value="0.01*mm"/> <!-- air gap between aerogel and filter -->

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -202,7 +202,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
 
   // tank solids:
   // - inner: cone along beamline
-  // - outer; cone to back of sensor box, then fixed radius cylinder
+  // - outer: cone to back of sensor box, then fixed radius cylinder
   Polycone vesselTank(0, 2 * M_PI,
            /* rmin */ {vesselSnout.rMin2(), std::lerp(vesselSnout.rMin2(), vesselRmin1, (sensorboxLength - snoutLength) / tankLength), vesselRmin1},
            /* rmax */ {vesselSnout.rMax2(), vesselRmax2, vesselRmax2},

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -89,6 +89,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
   auto sensorboxLength = desc.constant<double>("DRICH_sensorbox_length");
   auto sensorboxRmin   = desc.constant<double>("DRICH_sensorbox_rmin");
   auto sensorboxRmax   = desc.constant<double>("DRICH_sensorbox_rmax");
+  auto sensorboxDphi   = desc.constant<double>("DRICH_sensorbox_dphi");
   // - sensor photosensitive surface (pss)
   auto pssElem      = detElem.child(_Unicode(sensors)).child(_Unicode(pss));
   auto pssMat       = desc.material(pssElem.attr<std::string>(_Unicode(material)));
@@ -200,22 +201,40 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
       vesselRmax1 - wallThickness + windowThickness * (vesselRmax1 - vesselRmax0) / snoutLength);
 
   // tank solids
-  Cone vesselTank(tankLength / 2.0, vesselSnout.rMin2(), vesselRmax2, vesselRmin1, vesselRmax2);
-  Cone gasvolTank(tankLength / 2.0 - windowThickness, gasvolSnout.rMin2(), vesselRmax2 - wallThickness,
-                  vesselRmin1 + wallThickness, vesselRmax2 - wallThickness);
+  Polycone vesselTank(0, 2 * M_PI,
+           /* rmin */ {vesselSnout.rMin2(), vesselSnout.rMin2(), vesselRmin1},
+           /* rmax */ {vesselSnout.rMax2(), vesselRmax2, vesselRmax2},
+           /* z    */ {-tankLength / 2.0, -tankLength / 2.0 + sensorboxLength - snoutLength, tankLength / 2.0});
+  Polycone gasvolTank(0, 2 * M_PI,
+           /* rmin */ {gasvolSnout.rMin2(), gasvolSnout.rMin2(), vesselRmin1 + wallThickness},
+           /* rmax */ {gasvolSnout.rMax2(), vesselRmax2 - wallThickness, vesselRmax2 - wallThickness},
+           /* z    */ {-tankLength / 2.0 + windowThickness, -tankLength / 2.0 + windowThickness + sensorboxLength - snoutLength, tankLength / 2.0 - windowThickness});
 
   // sensorbox solids
-  // FIXME: this is currently just a simple tubular extrusion; this should be replaced by proper sensor boxes
-  Tube vesselSensorboxTube(sensorboxRmin, sensorboxRmax, sensorboxLength / 2.);
-  Tube gasvolSensorboxTube(sensorboxRmin + wallThickness, sensorboxRmax - wallThickness, sensorboxLength / 2.);
+  double dphi = atan2(wallThickness, sensorboxRmax); // thickness only correct at Rmax
+  Tube vesselSensorboxTube(sensorboxRmin, sensorboxRmax, sensorboxLength / 2.,
+                           -sensorboxDphi / 2., sensorboxDphi / 2.);
+  Tube gasvolSensorboxTube(sensorboxRmin + wallThickness, sensorboxRmax - wallThickness, sensorboxLength / 2.,
+                           -sensorboxDphi / 2. + dphi, sensorboxDphi / 2. - dphi);
 
   // union: snout + tank
-  UnionSolid vesselUnion0(vesselTank, vesselSnout, Position(0., 0., -vesselLength / 2.));
-  UnionSolid gasvolUnion0(gasvolTank, gasvolSnout, Position(0., 0., -vesselLength / 2. + windowThickness));
+  UnionSolid vesselUnion(vesselTank, vesselSnout, Position(0., 0., -vesselLength / 2.));
+  UnionSolid gasvolUnion(gasvolTank, gasvolSnout, Position(0., 0., -vesselLength / 2. + windowThickness));
 
-  // union: add sensorbox
-  UnionSolid vesselUnion(vesselUnion0, vesselSensorboxTube, Position(0., 0., -(snoutLength + sensorboxLength - 0.6) / 2.));
-  UnionSolid gasvolUnion(gasvolUnion0, gasvolSensorboxTube, Position(0., 0., -(snoutLength + sensorboxLength) / 2. + windowThickness));
+  // union: add sensorboxes for all sectors
+  for (int isec = 0; isec < nSectors; isec++) {
+    RotationZ sectorRotation((isec + 0.5) * 2 * M_PI / nSectors);
+    vesselUnion = UnionSolid(vesselUnion, vesselSensorboxTube,
+                             Transform3D(sectorRotation,
+                                         Position(0., 0., -(snoutLength + sensorboxLength - 0.6) / 2.)
+                                         )
+                             );
+    gasvolUnion = UnionSolid(gasvolUnion, gasvolSensorboxTube,
+                             Transform3D(sectorRotation,
+                                         Position(0., 0., -(snoutLength + sensorboxLength) / 2. + windowThickness)
+                                         )
+                             );
+  }
 
   //  extra solids for `debugOptics` only
   Box vesselBox(1001, 1001, 1001);

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -200,13 +200,15 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
       vesselRmin0 + boreDelta * (snoutLength - windowThickness) / vesselLength + wallThickness,
       vesselRmax1 - wallThickness + windowThickness * (vesselRmax1 - vesselRmax0) / snoutLength);
 
-  // tank solids
+  // tank solids:
+  // - inner: cone along beamline
+  // - outer; cone to back of sensor box, then fixed radius cylinder
   Polycone vesselTank(0, 2 * M_PI,
-           /* rmin */ {vesselSnout.rMin2(), vesselSnout.rMin2(), vesselRmin1},
+           /* rmin */ {vesselSnout.rMin2(), std::lerp(vesselSnout.rMin2(), vesselRmin1, (sensorboxLength - snoutLength) / tankLength), vesselRmin1},
            /* rmax */ {vesselSnout.rMax2(), vesselRmax2, vesselRmax2},
            /* z    */ {-tankLength / 2.0, -tankLength / 2.0 + sensorboxLength - snoutLength, tankLength / 2.0});
   Polycone gasvolTank(0, 2 * M_PI,
-           /* rmin */ {gasvolSnout.rMin2(), gasvolSnout.rMin2(), vesselRmin1 + wallThickness},
+           /* rmin */ {gasvolSnout.rMin2(), std::lerp(gasvolSnout.rMin2(), vesselRmin1 + wallThickness, (sensorboxLength - snoutLength) / tankLength), vesselRmin1 + wallThickness},
            /* rmax */ {gasvolSnout.rMax2(), vesselRmax2 - wallThickness, vesselRmax2 - wallThickness},
            /* z    */ {-tankLength / 2.0 + windowThickness, -tankLength / 2.0 + windowThickness + sensorboxLength - snoutLength, tankLength / 2.0 - windowThickness});
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Until now the dRICH sensor boxes were a 5cm larger outer radius cylinder sticking out of the gas volume. This did not leave room for service routing between the sectors of the dRICH.

This PR modifies the sensor boxes (and envelope volume) to be a cylinder segment of configurable delta phi (set to 48 degrees to fit the sensors). The sections between the segments are conical (polycone), as per both services routing cad and recent TIC presentation.

TODO:
- [x] #683 
- [x] polycone rmin at middle z-plane should be linerp of outer z-plane rmin values, not the current front z-plane rmin (may overlap with beam pipe but is incorrect in any case)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, adds azimuthally smaller sensor boxes, with side walls that have locally higher X0 expected 