### PR TITLE
fix: use DD4hep RPATH configuration for libepic.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ find_package(fmt REQUIRED)
 #-----------------------------------------------------------------------------------
 set(a_lib_name ${PROJECT_NAME})
 
+set(DD4HEP_SET_RPATH TRUE)
 dd4hep_configure_output(INSTALL ${CMAKE_INSTALL_PREFIX})
 dd4hep_set_compiler_flags()
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR configures the epic build to use RPATH in the produced library libepic.so.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: libepic.so not linked against libGDML.so, e.g. https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/2772722#L1896)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.