### PR TITLE
feat: add barrel flux return

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -632,15 +632,16 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
 
     <constant name="LFHCAL_rmax"          value="HcalBarrel_rmax"/>
 
+    <comment> Lepton_Assy_21.stp, rwimmer, 2024-04-03 </comment>
     <constant name="FluxEndcapN_collar_rmax" value="326.2*cm"/>
-    <constant name="FluxEndcapN_collar_rmin" value="269.0*cm"/>
-    <constant name="FluxEndcapN_collar_thickness" value="120.4*cm"/>
-    <constant name="FluxEndcapN_oculus_rmax" value="267.0*cm"/>
-    <constant name="FluxEndcapN_oculus_rmin" value="213.6*cm"/>
+    <constant name="FluxEndcapN_collar_rmin" value="275.0*cm"/>
+    <constant name="FluxEndcapN_collar_thickness" value="120.38*cm"/>
+    <constant name="FluxEndcapN_oculus_rmax" value="FluxEndcapN_collar_rmin"/>
+    <constant name="FluxEndcapN_oculus_rmin" value="221.6*cm"/>
     <constant name="FluxEndcapN_oculus_thickness" value="28.5*cm"/>
-    <constant name="FluxEndcapN_rmax" value="267.0*cm"/>
-    <constant name="FluxEndcapN_rmin" value="14*cm"/>
-    <constant name="FluxEndcapN_thickness" value="10*cm"/>
+    <constant name="FluxEndcapN_exterior_rmax" value="FluxEndcapN_collar_rmin*cm"/>
+    <constant name="FluxEndcapN_exterior_rmin" value="16*cm"/>
+    <constant name="FluxEndcapN_exterior_thickness" value="10*cm"/>
 
     <comment> Hadron End Cap Assembly_North Half.stp, rwimmer, 2024-04-03 </comment>
     <constant name="FluxEndcapP_collar_rmax" value="326.2*cm"/>

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -630,8 +630,6 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
 
     <constant name="HcalEndcapN_rmax"     value="min(HcalBarrel_rmax, 267.0 * cm)"/>
 
-    <constant name="LFHCAL_rmax"          value="HcalBarrel_rmax"/>
-
     <comment> Lepton_Assy_21.stp, rwimmer, 2024-04-03 </comment>
     <constant name="FluxEndcapN_collar_rmax" value="326.2*cm"/>
     <constant name="FluxEndcapN_collar_rmin" value="275.0*cm"/>
@@ -650,6 +648,9 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="FluxEndcapP_oculus_rmax" value="FluxEndcapP_collar_rmin"/>
     <constant name="FluxEndcapP_oculus_rmin" value="210.0*cm"/>
     <constant name="FluxEndcapP_oculus_thickness" value="22.2*cm"/>
+
+    <comment> LFHCAL includes support, which is part of the flux return </comment>
+    <constant name="LFHCAL_rmax" value="FluxEndcapP_collar_rmin"/>
 
     <constant name="FluxBarrelForward_zmax"  value="320*cm"/>
     <constant name="FluxBarrelBackward_zmax" value="FluxBarrelForward_zmax"/>

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -652,6 +652,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <comment> LFHCAL includes support, which is part of the flux return </comment>
     <constant name="LFHCAL_rmax" value="FluxEndcapP_collar_rmin"/>
 
+    <comment> STAR Asm for EPIC w cradle.stp, rwimmer, 2024-04-03 </comment>
     <constant name="FluxBarrelForward_zmax"  value="320*cm"/>
     <constant name="FluxBarrelBackward_zmax" value="FluxBarrelForward_zmax"/>
     <constant name="FluxBarrel_thickness"    value="62.5*cm"/> <!-- for envelope only -->

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -642,11 +642,12 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="FluxEndcapN_rmin" value="14*cm"/>
     <constant name="FluxEndcapN_thickness" value="10*cm"/>
 
+    <comment> Hadron End Cap Assembly_North Half.stp, rwimmer, 2024-04-03 </comment>
     <constant name="FluxEndcapP_collar_rmax" value="326.2*cm"/>
