### PR TITLE
hotfix: fix attempt to load non-existent far_forward/far_forward.xml

### DIFF
--- a/configurations/craterlake_no_bhcal.yml
+++ b/configurations/craterlake_no_bhcal.yml
@@ -30,6 +30,6 @@ features:
     backward:
     backward_endcap_flux:
   far_forward:
-    far_forward:
+    default:
   far_backward:
-    far_backward:
+    default:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes the [broken main CI pipelines](https://github.com/eic/epic/actions/runs/8462972314/job/23185174937#step:5:304) by ensuring that also epic_craterlake_no_bhcal conforms to the `far_forward:default:` syntax introduced in #679.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/epic/actions/runs/8462972314/job/23185174937#step:5:304)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.