### PR TITLE
feat: install setup.sh as FHS compliant bin/thisepic.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,10 @@ configure_file(templates/setup.sh.in ${CMAKE_CURRENT_BINARY_DIR}/setup.sh @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/setup.sh
     DESTINATION ${CMAKE_INSTALL_PREFIX}
 )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/setup.sh
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    RENAME this${PROJECT_NAME}.sh
+)
 
 # install programs
 install(PROGRAMS bin/g4MaterialScan_to_csv


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Installing `setup.sh` in the prefix is not consistent with the linux filesystem hierarchy standard and leads to `/usr/local/setup.sh`. This PR installs `setup.sh` into e.g. `/usr/local/bin/thisepic.sh`, which is FHS compliant.

Next steps:
- Transition to using FHS location
- Add deprecation warning to old version (v24.MM++)
- Remove old version (v24.MM++)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Not yet, but recommended default changes.