-    <constant name="FluxEndcapP_collar_rmin" value="269.0*cm"/>
-    <constant name="FluxEndcapP_collar_thickness" value="170.0*cm"/>
-    <constant name="FluxEndcapP_oculus_rmax" value="267.0*cm"/>
-    <constant name="FluxEndcapP_oculus_rmin" value="195.0*cm"/>
+    <constant name="FluxEndcapP_collar_rmin" value="289.56*cm"/>
+    <constant name="FluxEndcapP_collar_thickness" value="167.14*cm"/>
+    <constant name="FluxEndcapP_oculus_rmax" value="FluxEndcapP_collar_rmin"/>
+    <constant name="FluxEndcapP_oculus_rmin" value="210.0*cm"/>
     <constant name="FluxEndcapP_oculus_thickness" value="22.2*cm"/>
 
     <constant name="FluxBarrelForward_zmax"  value="320*cm"/>

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -642,6 +642,13 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="FluxEndcapN_rmin" value="14*cm"/>
     <constant name="FluxEndcapN_thickness" value="10*cm"/>
 
+    <constant name="FluxEndcapP_collar_rmax" value="326.2*cm"/>
+    <constant name="FluxEndcapP_collar_rmin" value="269.0*cm"/>
+    <constant name="FluxEndcapP_collar_thickness" value="170.0*cm"/>
+    <constant name="FluxEndcapP_oculus_rmax" value="267.0*cm"/>
+    <constant name="FluxEndcapP_oculus_rmin" value="195.0*cm"/>
+    <constant name="FluxEndcapP_oculus_thickness" value="22.2*cm"/>
+
     <comment>
       These are used by ddsim, the region where we store all secondaries
 

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -649,6 +649,14 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="FluxEndcapP_oculus_rmin" value="195.0*cm"/>
     <constant name="FluxEndcapP_oculus_thickness" value="22.2*cm"/>
 
+    <constant name="FluxBarrelForward_zmax"  value="320*cm"/>
+    <constant name="FluxBarrelBackward_zmax" value="FluxBarrelForward_zmax"/>
+    <constant name="FluxBarrel_thickness"    value="62.5*cm"/> <!-- for envelope only -->
+    <constant name="FluxBarrel_rmin"         value="273.05*cm"/>
+    <constant name="FluxBarrel_rmax"         value="FluxBarrel_rmin + FluxBarrel_thickness"/>
+    <constant name="FluxBarrel_length"       value="FluxBarrelForward_zmax + FluxBarrelBackward_zmax"/>
+    <constant name="FluxBarrel_offset"       value="(FluxBarrelForward_zmax - FluxBarrelBackward_zmax)/2.0"/>
+
     <comment>
       These are used by ddsim, the region where we store all secondaries
 

--- a/compact/display.xml
+++ b/compact/display.xml
@@ -107,6 +107,7 @@
     <vis name="HcalEndcapInsertVis"   ref="AnlGray"   showDaughters="false" visible="true"/>
     <vis name="LFHCALVis"             ref="AnlBlue"   showDaughters="true"  visible="true"/>
     <vis name="FluxBarrelVis"         ref="AnlGray"   showDaughters="true"  visible="false"/>
+    <vis name="FluxBarrelElementVis"  ref="AnlViolet" showDaughters="false" visible="true"/>
     <vis name="FluxEndcapNVis"        ref="AnlGray"   showDaughters="true"  visible="false"/>
     <vis name="FluxEndcapNLayerVis"   ref="AnlViolet" showDaughters="false" visible="true"/>
     <vis name="FluxEndcapPVis"        ref="AnlGray"   showDaughters="true"  visible="false"/>

--- a/compact/display.xml
+++ b/compact/display.xml
@@ -108,6 +108,8 @@
     <vis name="LFHCALVis"             ref="AnlBlue"   showDaughters="true" visible="true"/>
     <vis name="FluxEndcapNVis"        ref="AnlGray"   showDaughters="true" visible="false"/>
     <vis name="FluxEndcapNLayerVis"   ref="AnlViolet" showDaughters="false" visible="true"/>
