### PR TITLE
Use expr(1) for dawn views 12,14,15 to enable negative zpos

### DIFF
--- a/scripts/view12/generate_eps
+++ b/scripts/view12/generate_eps
@@ -72,8 +72,8 @@ make_slice(){
   local zpos="$1"
   local tagnum=$(printf "%04d" ${zpos})
   local FILE_TAG="${original_file_tag}a${tagnum}"
-  dawncut 0 0 1 ${zpos}1 ${INPUT_FILE} ${FILE_TAG}_temp0.prim
-  dawncut 0 0 -1 -${zpos}0  ${FILE_TAG}_temp0.prim  ${FILE_TAG}.prim
+  dawncut 0 0 1 $(( 10 * ${zpos} + 1 )) ${INPUT_FILE} ${FILE_TAG}_temp0.prim
+  dawncut 0 0 -1 $(( -10 * ${zpos} )) ${FILE_TAG}_temp0.prim  ${FILE_TAG}.prim
   dawn -d ${FILE_TAG}.prim
   ps2pdf ${FILE_TAG}.eps ${FILE_TAG}_full.pdf
   gs -o ${FILE_TAG}.pdf -sDEVICE=pdfwrite \

--- a/scripts/view14/generate_eps
+++ b/scripts/view14/generate_eps
@@ -75,10 +75,10 @@ make_slice(){
   local zpos="$1"
   local tagnum=$(printf "%04d" ${zpos})
   local FILE_TAG="${original_file_tag}a${tagnum}"
-  local z1=$(add ${zpos} 100)
-  local z2=$(add ${zpos} -100)
-  #dawncut 0 0 1 ${z1}1 ${INPUT_FILE} ${FILE_TAG}_temp0.prim
-  #dawncut 0 0 -1 -${z2}0  ${FILE_TAG}_temp0.prim  ${FILE_TAG}.prim
+  local z1=$(( ${zpos} + 100 ))
+  local z2=$(( ${zpos} - 100 ))
+  #dawncut 0 0 1 $(( 10 * ${z1} + 1 )) ${INPUT_FILE} ${FILE_TAG}_temp0.prim
+  #dawncut 0 0 -1 $(( -10 * ${z2} ))  ${FILE_TAG}_temp0.prim  ${FILE_TAG}.prim
   ../../bin/dawn_tweak -z ${zpos}0
   cp ${INPUT_FILE} ${FILE_TAG}.prim
   dawn -d ${FILE_TAG}.prim

--- a/scripts/view15/generate_eps
+++ b/scripts/view15/generate_eps
@@ -91,10 +91,10 @@ make_slice(){
   local zpos="$1"
   local tagnum=$(printf "%04d" ${zpos})
   local FILE_TAG="${original_file_tag}a${tagnum}"
-  local z1=$(add ${zpos} 100)
-  local z2=$(add ${zpos} -100)
-  #dawncut 0 0 1 ${z1}1 ${INPUT_FILE} ${FILE_TAG}_temp0.prim
-  #dawncut 0 0 -1 -${z2}0  ${FILE_TAG}_temp0.prim  ${FILE_TAG}.prim
+  local z1=$(( ${zpos} + 100 ))
+  local z2=$(( ${zpos} - 100 ))
+  #dawncut 0 0 1 $(( 10 * ${z1} + 1 )) ${INPUT_FILE} ${FILE_TAG}_temp0.prim
+  #dawncut 0 0 -1 $(( -10 * ${z2} )) ${FILE_TAG}_temp0.prim  ${FILE_TAG}.prim
   ../../bin/dawn_tweak -z ${zpos}0 --draw 5
   #cp ${INPUT_FILE} ${FILE_TAG}.prim
   dawncut -1 0 0 0 ${INPUT_FILE} ${FILE_TAG}.prim


### PR DESCRIPTION
The current code depends on `-$zpos` to expand to a negated value of $zpos, which doesn't work for negative values.