### PR TITLE
Added definitions_craterlake to ip6 configurations

### DIFF
--- a/configurations/ip6.yml
+++ b/configurations/ip6.yml
@@ -1,5 +1,7 @@
 features:
   beampipe:
+  tracking:
+    definitions_craterlake:
   far_forward:
     default:
   far_backward:

--- a/configurations/ip6_extended.yml
+++ b/configurations/ip6_extended.yml
@@ -1,5 +1,7 @@
 features:
   beampipe:
+  tracking:
+    definitions_craterlake:
   far_forward:
     default:
   far_backward:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The ip6 configurations were unable to be used to reconstruct tracks from the B0 surfaces without the DD4hep_SubdetectorAssembly which wraps around it which is defined in definitions_craterlake.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No