+    <vis name="FluxEndcapPVis"        ref="AnlGray"   showDaughters="true"  visible="false"/>
+    <vis name="FluxEndcapPLayerVis"   ref="AnlViolet" showDaughters="false" visible="true"/>
     <comment>
       Passive steel for flux return
     </comment>

--- a/compact/display.xml
+++ b/compact/display.xml
@@ -105,8 +105,9 @@
     <vis name="HcalSensorVis"         ref="AnlBlue"   showDaughters="false" visible="false"/>
     <vis name="HcalAbsorberVis"       ref="AnlGray"   showDaughters="false" visible="false"/>
     <vis name="HcalEndcapInsertVis"   ref="AnlGray"   showDaughters="false" visible="true"/>
-    <vis name="LFHCALVis"             ref="AnlBlue"   showDaughters="true" visible="true"/>
-    <vis name="FluxEndcapNVis"        ref="AnlGray"   showDaughters="true" visible="false"/>
+    <vis name="LFHCALVis"             ref="AnlBlue"   showDaughters="true"  visible="true"/>
+    <vis name="FluxBarrelVis"         ref="AnlGray"   showDaughters="true"  visible="false"/>
+    <vis name="FluxEndcapNVis"        ref="AnlGray"   showDaughters="true"  visible="false"/>
     <vis name="FluxEndcapNLayerVis"   ref="AnlViolet" showDaughters="false" visible="true"/>
     <vis name="FluxEndcapPVis"        ref="AnlGray"   showDaughters="true"  visible="false"/>
     <vis name="FluxEndcapPLayerVis"   ref="AnlViolet" showDaughters="false" visible="true"/>

--- a/compact/hcal/backward_endcap_flux.xml
+++ b/compact/hcal/backward_endcap_flux.xml
@@ -15,9 +15,9 @@
   <!-- Define detector -->
   <detectors>
     <documentation>
-      ### Backwards (Negative Z) Endcap Flux Return
+      ### Backward (Negative Z) Endcap Flux Return
     </documentation>
-    <detector name="FluxEndcapN" type="epic_EndcapFluxReturnN" vis="FluxEndcapNVis">
+    <detector name="FluxEndcapN" type="epic_EndcapFluxReturn" vis="FluxEndcapNVis" reflect="true">
       <position x="0" y="0" z="-FluxEndcapN_zmin"/>
 
        <layer id="1" name="Collar" material="Steel235"

--- a/compact/hcal/backward_endcap_flux.xml
+++ b/compact/hcal/backward_endcap_flux.xml
@@ -6,7 +6,7 @@
     <documentation>
       #### Dimension constants
     </documentation>
-    <constant name="FluxEndcapN_zshift" value="FluxEndcapN_collar_thickness-FluxEndcapN_thickness"/>
+    <constant name="FluxEndcapN_zshift" value="FluxEndcapN_collar_thickness-FluxEndcapN_exterior_thickness"/>
     <constant name="FluxEndcapN_zmin" value="BackwardServiceGap_zmax"/>
 
   </define>
@@ -29,8 +29,8 @@
         thickness="FluxEndcapN_oculus_thickness" vis="FluxEndcapNLayerVis"
        />
        <layer id="3" name="FluxReturn" material="Steel235"
-        rmin="FluxEndcapN_rmin" rmax="FluxEndcapN_rmax" zpos="FluxEndcapN_zshift"
-        thickness="FluxEndcapN_thickness" vis="FluxEndcapNLayerVis"
+        rmin="FluxEndcapN_exterior_rmin" rmax="FluxEndcapN_exterior_rmax" zpos="FluxEndcapN_zshift"
+        thickness="FluxEndcapN_exterior_thickness" vis="FluxEndcapNLayerVis"
        />
 
 

--- a/compact/hcal/barrel_flux_return.xml
+++ b/compact/hcal/barrel_flux_return.xml
@@ -1,0 +1,106 @@
+<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
+<!-- Copyright (C) 2023 Wouter Deconinck, Leszek Kosarzewski -->
+
+<lccdd>
+  <define>
+    <documentation>
+      #### Dimension constants
+    </documentation>
+    <constant name="FluxBarrel_repeat" value="30"/>
+    <constant name="FluxBarrel_dphi" value="360*deg / FluxBarrel_repeat"/>
+
+    <comment> Trapezoid for STAR backlegs </comment>
+    <constant name="FluxBarrel_Backleg_x" value="609.6*mm"/>
+    <constant name="FluxBarrel_Backleg_y1" value="444.5*mm"/>
+    <constant name="FluxBarrel_Backleg_y2" value="572.64*mm"/>
+    <constant name="FluxBarrel_Backleg_Regular_z" value="6316.2*mm"/>
+    <constant name="FluxBarrel_Backleg_Chimney_z" value="3616.2*mm"/>
+    <constant name="FluxBarrel_Backleg_Chimney_repeat" value="3"/>
+    <constant name="FluxBarrel_Backleg_Regular_repeat" value="FluxBarrel_repeat - FluxBarrel_Backleg_Chimney_repeat"/>
+
+    <comment> Box for spacers </comment>
+    <constant name="FluxBarrel_Spacer_x" value="612.96*mm"/>
+    <constant name="FluxBarrel_Spacer_y" value="128.76*mm"/>
+    <constant name="FluxBarrel_Spacer_Regular_z" value="FluxBarrel_Backleg_Regular_z"/>
+    <constant name="FluxBarrel_Spacer_Chimney_z" value="FluxBarrel_Backleg_Chimney_z"/>
+    <constant name="FluxBarrel_Spacer_Chimney_repeat" value="2"/>
+    <constant name="FluxBarrel_Spacer_Regular_repeat" value="FluxBarrel_repeat - FluxBarrel_Spacer_Chimney_repeat"/>
+  </define>
+
+  <!-- Define detector -->
+  <detectors>
+    <documentation>
+      ### Barrel Flux Return
+    </documentation>
+    <detector name="FluxBarrel" type="epic_BarrelFluxReturn" vis="FluxBarrelVis">
+      <dimensions
+        rmin="FluxBarrel_rmin"
+        rmax="FluxBarrel_rmax"
+        z="FluxBarrel_length"/>
+
+      <comment> Trd1 is defined such that x1/x2 are equivalent with y at phi = 0 </comment>
+      <shape name="FluxBarrel_Backleg_Regular"
+             type="Trd1"
+             z="FluxBarrel_Backleg_x/2"
+             x1="FluxBarrel_Backleg_y1/2"
+             x2="FluxBarrel_Backleg_y2/2"
+             y="FluxBarrel_Backleg_Regular_z/2"
+             material="Steel1008"/>
+      <replicate count="FluxBarrel_Backleg_Regular_repeat"
+                 shape="FluxBarrel_Backleg_Regular"
+                 dphi="FluxBarrel_dphi"
+                 phi0="90*deg + (FluxBarrel_Backleg_Chimney_repeat + 1) / 2 * FluxBarrel_dphi">
+        <rotation y="90*deg" z="90*deg"/>
+        <position x="FluxBarrel_rmin + FluxBarrel_Backleg_x/2"/>
+      </replicate>
+      <shape name="FluxBarrel_Backleg_Chimney"
+             type="Trd1"
+             z="FluxBarrel_Backleg_x/2"
+             x1="FluxBarrel_Backleg_y1/2"
+             x2="FluxBarrel_Backleg_y2/2"
+             y="FluxBarrel_Backleg_Chimney_z/2"
+             material="Steel1008"/>
+      <replicate count="FluxBarrel_Backleg_Chimney_repeat"
+                 shape="FluxBarrel_Backleg_Chimney"
+                 dphi="FluxBarrel_dphi"
+                 phi0="90*deg - (FluxBarrel_Backleg_Chimney_repeat - 1) / 2 * FluxBarrel_dphi">
+        <rotation y="90*deg" z="90*deg"/>
+        <position
+          x="FluxBarrel_rmin + FluxBarrel_Backleg_x/2"
+          z="(FluxBarrel_Backleg_Regular_z - FluxBarrel_Backleg_Chimney_z)/2"/>
+      </replicate>
+
+      <shape name="FluxBarrel_Spacer_Regular"
+             type="Box"
+             dx="FluxBarrel_Spacer_x/2"
+             dy="FluxBarrel_Spacer_y/2"
+             dz="FluxBarrel_Spacer_Regular_z/2"
+             material="Steel1008"/>
+      <replicate count="FluxBarrel_Spacer_Regular_repeat"
+                 shape="FluxBarrel_Spacer_Regular"
+                 dphi="FluxBarrel_dphi"
+                 phi0="90*deg + (FluxBarrel_Spacer_Chimney_repeat + 1) / 2 * FluxBarrel_dphi">
+        <position
+          x="FluxBarrel_rmin + FluxBarrel_Spacer_x/2"/>
+      </replicate>
+      <shape name="FluxBarrel_Spacer_Chimney"
+             type="Box"
+             dx="FluxBarrel_Spacer_x / 2"
+             dy="FluxBarrel_Spacer_y / 2"
+             dz="FluxBarrel_Spacer_Chimney_z / 2"
+             material="Steel1008"/>
+      <replicate
+          count="FluxBarrel_Spacer_Chimney_repeat"
+          shape="FluxBarrel_Spacer_Chimney"
+          dphi="FluxBarrel_dphi"
+          phi0="90*deg - (FluxBarrel_Spacer_Chimney_repeat - 1) / 2 * FluxBarrel_dphi">
+        <position
+          x="FluxBarrel_rmin + FluxBarrel_Spacer_x/2"
+          z="(FluxBarrel_Spacer_Regular_z - FluxBarrel_Spacer_Chimney_z)/2"/>
+      </replicate>
+
+    </detector>
+  </detectors>
+
+
+</lccdd>

--- a/compact/hcal/barrel_flux_return.xml
+++ b/compact/hcal/barrel_flux_return.xml
@@ -45,7 +45,8 @@
              x1="FluxBarrel_Backleg_y1/2"
              x2="FluxBarrel_Backleg_y2/2"
              y="FluxBarrel_Backleg_Regular_z/2"
-             material="Steel1008"/>
+             material="Steel1008"
+             vis="FluxBarrelElementVis"/>
       <replicate count="FluxBarrel_Backleg_Regular_repeat"
                  shape="FluxBarrel_Backleg_Regular"
                  dphi="FluxBarrel_dphi"
@@ -59,7 +60,8 @@
              x1="FluxBarrel_Backleg_y1/2"
              x2="FluxBarrel_Backleg_y2/2"
              y="FluxBarrel_Backleg_Chimney_z/2"
-             material="Steel1008"/>
+             material="Steel1008"
+             vis="FluxBarrelElementVis"/>
       <replicate count="FluxBarrel_Backleg_Chimney_repeat"
                  shape="FluxBarrel_Backleg_Chimney"
                  dphi="FluxBarrel_dphi"
@@ -75,7 +77,8 @@
              dx="FluxBarrel_Spacer_x/2"
              dy="FluxBarrel_Spacer_y/2"
              dz="FluxBarrel_Spacer_Regular_z/2"
-             material="Steel1008"/>
+             material="Steel1008"
+             vis="FluxBarrelElementVis"/>
       <replicate count="FluxBarrel_Spacer_Regular_repeat"
                  shape="FluxBarrel_Spacer_Regular"
                  dphi="FluxBarrel_dphi"
@@ -88,7 +91,8 @@
              dx="FluxBarrel_Spacer_x / 2"
              dy="FluxBarrel_Spacer_y / 2"
              dz="FluxBarrel_Spacer_Chimney_z / 2"
-             material="Steel1008"/>
+             material="Steel1008"
+             vis="FluxBarrelElementVis"/>
       <replicate
           count="FluxBarrel_Spacer_Chimney_repeat"
           shape="FluxBarrel_Spacer_Chimney"

--- a/compact/hcal/forward_endcap_flux.xml
+++ b/compact/hcal/forward_endcap_flux.xml
@@ -1,0 +1,35 @@
+<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
+<!-- Copyright (C) 2023 Wouter Deconinck, Leszek Kosarzewski -->
+
+<lccdd>
+  <define>
+    <documentation>
+      #### Dimension constants
+    </documentation>
+    <constant name="FluxEndcapP_zmin" value="ForwardServiceGap_zmax"/>
+
+  </define>
+
+
+  <!-- Define detector -->
+  <detectors>
+    <documentation>
+      ### Forward (Positive Z) Endcap Flux Return
+    </documentation>
+    <detector name="FluxEndcapP" type="epic_EndcapFluxReturn" vis="FluxEndcapPVis">
+      <position x="0" y="0" z="FluxEndcapP_zmin"/>
+
+       <layer id="1" name="Collar" material="Steel235"
+        rmin="FluxEndcapP_collar_rmin" rmax="FluxEndcapP_collar_rmax" zpos="0*cm"
+        thickness="FluxEndcapP_collar_thickness" vis="FluxEndcapPLayerVis"
+       />
+       <layer id="2" name="Oculus" material="Steel235"
+        rmin="FluxEndcapP_oculus_rmin" rmax="FluxEndcapP_oculus_rmax" zpos="0*cm"
+        thickness="FluxEndcapP_oculus_thickness" vis="FluxEndcapPLayerVis"
+       />
+
+    </detector>
+  </detectors>
+
+
+</lccdd>

--- a/compact/hcal/lfhcal.xml
+++ b/compact/hcal/lfhcal.xml
@@ -94,7 +94,12 @@
       <dimensions
         z="LFHCAL_length"
         rmin="20*cm"
-        rmax="LFHCAL_rmax"/>
+        rmax="LFHCAL_rmax"
+        x="3*EightM_OuterWidth"
+        y="6*EightM_OuterHeight"
+        x0="-FourM_OuterWidth"/>
+      <envelope material="Steel235"/>
+
       <eightmodule name="8MModule" vis= "LFHCAL8MModVis" repeat="0" >
         <dimensions
         width="EightM_OuterWidth"
@@ -231,7 +236,7 @@
         <position x="40*cm" y="-35*cm" z="0*cm"/>
         <position x="-30*cm" y="-45*cm" z="0*cm"/>
         <position x="30*cm" y="-45*cm" z="0*cm"/>
-        <position x="0*cm" y="-55*cm" z="0*cm"/>
+        <position x="0* cm" y="-55*cm" z="0*cm"/>
         <position x="10*cm" y="55*cm" z="0*cm"/>
         <position x="-50*cm" y="-25*cm" z="0*cm"/>
         <position x="50*cm" y="-25*cm" z="0*cm"/>

--- a/compact/hcal/lfhcal.xml
+++ b/compact/hcal/lfhcal.xml
@@ -236,7 +236,7 @@
         <position x="40*cm" y="-35*cm" z="0*cm"/>
         <position x="-30*cm" y="-45*cm" z="0*cm"/>
         <position x="30*cm" y="-45*cm" z="0*cm"/>
-        <position x="0* cm" y="-55*cm" z="0*cm"/>
+        <position x="0*cm" y="-55*cm" z="0*cm"/>
         <position x="10*cm" y="55*cm" z="0*cm"/>
         <position x="-50*cm" y="-25*cm" z="0*cm"/>
         <position x="50*cm" y="-25*cm" z="0*cm"/>

--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -74,6 +74,18 @@
     <fraction n=".002" ref="C"/>
     <fraction n=".005" ref="Mn"/>
   </material>
+  <material name="Steel1008">
+    <comment>
+      SAE AISI 1008 cold-rolled low-carbon steel
+      https://www.azom.com/article.aspx?ArticleID=6538
+    </comment>
+    <D value="7.85" unit="g/cm3"/>
+    <fraction n="0.994" ref="Fe"/>
+    <fraction n=".004" ref="Mn"/>
+    <fraction n=".001" ref="C"/>
+    <fraction n=".0005" ref="S"/>
+    <fraction n=".0005" ref="P"/>
+  </material>
   <material name="Aluminum5083">
     <D value="2.650" unit="g/cm3"/>
     <fraction n="0.94" ref="Al"/>

--- a/configurations/craterlake.yml
+++ b/configurations/craterlake.yml
@@ -28,6 +28,8 @@ features:
     lfhcal_with_space_for_insert:
     forward_insert:
     barrel_gdml:
+    barrel_flux_return:
+    forward_endcap_flux:
     backward:
     backward_endcap_flux:
   far_forward:

--- a/configurations/craterlake_10x100.yml
+++ b/configurations/craterlake_10x100.yml
@@ -27,6 +27,8 @@ features:
   hcal:
     lfhcal_with_space_for_insert:
     forward_insert:
+    forward_endcap_flux:
+    barrel_flux_return:
     barrel_gdml:
     backward:
     backward_endcap_flux:

--- a/configurations/craterlake_10x275.yml
+++ b/configurations/craterlake_10x275.yml
@@ -28,6 +28,8 @@ features:
     lfhcal_with_space_for_insert:
     forward_insert:
     barrel_gdml:
+    barrel_flux_return:
+    forward_endcap_flux:
     backward:
     backward_endcap_flux:
   far_forward:

--- a/configurations/craterlake_18x110_Au.yml
+++ b/configurations/craterlake_18x110_Au.yml
@@ -28,6 +28,8 @@ features:
     lfhcal_with_space_for_insert:
     forward_insert:
     barrel_gdml:
+    barrel_flux_return:
+    forward_endcap_flux:
     backward:
     backward_endcap_flux:
   far_forward:

--- a/configurations/craterlake_18x275.yml
+++ b/configurations/craterlake_18x275.yml
@@ -28,6 +28,8 @@ features:
     lfhcal_with_space_for_insert:
     forward_insert:
     barrel_gdml:
+    barrel_flux_return:
+    forward_endcap_flux:
     backward:
     backward_endcap_flux:
   far_forward:

--- a/configurations/craterlake_no_bhcal.yml
+++ b/configurations/craterlake_no_bhcal.yml
@@ -27,6 +27,8 @@ features:
   hcal:
     lfhcal_with_space_for_insert:
     forward_insert:
+    barrel_flux_return:
+    forward_endcap_flux:
     backward:
     backward_endcap_flux:
   far_forward:

--- a/src/BarrelFluxReturn_geo.cpp
+++ b/src/BarrelFluxReturn_geo.cpp
@@ -19,6 +19,7 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& description, xml_h e, [[m
   dd4hep::Material air = description.air();
   Tube env_solid(x_dim.rmin(), x_dim.rmax(), x_dim.z() / 2.0);
   Volume env_vol(x_det.nameStr() + "_env", env_solid, air);
+  env_vol.setVisAttributes(description.visAttributes(x_det.visStr()));
 
   // Create volume map
   std::map<std::string, dd4hep::Volume> volumes_by_name;
@@ -26,7 +27,9 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& description, xml_h e, [[m
     xml_comp_t x_shape = shape;
     Solid solid = xml::createShape(description, x_shape.typeStr(), shape);
     Material mat = description.material(x_shape.materialStr());
-    volumes_by_name[x_shape.nameStr()] = Volume(x_shape.nameStr(), solid, mat);
+    volumes_by_name[x_shape.nameStr()] =
+      Volume(x_shape.nameStr(), solid, mat)
+      .setVisAttributes(description.visAttributes(x_shape.visStr()));
   }
 
   // Replicate volumes

--- a/src/BarrelFluxReturn_geo.cpp
+++ b/src/BarrelFluxReturn_geo.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2024 Wouter Deconinck
+
+#include "DD4hep/DetFactoryHelper.h"
+#include "DD4hep/Printout.h"
+#include "XML/Utilities.h"
+
+using namespace dd4hep;
+
+static dd4hep::Ref_t create_detector(dd4hep::Detector& description, xml_h e, [[maybe_unused]] dd4hep::SensitiveDetector sens)
+{
+  xml_det_t x_det  = e;
+  xml_comp_t x_dim = x_det.dimensions();
+
+  // Create element
+  dd4hep::DetElement sdet(x_det.nameStr(), x_det.id());
+
+  // Create envelope
+  dd4hep::Material air = description.air();
+  Tube env_solid(x_dim.rmin(), x_dim.rmax(), x_dim.z() / 2.0);
+  Volume env_vol(x_det.nameStr() + "_env", env_solid, air);
+
+  // Create volume map
+  std::map<std::string, dd4hep::Volume> volumes_by_name;
+  for (xml_coll_t shape(e, _U(shape)); shape; ++shape) {
+    xml_comp_t x_shape = shape;
+    Solid solid = xml::createShape(description, x_shape.typeStr(), shape);
+    Material mat = description.material(x_shape.materialStr());
+    volumes_by_name[x_shape.nameStr()] = Volume(x_shape.nameStr(), solid, mat);
+  }
+
+  // Replicate volumes
+  for (xml_coll_t repl(e, _U(replicate)); repl; ++repl) {
+    xml_comp_t x_repl = repl;
+    Volume& vol = volumes_by_name[x_repl.attr<std::string>(_U(shape))];
+    Transform3D tf = xml::createTransformation(x_repl);
+    for (int i = 0; i < x_repl.count(); ++i) {
+      double phi = x_repl.phi0() + i * x_repl.attr<double>(_Unicode(dphi));
+      env_vol.placeVolume(vol, Transform3D(RotationZ(phi)) * tf);
+    }
+  }
+
+  // Get position and place volume
+  PlacedVolume pv = description.pickMotherVolume(sdet).placeVolume(env_vol);
+  sdet.setPlacement(pv);
+  return sdet;
+}
+
+DECLARE_DETELEMENT(epic_BarrelFluxReturn, create_detector)

--- a/src/EndcapFluxReturn_geo.cpp
+++ b/src/EndcapFluxReturn_geo.cpp
@@ -16,10 +16,9 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& description, xml_h e, [[m
   xml_det_t x_det    = e;
   int       det_id   = x_det.id();
   std::string    det_name = x_det.nameStr();
+  bool           reflect  = x_det.reflect(false);
   dd4hep::Material  air      = description.air();
   xml_comp_t x_pos  = x_det.position();
-
-
   dd4hep::Assembly     assembly(det_name);
   dd4hep::DetElement   sdet(det_name, det_id);
   dd4hep::PlacedVolume pv;
@@ -51,7 +50,7 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& description, xml_h e, [[m
     s_phv2.addPhysVolID("halfdisk", 1);
 
 
-    pv = assembly.placeVolume(disk, dd4hep::Position(0, 0, -layer_thickness/2-layer_zpos));
+    pv = assembly.placeVolume(disk, dd4hep::Position(0, 0, (reflect ? -1.0 : 1.0) * (layer_thickness/2 + layer_zpos)));
     pv.addPhysVolID("layer", layer_id);
     disk_ele.setPlacement(pv);
   }
@@ -63,4 +62,4 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& description, xml_h e, [[m
   return sdet;
 }
 
-DECLARE_DETELEMENT(epic_EndcapFluxReturnN, create_detector)
+DECLARE_DETELEMENT(epic_EndcapFluxReturn, create_detector)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds the barrel flux return backlegs and spacers per the info in #693. Needed for hall background radiation studies. Also adds forward endcap flux return.

![image](https://github.com/eic/epic/assets/4656391/162865d8-0b08-4ead-a33c-ade3a2dfc0df)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @ajentsch 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Not really for any detector behavior.