### PR TITLE
Low 2 acts surfaces

### DIFF
--- a/bin/acts_geo_check
+++ b/bin/acts_geo_check
@@ -20,4 +20,11 @@ if [[ "$nlines" > "0" ]] ; then
   res="1"
 fi
 
+nlines=$(grep -in inconsistent ${logfile} | grep -in acts | wc -l)
+if [[ "$nlines" > "0" ]] ; then
+  echo " ACTS geometry error: "
+  grep -in inconsistent ${logfile} | grep -in acts
+  res="1"
+fi
+
 exit ${res}

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -314,8 +314,10 @@ The unused IDs below are saved for future use.
     <constant name="LumiSpecCAL_ID"          value="194"/>
     <constant name="LumiDirectPCAL_ID"       value="195"/>
 
-    <constant name="TaggerTracker_ID"        value="198"/>
-    <constant name="TaggerCalorimeter_ID"    value="199"/>
+    <constant name="TaggerSubAssembly_ID"      value="196"/>
+    <constant name="TaggerTrackerCompanion_ID" value="197"/>
+    <constant name="TaggerTracker_ID"          value="198"/>
+    <constant name="TaggerCalorimeter_ID"      value="199"/>
 
     <documentation>
 ## Detector Definition Parameters

--- a/compact/far_backward/taggers.xml
+++ b/compact/far_backward/taggers.xml
@@ -50,6 +50,8 @@
         <trackLayer  id="2" type="timepix" z="203*mm" sensor_thickness="400*um"/>
         <trackLayer  id="3" type="timepix" z="303*mm" sensor_thickness="400*um"/>
         <windowLayer id="1" type="window"  z="0*mm"   thickness="2*mm" material="CarbonFiber"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="12"/>
+        <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="12"/>
       </module>
       <module id="2"
         name="Tagger2"
@@ -62,11 +64,13 @@
         >
         <dimensions x="Tagger2_Width/2" y="Tagger2_Height/2" z="Tagger2_Length"/>
         <foilLayer   id="0" type="foil"    z="0*mm"   thickness="100*um" angle="70*deg"/>
-        <trackLayer  id="0" type="timepix" z="3*mm"   sensor_thickness="400*um"/>
-        <trackLayer  id="1" type="timepix" z="103*mm" sensor_thickness="400*um"/>
-        <trackLayer  id="2" type="timepix" z="203*mm" sensor_thickness="400*um"/>
-        <trackLayer  id="3" type="timepix" z="303*mm" sensor_thickness="400*um"/>
+        <trackLayer  id="4" type="timepix" z="3*mm"   sensor_thickness="400*um"/>
+        <trackLayer  id="5" type="timepix" z="103*mm" sensor_thickness="400*um"/>
+        <trackLayer  id="6" type="timepix" z="203*mm" sensor_thickness="400*um"/>
+        <trackLayer  id="7" type="timepix" z="303*mm" sensor_thickness="400*um"/>
         <windowLayer id="1" type="window"  z="0*mm"   thickness="2*mm" material="CarbonFiber"/>
+        <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="12"/>
+        <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="12"/>
       </module>
 
     </detector>
@@ -74,12 +78,6 @@
   </detectors>
 
 
-  <plugins>
-    <plugin name="DD4hep_ParametersPlugin">
-      <argument value="BackwardsTaggerStation"/>
-      <argument value="layer_pattern: str=Tagger_tracker_layer\d"/>
-    </plugin>
-  </plugins>
 
 
   <readouts>

--- a/compact/far_backward/taggers.xml
+++ b/compact/far_backward/taggers.xml
@@ -10,9 +10,20 @@
   </define>
 
   <detectors>
+    <detector
+      id="TaggerTrackerCompanion_ID"
+      name="TaggerTrackerCompanion"
+      type="epic_CompositeTracker"
+      actsType="endcap"
+      vis="TrackerSubAssemblyVis">
+      <type_flags type="DetType_TRACKER + DetType_ENDCAP"/>
+      <position x="0*cm" y="0*cm" z="+4*um" />
+    </detector>
 
     <comment> Main beamline vacuum volume spanning between B2BeR and Q3eR magnets</comment>
     <detector id="TaggerTracker_ID" name="BackwardsTaggerStation" type="BackwardsTagger" wall="Backwards_Box_Wall" lumi="true" vis="BeamPipeVis" readout="TaggerTrackerHits">
+    
+      <type_flags type="DetType_TRACKER + DetType_ENDCAP"/>
       <focus      x="Dipole_Focus_X"    y="Dipole_Focus_Y"    z="Dipole_Focus_Z" />
       <bounding   xmin="Vacuum_BB_MinX" xmax="Vacuum_BB_MaxX"
                   ymin="Vacuum_BB_MinY" ymax="Vacuum_BB_MaxY"
@@ -66,7 +77,7 @@
   <plugins>
     <plugin name="DD4hep_ParametersPlugin">
       <argument value="BackwardsTaggerStation"/>
-      <argument value="layer_pattern: str=Tagger\d"/>
+      <argument value="layer_pattern: str=Tagger_tracker_layer\d"/>
     </plugin>
   </plugins>
 

--- a/compact/far_forward/beampipe_hadron_B0.xml
+++ b/compact/far_forward/beampipe_hadron_B0.xml
@@ -10,7 +10,7 @@
 
   <detectors>
 
-    <detector id="BeamPipeB0_ID" name="BeamPipeB0" type="hadronDownstreamBeamPipe" vis="BeamPipeVis">
+    <detector id="BeamPipeB0_ID" name="BeamPipeB0" type="forwardBeamPipeBrazil" vis="BeamPipeVis">
       <position x="-0.165*m" y="0*m" z="6.4*m" />
       <rotation x="0*rad" y="0*rad" z="0*rad" />
     </detector>

--- a/compact/far_forward/roman_pots_eRD24_design.xml
+++ b/compact/far_forward/roman_pots_eRD24_design.xml
@@ -2,241 +2,238 @@
 <!-- Copyright (C) 2022 Alex Jentsch, Whitney Armstrong -->
 
 <lccdd>
-  <define>
-    <comment>
-      ---------------------------------
-      Roman Pots Implementation from eRD24 RD Effort
-      Author: Alex Jentsch
-      Date of first commit: June 15th, 2021
-      ---------------------------------
-    </comment>
+    <define>
+        <comment>
+            ---------------------------------
+            Roman Pots Implementation from eRD24 RD Effort
+            Author: Alex Jentsch
+            Date of first commit: June 15th, 2021
+            ---------------------------------
+        </comment>
 
-    <!-- Global "station" location, rotation, position information -->
+        <!-- Global "station" location, rotation, position information -->
 
-    <constant name="ForwardRomanPotStation1_zpos" value="26.0*m"/>
-    <constant name="ForwardRomanPotStation1_xpos" value="-0.8333878326*m"/>
-    <constant name="ForwardRomanPotStation2_zpos" value="28.0*m"/>
-    <constant name="ForwardRomanPotStation2_xpos" value="-0.924342804*m"/>
+        <constant name="ForwardRomanPotStation1_zpos" value="32547.3*mm"/>
+        <constant name="ForwardRomanPotStation1_xpos" value="-1131.19*mm"/>
+        <constant name="ForwardRomanPotStation2_zpos" value="34245.5*mm"/>
+        <constant name="ForwardRomanPotStation2_xpos" value="-1208.43*mm"/>
 
-    <constant name="ForwardRomanPotStation1_rotation" value="-0.047*rad"/>
-    <constant name="ForwardRomanPotStation2_rotation" value="-0.047*rad"/>
+        <constant name="ForwardRomanPotStation1_rotation" value="-0.04545*rad"/>
+        <constant name="ForwardRomanPotStation2_rotation" value="-0.04545*rad"/>
 
-    <constant name="ForwardRomanPotStation1_insertionPosition" value="0.0*cm"/>
-    <constant name="ForwardRomanPotStation2_insertionPosition" value="0.0*cm"/>
+        <constant name="ForwardRomanPotStation1_insertionPosition" value="0.0*cm"/>
+        <constant name="ForwardRomanPotStation2_insertionPosition" value="0.0*cm"/>
 
-    <!-- Module/layer information -->
-    <!-- Each module is simply a 3.2cm wide by 3.2cm tall square -->
+        <!-- Module/layer information -->
+        <!-- Each module is simply a 3.2cm wide by 3.2cm tall square -->
 
-    <!-- Module insertion positions -->
+        <!-- Module insertion positions -->
 
-    <constant name="ForwardRomanPotStation1_insertion_outer" value="3.2*cm"/>
-    <constant name="ForwardRomanPotStation2_insertion_outer" value="3.2*cm"/>
+        <constant name="ForwardRomanPotStation1_insertion_outer" value="3.2*cm"/>
+        <constant name="ForwardRomanPotStation2_insertion_outer" value="3.2*cm"/>
 
-    <!-- HIGH ACCEPTANCE VALUES -->
-
-    <constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
-    <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
-
-    <constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
-    <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
-
-
-    <!-- HIGH DIVERGENCE VALUES -->
-
-    <!--
-
-        <constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
-        <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
+        <!-- HIGH ACCEPTANCE VALUES -->
 
         <constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
         <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
 
-    -->
-
-    <!-- Each module is a sandwich of 1mm aluminum, 0.3mm air, 0.3mm silicon, 0.3mm inactive silicon, 0.3mm copper, and 1mm aluminum -->
-    <!-- Vacuum is between each module -->
-
-    <!-- module size -->
-
-    <constant name="ForwardRomanPot_ModuleWidth"  value="32.0*mm"/>
-    <constant name="ForwardRomanPot_ModuleHeight"   value="32.0*mm"/>
-
-    <!-- materials -->
-    <!-- <constant name="ForwardRomanPot_RFShieldMat"     value="StainlessSteel"/> -->
-    <!-- <constant name="ForwardRomanPot_LGADMat"         value="SiliconOxide"/>   -->
-    <!-- <constant name="ForwardRomanPot_ASICMat"         value="SiliconOxide"/>   -->
-    <!-- <constant name="ForwardRomanPot_ThermalStripMat" value="Copper"/>         -->
-
-    <!-- Thicknesses -->
-    <constant name="ForwardRomanPot_RFShieldThickness"          value="1.0*mm"/>
-    <constant name="ForwardRomanPot_LGADThickness"              value="0.3*mm"/>
-    <constant name="ForwardRomanPot_ASICThickness"              value="0.3*mm"/>
-    <constant name="ForwardRomanPot_ThermalStripThickness"      value="0.3*mm"/>
-    <constant name="ForwardRomanPot_ShieldingAirLayerThickness" value="0.3*mm"/>
-    <constant name="ForwardRomanPot_LayerSeparationThickness" value="1.0*cm"/>
-
-  </define>
+        <constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
+        <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
 
 
-  <detectors>
-    <detector id="ForwardRomanPot_Station_1_ID"
-      name="ForwardRomanPot_Station_1"
-      readout="ForwardRomanPotHits"
-      type="ip6_ForwardRomanPot"
-      insideTrackingVolume="true"
-      reflect="false" vis="FFTrackerVis">
-    <position x="ForwardRomanPotStation1_xpos" y="0" z="ForwardRomanPotStation1_zpos" />
-    <rotation x="0" y="ForwardRomanPotStation1_rotation" z="0" />
-    <module name="ModuleRP1" vis="FFTrackerShieldedModuleVis" nx="2" ny="2" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
-            <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
-            <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />
-            <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />
-            <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardRomanPot_LGADThickness" sensitive="true"/>
-            <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardRomanPot_ShieldingAirLayerThickness"/>
-            <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
-            <!--<module_component material="Vacuum"       thickness="ForwardRomanPot_LayerSeparationThickness"/>-->
-    </module>
-    <module_assembly name="Station1Top">
-      <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="(6*ForwardRomanPot_ModuleWidth)/2.0" y="ForwardRomanPotStation1_insertion_outer"/>
-      </array>
-      <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="ForwardRomanPotStation1_insertion_outer"/>
-      </array>
-      <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="0" y="ForwardRomanPotStation1_insertion_central"/>
-      </array>
-          <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
-      </array>
-          <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
-      </array>
-    </module_assembly>
-    <module_assembly name="Station1Bottom">
-      <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="(4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0" y="-ForwardRomanPotStation1_insertion_outer"/>
-      </array>
-      <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="-ForwardRomanPotStation1_insertion_outer"/>
-      </array>
-      <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="0" y="-ForwardRomanPotStation1_insertion_central"/>
-      </array>
-      <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
-      </array>
-      <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
-      </array>
-    </module_assembly>
+        <!-- HIGH DIVERGENCE VALUES -->
 
-    <layer id="1" vis="FFTrackerLayerVis">
-      <position x="0" y="0" z="0.0*cm"/>
-      <component assembly="Station1Top">
-        <position x="0" y="0" z="0.0*cm"/>
-      </component>
-      <component assembly="Station1Bottom">
-        <position x="0" y="0" z="0.0*cm"/>
-      </component>
-    </layer>
-    <layer id="2" vis="FFTrackerLayerVis">
-      <position x="0" y="0" z="0.0*cm"/>
-      <component assembly="Station1Top">
-        <position x="0" y="0" z="20.0*mm"/>
-      </component>
-      <component assembly="Station1Bottom">
-        <position x="0" y="0" z="20.0*mm"/>
-      </component>
-    </layer>
+        <comment>
 
-  </detector>
+            <constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
+            <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
 
-  <detector
-      id="ForwardRomanPot_Station_2_ID"
-      name="ForwardRomanPot_Station_2"
-      readout="ForwardRomanPotHits"
-      type="ip6_ForwardRomanPot"
-      insideTrackingVolume="true"
-      reflect="false"
-      vis="FFTrackerVis">
-      <position x="ForwardRomanPotStation2_xpos" y="0" z="ForwardRomanPotStation2_zpos" />
-    <rotation x="0" y="ForwardRomanPotStation1_rotation" z="0" />
-    <module name="Module1" vis="FFTrackerShieldedModuleVis" nx="2" ny="2" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
-            <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
-            <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />
-            <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />
-            <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardRomanPot_LGADThickness" sensitive="true"/>
-            <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardRomanPot_ShieldingAirLayerThickness"/>
-            <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
-    </module>
-    <module_assembly name="Station2Top">
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="(4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0" y="ForwardRomanPotStation1_insertion_outer"/>
-      </array>
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="ForwardRomanPotStation1_insertion_outer"/>
-      </array>
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="0" y="ForwardRomanPotStation1_insertion_central"/>
-      </array>
-      <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
-      </array>
-      <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
-      </array>
-    </module_assembly>
-    <module_assembly name="Station2Bottom">
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="(4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0" y="-ForwardRomanPotStation1_insertion_outer"/>
-      </array>
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="-ForwardRomanPotStation1_insertion_outer"/>
-      </array>
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="0" y="-ForwardRomanPotStation1_insertion_central"/>
-      </array>
-      <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
-      </array>
-      <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-        <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
-      </array>
-    </module_assembly>
+            <constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
+            <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
+
+        </comment>
+
+        <!-- Each module is a sandwich of 1mm aluminum, 0.3mm air, 0.3mm silicon, 0.3mm inactive silicon, 0.3mm copper, and 1mm aluminum -->
+        <!-- Vacuum is between each module -->
+
+        <!-- module size -->
+
+        <constant name="ForwardRomanPot_ModuleWidth"  value="32.0*mm"/>
+        <constant name="ForwardRomanPot_ModuleHeight"   value="32.0*mm"/>
+
+        <!-- materials -->
+        <!-- <constant name="ForwardRomanPot_RFShieldMat"     value="StainlessSteel"/> -->
+        <!-- <constant name="ForwardRomanPot_LGADMat"         value="SiliconOxide"/>   -->
+        <!-- <constant name="ForwardRomanPot_ASICMat"         value="SiliconOxide"/>   -->
+        <!-- <constant name="ForwardRomanPot_ThermalStripMat" value="Copper"/>         -->
+
+        <!-- Thicknesses -->
+        <constant name="ForwardRomanPot_RFShieldThickness"          value="1.0*mm"/>
+        <constant name="ForwardRomanPot_LGADThickness"              value="0.3*mm"/>
+        <constant name="ForwardRomanPot_ASICThickness"              value="0.3*mm"/>
+        <constant name="ForwardRomanPot_ThermalStripThickness"      value="0.3*mm"/>
+        <constant name="ForwardRomanPot_ShieldingAirLayerThickness" value="0.3*mm"/>
+        <constant name="ForwardRomanPot_LayerSeparationThickness" value="1.0*cm"/>
+
+    </define>
 
 
-    <layer id="1" vis="FFTrackerLayerVis">
-      <position x="0" y="0" z="0.0*cm"/>
-      <component assembly="Station2Top">
-        <position x="0" y="0" z="0.0*cm"/>
-      </component>
-      <component assembly="Station2Bottom">
-        <position x="0" y="0" z="0.0*cm"/>
-      </component>
-    </layer>
-    <layer id="2" vis="FFTrackerLayerVis">
-      <position x="0" y="0" z="0.0*cm"/>
-      <component assembly="Station2Top">
-        <position x="0" y="0" z="20.0*mm"/>
-      </component>
-      <component assembly="Station2Bottom">
-        <position x="0" y="0" z="20.0*mm"/>
-      </component>
-    </layer>
-  </detector>
+    <detectors>
+        <detector
+                id="ForwardRomanPot_Station_1_ID"
+                name="ForwardRomanPot_Station_1"
+                readout="ForwardRomanPotHits"
+                type="ip6_ForwardRomanPot"
+                insideTrackingVolume="true"
+                reflect="false" vis="FFTrackerVis">
+            <position x="ForwardRomanPotStation1_xpos" y="0" z="ForwardRomanPotStation1_zpos" />
+            <rotation x="0" y="ForwardRomanPotStation1_rotation" z="0" />
+            <module name="ModuleRP1" vis="FFTrackerShieldedModuleVis" nx="2" ny="2" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
+                <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
+                <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />
+                <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />
+                <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardRomanPot_LGADThickness" sensitive="true"/>
+                <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardRomanPot_ShieldingAirLayerThickness"/>
+                <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
+                <!--<module_component material="Vacuum"       thickness="ForwardRomanPot_LayerSeparationThickness"/>-->
+            </module>
+            <module_assembly name="Station1Top">
+                <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="(6*ForwardRomanPot_ModuleWidth)/2.0" y="ForwardRomanPotStation1_insertion_outer"/>
+                </array>
+                <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="ForwardRomanPotStation1_insertion_outer"/>
+                </array>
+                <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="0" y="ForwardRomanPotStation1_insertion_central"/>
+                </array>
+                <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
+                </array>
+                <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
+                </array>
+            </module_assembly>
+            <module_assembly name="Station1Bottom">
+                <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="(4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0" y="-ForwardRomanPotStation1_insertion_outer"/>
+                </array>
+                <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="-ForwardRomanPotStation1_insertion_outer"/>
+                </array>
+                <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="0" y="-ForwardRomanPotStation1_insertion_central"/>
+                </array>
+                <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
+                </array>
+                <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
+                </array>
+            </module_assembly>
+
+            <layer id="1" vis="FFTrackerLayerVis">
+                <position x="0" y="0" z="0.0*cm"/>
+                <component assembly="Station1Top">
+                    <position x="0" y="0" z="0.0*cm"/>
+                </component>
+                <component assembly="Station1Bottom">
+                    <position x="0" y="0" z="0.0*cm"/>
+                </component>
+            </layer>
+            <layer id="2" vis="FFTrackerLayerVis">
+                <position x="0" y="0" z="0.0*cm"/>
+                <component assembly="Station1Top">
+                    <position x="0" y="0" z="20.0*mm"/>
+                </component>
+                <component assembly="Station1Bottom">
+                    <position x="0" y="0" z="20.0*mm"/>
+                </component>
+            </layer>
+
+        </detector>
+
+        <detector
+                id="ForwardRomanPot_Station_2_ID"
+                name="ForwardRomanPot_Station_2"
+                readout="ForwardRomanPotHits"
+                type="ip6_ForwardRomanPot"
+                insideTrackingVolume="true"
+                reflect="false"
+                vis="FFTrackerVis">
+            <position x="ForwardRomanPotStation2_xpos" y="0" z="ForwardRomanPotStation2_zpos" />
+            <rotation x="0" y="ForwardRomanPotStation1_rotation" z="0" />
+            <module name="Module1" vis="FFTrackerShieldedModuleVis" nx="2" ny="2" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
+                <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
+                <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />
+                <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />
+                <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardRomanPot_LGADThickness" sensitive="true"/>
+                <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardRomanPot_ShieldingAirLayerThickness"/>
+                <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
+            </module>
+            <module_assembly name="Station2Top">
+                <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="(4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0" y="ForwardRomanPotStation1_insertion_outer"/>
+                </array>
+                <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="ForwardRomanPotStation1_insertion_outer"/>
+                </array>
+                <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="0" y="ForwardRomanPotStation1_insertion_central"/>
+                </array>
+                <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
+                </array>
+                <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
+                </array>
+            </module_assembly>
+            <module_assembly name="Station2Bottom">
+                <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="(4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0" y="-ForwardRomanPotStation1_insertion_outer"/>
+                </array>
+                <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="-ForwardRomanPotStation1_insertion_outer"/>
+                </array>
+                <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="0" y="-ForwardRomanPotStation1_insertion_central"/>
+                </array>
+                <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
+                </array>
+                <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                    <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
+                </array>
+            </module_assembly>
 
 
-</detectors>
+            <layer id="1" vis="FFTrackerLayerVis">
+                <position x="0" y="0" z="0.0*cm"/>
+                <component assembly="Station2Top">
+                    <position x="0" y="0" z="0.0*cm"/>
+                </component>
+                <component assembly="Station2Bottom">
+                    <position x="0" y="0" z="0.0*cm"/>
+                </component>
+            </layer>
+            <layer id="2" vis="FFTrackerLayerVis">
+                <position x="0" y="0" z="0.0*cm"/>
+                <component assembly="Station2Top">
+                    <position x="0" y="0" z="20.0*mm"/>
+                </component>
+                <component assembly="Station2Bottom">
+                    <position x="0" y="0" z="20.0*mm"/>
+                </component>
+            </layer>
+        </detector>
 
+    </detectors>
 
-
-
-  <readouts>
-    <readout name="ForwardRomanPotHits">
-      <segmentation type="CartesianGridXY" grid_size_x="0.5*mm" grid_size_y="0.5*mm" />
-      <id>system:8,assembly:3,layer:4,module:4,sensor:4,x:32:-16,y:-16</id>
-    </readout>
-  </readouts>
+    <readouts>
+        <readout name="ForwardRomanPotHits">
+            <segmentation type="CartesianGridXY" grid_size_x="0.5*mm" grid_size_y="0.5*mm" />
+            <id>system:8,assembly:3,layer:4,module:4,sensor:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
 
 </lccdd>

--- a/compact/tracking/definitions_craterlake.xml
+++ b/compact/tracking/definitions_craterlake.xml
@@ -186,6 +186,13 @@
       <composite name="B0Tracker"/>
       <composite name="B0TrackerCompanion"/>
     </detector>
+    <detector id="TaggerSubAssembly_ID"
+      name="TaggerSubAssembly"
+      type="DD4hep_SubdetectorAssembly"
+      vis="TrackerSubAssemblyVis">
+      <composite name="TaggerTrackerCompanion"/>
+      <composite name="BackwardsTaggerStation"/>
+    </detector>
   </detectors>
 
   <documentation>

--- a/src/BackwardsTaggers_geo.cpp
+++ b/src/BackwardsTaggers_geo.cpp
@@ -183,7 +183,8 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens)
       nAir++;
     }
 
-    Assembly TaggerAssembly("Tagger_module_assembly");
+    //Assembly TaggerAssembly("Tagger_module_assembly");
+    Assembly TaggerAssembly(moduleName);
 
     PlacedVolume pv_mod2 = mother.placeVolume(
         TaggerAssembly,
@@ -192,9 +193,24 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens)
     DetElement moddet(det,moduleName, moduleID);
     pv_mod2.addPhysVolID("module", moduleID);
     moddet.setPlacement(pv_mod2);
+    
+    auto &moduleParams = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(moddet);
+    moduleParams.set<string>("layer_pattern", "Tagger_tracker_layer\\d");
 
     Make_Tagger(desc, mod, TaggerAssembly, moddet, sens);
 
+    // //Loop through moddet checking the names of its children
+    // std::cout << "Children of " << moddet.name() << std::endl;
+    // for (auto child : moddet.children()) {
+    //   std::cout << child.first << std::endl;
+    // }
+
+  }
+
+  //Loop through det checking the names of its children
+  std::cout << "Children of " << det.name() << std::endl;
+  for (auto child : det.children()) {
+    std::cout << child.first << std::endl;
   }
 
   //-----------------------------------------------------------------
@@ -369,6 +385,11 @@ static void Make_Tagger(Detector& desc, xml_coll_t& mod, Assembly& env, DetEleme
     double layerZ         = dd4hep::getAttrOrDefault<double>(lay, _Unicode(z), 0 * mm);
     double layerThickness = dd4hep::getAttrOrDefault<double>(lay, _Unicode(sensor_thickness), 200 * um);
 
+    double envelope_r_min = dd4hep::getAttrOrDefault<double>(lay, _Unicode(envelope_r_min),  -1.0*mm);
+    double envelope_r_max = dd4hep::getAttrOrDefault<double>(lay, _Unicode(envelope_r_max),  1.0*mm);
+    double envelope_z_min = dd4hep::getAttrOrDefault<double>(lay, _Unicode(envelope_z_min),  -1.0*mm);
+    double envelope_z_max = dd4hep::getAttrOrDefault<double>(lay, _Unicode(envelope_z_max),  1.0*mm);
+
     Volume mother          = env;
     double MotherThickness = tagboxL;
 
@@ -382,31 +403,40 @@ static void Make_Tagger(Detector& desc, xml_coll_t& mod, Assembly& env, DetEleme
 
     Box    Layer_Box(tag_w, tag_h, layerThickness / 2);
 
-    std::string layerName = "Tagger_tracker_layer" + std::to_string(layerID) +"_N";
+    std::string layerName = "Tagger_tracker_layer" + std::to_string(layerID);
     Volume layVol(layerName, Layer_Box, Silicon);
     layVol.setSensitiveDetector(sens);
     layVol.setVisAttributes(desc.visAttributes(layerVis));
 
-
+    
     PlacedVolume pv_layer = mother.placeVolume(layVol, Transform3D(rotate, Position(0, 0, MotherThickness - layerZ + layerThickness / 2)));
     pv_layer.addPhysVolID("layer", layerID);
 
-    
-    std::cout << pv_layer.volume().name() << " " << layerID << std::endl;
     DetElement laydet(modElement,pv_layer.volume().name(), layerID);
 
     // -------- create a measurement plane for the tracking surface attched to the sensitive volume -----
     Vector3D u(-1., 0., 0.);
-    Vector3D v(0., -1., 0.);
-    Vector3D n(0., 0., 1.);
+    Vector3D v( 0.,-1., 0.);
+    Vector3D n( 0., 0., 1.);
 
     // Add surface to layer for acts reconstruction 
     SurfaceType type(SurfaceType::Sensitive);
 
+    layVol->GetShape()->ComputeBBox();
     auto &layerParams = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(laydet);
     layerParams.set<string>("axis_definitions", "XZY");
+    layerParams.set<double>("envelope_r_min", envelope_r_min);
+    layerParams.set<double>("envelope_r_max", envelope_r_max);
+    layerParams.set<double>("envelope_z_min", envelope_z_min);
+    layerParams.set<double>("envelope_z_max", envelope_z_max);
 
-    VolPlane surf(layVol, type, 1.0, 1.0, u, v, n); //,o ) ;
+    for (xml_coll_t lmat(mod, _Unicode(layer_material)); lmat; ++lmat) {
+      xml_comp_t x_layer_material = lmat;
+      DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(x_layer_material, layerParams, "layer_material");
+    }
+
+
+    VolPlane surf(layVol, type, 1.0, 2.0, u, v, n); //,o ) ;
     volSurfaceList(laydet)->push_back(surf);
 
     laydet.setPlacement(pv_layer);

--- a/src/forwardBeamPipeBrazil.cpp
+++ b/src/forwardBeamPipeBrazil.cpp
@@ -1,0 +1,499 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2024 Alex Jentsch
+
+#include "DD4hep/DetFactoryHelper.h"
+#include "DD4hep/Printout.h"
+#include "TMath.h"
+#include <XML/Helper.h>
+
+using namespace std;
+using namespace dd4hep;
+
+static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens */)
+{
+
+    using namespace ROOT::Math;
+    xml_det_t x_det    = e;
+    string    det_name = x_det.nameStr();
+    DetElement sdet(det_name, x_det.id());
+    Assembly   assembly(det_name + "_assembly");
+    Material m_Al     = det.material("Aluminum");
+    Material m_Be     = det.material("Beryllium");
+    Material m_SS     = det.material("StainlessSteel");
+    Material m_vac    = det.material("Vacuum");
+    string   vis_name = x_det.visStr();
+
+    PlacedVolume pv_assembly;
+
+    double b0_hadron_tube_inner_r = 2.9 * dd4hep::cm;
+    double b0_hadron_tube_outer_r = 3.1 * dd4hep::cm;
+    double b0_hadron_tube_length  = 120.0 * dd4hep::cm;
+
+    double pipeThickness     = 5.0 * dd4hep::mm;
+
+    struct beampipe_dimensions_t {
+        Double_t length = 0.0;
+        Double_t innerXRadius = 0.0;
+        Double_t innerYRadius = 0.0;
+        Double_t outerXRadius = 0.0;
+        Double_t outerYRadius = 0.0;
+        Double_t xCenter = 0.0;
+        Double_t yCenter = 0.0;
+        Double_t zCenter = 0.0;
+        Double_t rotationAngle = 0.0;
+    };
+
+    std::vector<beampipe_dimensions_t> beampipe_dimensions;
+
+    double globRotationAngle = -0.0454486856; //This is the angle of the proton orbit from the end of B1APF to the beginning of B2PF
+    double crossingAngle     = -0.025; //relevant for the neutral cone
+
+    double b1APFEndPoint_z = 22062.3828 * dd4hep::mm; //location of proton orbit at b1APF exit -- in mm
+    double b1APFEndPoint_x = 654.3372 * dd4hep::mm; //location of proton orbit at b1APF exit -- in mm
+
+    double tmp_endpoint_z = 0.0;
+    double tmp_endpoint_x = 0.0;
+
+    //forumula -> Z = b1APFEndPoint_z+((0.5*elementLengt)*Cos(globRotationAngle))
+    //forumula -> X = b1APFEndPoint_z+((0.5*elementLengt)*Sin(globRotationAngle))
+
+    //------------------------------------------------------------------------------------
+    //Geometry extracted from version 0 VPC drawings shown at the FF preliminary
+    //design review in February 2024 -- CAD model not available as of April 1st, 2024
+    //------------------------------------------------------------------------------------
+
+    //------------------------------------------------------------------------------------
+    //primary pipe after B1APF, before neutral exit window + transition to smaller pipe
+    //rectangular cross-section!!!!!
+    //------------------------------------------------------------------------------------
+
+
+    beampipe_dimensions.push_back({
+        .length            = 7615.486 * dd4hep::mm, //from VPC drawings, in mm
+        .innerXRadius      = 275.0 * dd4hep::mm,
+        .innerYRadius      = 175.0 * dd4hep::mm,
+        .rotationAngle     = globRotationAngle
+    });
+
+    beampipe_dimensions[0].outerXRadius      = beampipe_dimensions[0].innerXRadius + pipeThickness;
+    beampipe_dimensions[0].outerYRadius      = beampipe_dimensions[0].innerYRadius + pipeThickness;
+    beampipe_dimensions[0].xCenter           = -1*(b1APFEndPoint_x+((0.5*beampipe_dimensions[0].length)*TMath::Sin(-globRotationAngle)));
+    beampipe_dimensions[0].yCenter           = 0.0;
+    beampipe_dimensions[0].zCenter           = (b1APFEndPoint_z+((0.5*beampipe_dimensions[0].length)*TMath::Cos(-globRotationAngle)));
+
+    tmp_endpoint_z = beampipe_dimensions[0].zCenter+((0.5*beampipe_dimensions[0].length)*TMath::Cos(-globRotationAngle));
+    tmp_endpoint_x = -1*beampipe_dimensions[0].xCenter+((0.5*beampipe_dimensions[0].length)*TMath::Sin(-globRotationAngle));
+
+    double windowRadius = 110.0 * dd4hep::mm;
+
+
+    //------------------------------------------------------------------------------------
+    //first small pipe section, between primary vessel and RP station 1
+    //rectangular cross-section!!!!!
+    //------------------------------------------------------------------------------------
+
+    beampipe_dimensions.push_back({
+        .length            = 2780.273 * dd4hep::mm, // from VPC drawings
+        .innerXRadius      = 150.0 * dd4hep::mm,
+        .innerYRadius      = 30.0 * dd4hep::mm,
+        .rotationAngle     = globRotationAngle
+    });
+
+    beampipe_dimensions[1].outerXRadius      = beampipe_dimensions[1].innerXRadius + pipeThickness;
+    beampipe_dimensions[1].outerYRadius      = beampipe_dimensions[1].innerYRadius + pipeThickness;
+    beampipe_dimensions[1].xCenter           = -1*(tmp_endpoint_x+((0.5*beampipe_dimensions[1].length)*TMath::Sin(-globRotationAngle)));
+    beampipe_dimensions[1].yCenter           = 0.0;
+    beampipe_dimensions[1].zCenter           = tmp_endpoint_z+((0.5*beampipe_dimensions[1].length)*TMath::Cos(-globRotationAngle));
+
+    tmp_endpoint_z = beampipe_dimensions[1].zCenter+((0.5*beampipe_dimensions[1].length)*TMath::Cos(-globRotationAngle));
+    tmp_endpoint_x = -1*beampipe_dimensions[1].xCenter+((0.5*beampipe_dimensions[1].length)*TMath::Sin(-globRotationAngle));
+
+    //------------------------------------------------------------------------------------
+    //First roman pots scattering chamber
+    //------------------------------------------------------------------------------------
+
+    beampipe_dimensions.push_back({
+        .length            = 200 * dd4hep::mm, // from VPC drawings
+        .innerXRadius      = 200.0 * dd4hep::mm,
+        .innerYRadius      = 125.0 * dd4hep::mm,
+        .rotationAngle     = globRotationAngle
+    });
+
+    beampipe_dimensions[2].outerXRadius      = beampipe_dimensions[2].innerXRadius + pipeThickness;
+    beampipe_dimensions[2].outerYRadius      = beampipe_dimensions[2].innerYRadius + pipeThickness;
+    beampipe_dimensions[2].xCenter           = -1*(tmp_endpoint_x+((0.5*beampipe_dimensions[2].length)*TMath::Sin(-globRotationAngle)));
+    beampipe_dimensions[2].yCenter           = 0.0;
+    beampipe_dimensions[2].zCenter           = tmp_endpoint_z+((0.5*beampipe_dimensions[2].length)*TMath::Cos(-globRotationAngle));
+
+    tmp_endpoint_z = beampipe_dimensions[2].zCenter+((0.5*beampipe_dimensions[2].length)*TMath::Cos(-globRotationAngle));
+    tmp_endpoint_x = -1*beampipe_dimensions[2].xCenter+((0.5*beampipe_dimensions[2].length)*TMath::Sin(-globRotationAngle));
+
+    //------------------------------------------------------------------------------------
+    //pipe between RP 1 and RP 2 stations
+    //rectangular cross-section!!!!!
+    //------------------------------------------------------------------------------------
+
+
+    beampipe_dimensions.push_back({
+        .length            = 1500.0 * dd4hep::mm, // from VPC drawings
+        .innerXRadius      = 150.0 * dd4hep::mm,
+        .innerYRadius      = 30.0 * dd4hep::mm,
+        .rotationAngle     = globRotationAngle
+    });
+
+    beampipe_dimensions[3].outerXRadius      = beampipe_dimensions[3].innerXRadius + pipeThickness;
+    beampipe_dimensions[3].outerYRadius      = beampipe_dimensions[3].innerYRadius + pipeThickness;
+    beampipe_dimensions[3].xCenter           = -1*(tmp_endpoint_x+((0.5*beampipe_dimensions[3].length)*TMath::Sin(-globRotationAngle)));
+    beampipe_dimensions[3].yCenter           = 0.0;
+    beampipe_dimensions[3].zCenter           = tmp_endpoint_z+((0.5*beampipe_dimensions[3].length)*TMath::Cos(-globRotationAngle));
+
+    tmp_endpoint_z = beampipe_dimensions[3].zCenter+((0.5*beampipe_dimensions[3].length)*TMath::Cos(-globRotationAngle));
+    tmp_endpoint_x = -1*beampipe_dimensions[3].xCenter+((0.5*beampipe_dimensions[3].length)*TMath::Sin(-globRotationAngle));
+
+    //------------------------------------------------------------------------------------
+    //second roman pots scattering chamber
+    //------------------------------------------------------------------------------------
+
+
+    beampipe_dimensions.push_back({
+        .length            = 200 * dd4hep::mm, // from VPC drawings
+        .innerXRadius      = 200.0 * dd4hep::mm,
+        .innerYRadius      = 125.0 * dd4hep::mm,
+        .rotationAngle     = globRotationAngle
+    });
+
+    beampipe_dimensions[4].outerXRadius      = beampipe_dimensions[4].innerXRadius + pipeThickness;
+    beampipe_dimensions[4].outerYRadius      = beampipe_dimensions[4].innerYRadius + pipeThickness;
+    beampipe_dimensions[4].xCenter           = -1*(tmp_endpoint_x+((0.5*beampipe_dimensions[4].length)*TMath::Sin(-globRotationAngle)));
+    beampipe_dimensions[4].yCenter           = 0.0;
+    beampipe_dimensions[4].zCenter           = tmp_endpoint_z+((0.5*beampipe_dimensions[4].length)*TMath::Cos(-globRotationAngle));
+
+    tmp_endpoint_z = beampipe_dimensions[4].zCenter+((0.5*beampipe_dimensions[4].length)*TMath::Cos(-globRotationAngle));
+    tmp_endpoint_x = -1*beampipe_dimensions[4].xCenter+((0.5*beampipe_dimensions[4].length)*TMath::Sin(-globRotationAngle));
+
+    //------------------------------------------------------------------------------------
+    // Pipe from second RP chamber to taper
+    //------------------------------------------------------------------------------------
+
+
+    beampipe_dimensions.push_back({
+        .length            = 100.0 * dd4hep::mm, // from VPC drawings
+        .innerXRadius      = 150.0 * dd4hep::mm,
+        .innerYRadius      = 30.0 * dd4hep::mm,
+        .rotationAngle     = globRotationAngle
+    });
+
+    beampipe_dimensions[5].outerXRadius      = beampipe_dimensions[5].innerXRadius + pipeThickness;
+    beampipe_dimensions[5].outerYRadius      = beampipe_dimensions[5].innerYRadius + pipeThickness;
+    beampipe_dimensions[5].xCenter           = -1*(tmp_endpoint_x+((0.5*beampipe_dimensions[5].length)*TMath::Sin(-globRotationAngle)));
+    beampipe_dimensions[5].yCenter           = 0.0;
+    beampipe_dimensions[5].zCenter           = tmp_endpoint_z+((0.5*beampipe_dimensions[5].length)*TMath::Cos(-globRotationAngle));
+
+    tmp_endpoint_z = beampipe_dimensions[5].zCenter+((0.5*beampipe_dimensions[5].length)*TMath::Cos(-globRotationAngle));
+    tmp_endpoint_x = -1*beampipe_dimensions[5].xCenter+((0.5*beampipe_dimensions[5].length)*TMath::Sin(-globRotationAngle));
+
+    //------------------------------------------------------------------------------------
+    // taper near ZDC
+    //------------------------------------------------------------------------------------
+
+
+    beampipe_dimensions.push_back({
+        .length            = 599.692 * dd4hep::mm, // from VPC drawings
+        .innerXRadius      = 150.0 * dd4hep::mm,
+        .innerYRadius      = 30.0 * dd4hep::mm,
+        .rotationAngle     = globRotationAngle
+
+    });
+
+    beampipe_dimensions[6].outerXRadius      = beampipe_dimensions[6].innerXRadius + pipeThickness;
+    beampipe_dimensions[6].outerYRadius      = beampipe_dimensions[6].innerYRadius + pipeThickness;
+    beampipe_dimensions[6].xCenter           = -1*(tmp_endpoint_x+((0.5*beampipe_dimensions[6].length)*TMath::Sin(-globRotationAngle)));
+    beampipe_dimensions[6].yCenter           = 0.0;
+    beampipe_dimensions[6].zCenter           = tmp_endpoint_z+((0.5*beampipe_dimensions[6].length)*TMath::Cos(-globRotationAngle));
+
+    tmp_endpoint_z = beampipe_dimensions[6].zCenter+((0.5*beampipe_dimensions[6].length)*TMath::Cos(-globRotationAngle));
+    tmp_endpoint_x = -1*beampipe_dimensions[6].xCenter+((0.5*beampipe_dimensions[6].length)*TMath::Sin(-globRotationAngle));
+
+    //------------------------------------------------------------------------------------
+    // pipe connecting taper to B2PF magnet, just past ZDC
+    //------------------------------------------------------------------------------------
+
+    //numbers here are not really correct for the full taper, just for the opening
+
+    beampipe_dimensions.push_back({
+        .length            = 3000.0 * dd4hep::mm, // from VPC drawings
+        .innerXRadius      = 35.0 * dd4hep::mm,
+        .innerYRadius      = 0.0,
+        .rotationAngle     = globRotationAngle
+    });
+
+    beampipe_dimensions[7].outerXRadius      = beampipe_dimensions[7].innerXRadius + pipeThickness;
+    beampipe_dimensions[7].outerYRadius      = beampipe_dimensions[7].innerYRadius + pipeThickness; //NOT USED HERE
+    beampipe_dimensions[7].xCenter           = -1*(tmp_endpoint_x+((0.5*beampipe_dimensions[7].length)*TMath::Sin(-globRotationAngle)));
+    beampipe_dimensions[7].yCenter           = 0.0;
+    beampipe_dimensions[7].zCenter           = tmp_endpoint_z+((0.5*beampipe_dimensions[7].length)*TMath::Cos(-globRotationAngle));
+
+
+    //------------------------------------------
+    //begin building main volumes here
+    //------------------------------------------
+
+    //-------------------------------------------------------------------
+
+    int pieceIdx = 0; //Larger, rectangular pipe transporting proton and neutral envelopes (neutral exit window and transfer to smaller proton line at the end)
+
+    Box pipeAfterB1APF_outer(beampipe_dimensions[pieceIdx].outerXRadius, beampipe_dimensions[pieceIdx].outerYRadius, beampipe_dimensions[pieceIdx].length/2);
+    Box pipeAfterB1APF_inner(beampipe_dimensions[pieceIdx].innerXRadius, beampipe_dimensions[pieceIdx].innerYRadius, (beampipe_dimensions[pieceIdx].length)/2);
+    Box pipeAfterB1APF_firstEndCap(beampipe_dimensions[pieceIdx].outerXRadius, beampipe_dimensions[pieceIdx].outerYRadius, 5.0/2.0);
+    Tube neutral_exit_window_cutout(0.0, windowRadius, 1.0); // 1.0cm thick
+    //FIXME: proton transfer window is done by hand right now - not a nicer way to do it until we get the CAD drawing
+    Box protonTransferWindow(155.0 * dd4hep::mm, beampipe_dimensions[1].outerYRadius, (5.0/2));
+
+    SubtractionSolid tmpAfterB1APF(pipeAfterB1APF_outer, pipeAfterB1APF_inner); //This gets rid of the inner portion of the pipe, but leaves the endcaps
+    tmpAfterB1APF = SubtractionSolid(tmpAfterB1APF, pipeAfterB1APF_firstEndCap, Position(0.0, 0.0, (-beampipe_dimensions[pieceIdx].length)/2));
+    tmpAfterB1APF = SubtractionSolid(tmpAfterB1APF, protonTransferWindow, Position((-120.0  * dd4hep::mm), 0.0, (beampipe_dimensions[pieceIdx].length)/2 ));
+    tmpAfterB1APF = SubtractionSolid(tmpAfterB1APF, neutral_exit_window_cutout, Position(160.0  * dd4hep::mm, 0.0, 0.5*beampipe_dimensions[pieceIdx].length));
+
+    Volume v_pipeAfterB1APF(Form("v_pipeAfterB1APF_%d", pieceIdx), tmpAfterB1APF, m_SS);
+    sdet.setAttributes(det, v_pipeAfterB1APF, x_det.regionStr(), x_det.limitsStr(), vis_name);
+
+    auto pv_pipe_0 = assembly.placeVolume(v_pipeAfterB1APF, Transform3D(RotationY(crossingAngle), Position(beampipe_dimensions[pieceIdx].xCenter + 4.0,  beampipe_dimensions[pieceIdx].yCenter, beampipe_dimensions[pieceIdx].zCenter))); // 2353.06094)));
+    pv_pipe_0.addPhysVolID("sector", 1);
+    DetElement pipe_de_0(sdet, Form("sector_pipe_%d_de", pieceIdx), 1);
+    pipe_de_0.setPlacement(pv_pipe_0);
+
+    //--------------------------------------------------------------------
+
+    double lengthDelta = 0.0; //over-length value to remove end-pieces for hollow rectangular pipes
+
+    // 1 -- small pipe connecting big pipe to RP station 1
+    // 2 -- roman pots scattering chamber 1
+    // 3 -- small pipe connecting RP1 and RP2
+    // 4 -- roman pots scattering chamber 2
+    // 5 -- small pipe connecting RP2 to ZDC taper
+
+    lengthDelta = 5.0; //for small beam pipes to remove endcaps
+
+    for(int idx = 1; idx < 6; idx++){ //loop for the easier pieces to simplify
+
+        if(idx == 2 || idx == 4){ continue;}
+
+        Box outer(beampipe_dimensions[idx].outerXRadius, beampipe_dimensions[idx].outerYRadius, beampipe_dimensions[idx].length/2);
+        Box inner(beampipe_dimensions[idx].innerXRadius, beampipe_dimensions[idx].innerYRadius, (beampipe_dimensions[idx].length+lengthDelta)/2);
+
+        SubtractionSolid hollow_pipe(outer, inner);
+
+        Volume v_hollow_pipe(Form("v_pipe_%d", idx), hollow_pipe, m_SS);
+        sdet.setAttributes(det, v_hollow_pipe, x_det.regionStr(), x_det.limitsStr(), vis_name);
+
+        auto pv_final = assembly.placeVolume(v_hollow_pipe, Transform3D(RotationY(beampipe_dimensions[idx].rotationAngle), Position(beampipe_dimensions[idx].xCenter,  beampipe_dimensions[idx].yCenter, beampipe_dimensions[idx].zCenter)));
+        pv_final.addPhysVolID("sector", 1);
+        DetElement final_de(sdet, Form("sector_pipe_%d_de", idx), 1);
+        final_de.setPlacement(pv_final);
+
+    }
+
+    lengthDelta = 0.0; //not needed for scattering chambers
+
+    for(int idx = 1; idx < 6; idx++){ //loop for the easier pieces to simplify
+
+        if(idx == 1 || idx == 3 || idx == 5){ continue;}
+
+        Box outer(beampipe_dimensions[idx].outerXRadius, beampipe_dimensions[idx].outerYRadius, beampipe_dimensions[idx].length/2);
+        Box inner(beampipe_dimensions[idx].innerXRadius, beampipe_dimensions[idx].innerYRadius, (beampipe_dimensions[idx].length+lengthDelta)/2);
+                Box RP_subtract_outer(beampipe_dimensions[1].outerXRadius, beampipe_dimensions[1].outerYRadius, (beampipe_dimensions[2].length+5.0)/2);
+
+        SubtractionSolid hollow_pipe(outer, inner);
+        hollow_pipe = SubtractionSolid(hollow_pipe, RP_subtract_outer);
+
+        Volume v_hollow_pipe(Form("v_pipe_%d", idx), hollow_pipe, m_SS);
+        sdet.setAttributes(det, v_hollow_pipe, x_det.regionStr(), x_det.limitsStr(), vis_name);
+
+        auto pv_final = assembly.placeVolume(v_hollow_pipe, Transform3D(RotationY(beampipe_dimensions[idx].rotationAngle), Position(beampipe_dimensions[idx].xCenter,  beampipe_dimensions[idx].yCenter, beampipe_dimensions[idx].zCenter)));
+        pv_final.addPhysVolID("sector", 1);
+        DetElement final_de(sdet, Form("sector_pipe_%d_de", idx), 1);
+        final_de.setPlacement(pv_final);
+
+    }
+
+    //----------------------------------------------------------------
+
+    pieceIdx = 6;
+
+    Double_t trpVertices[16];
+    Double_t trpVerticesInner[16];
+    //(x0, y0, x1, y1, ... , x7, y7)
+    //opening side - larger size
+    trpVertices[0] =  -beampipe_dimensions[6].outerXRadius;
+    trpVertices[1] =  -beampipe_dimensions[6].outerYRadius;
+
+    trpVertices[2] = -beampipe_dimensions[6].outerXRadius;
+    trpVertices[3] = beampipe_dimensions[6].outerYRadius;
+
+    trpVertices[4] =  beampipe_dimensions[6].outerXRadius;
+    trpVertices[5] =  beampipe_dimensions[6].outerYRadius;
+
+    trpVertices[6] = beampipe_dimensions[6].outerXRadius;
+    trpVertices[7] = -beampipe_dimensions[6].outerYRadius;
+
+    //exiting side - smaller size
+
+    trpVertices[8] = -beampipe_dimensions[6].outerYRadius;
+    trpVertices[9] = -beampipe_dimensions[6].outerYRadius;
+
+    trpVertices[10] = -beampipe_dimensions[6].outerYRadius;
+    trpVertices[11] = beampipe_dimensions[6].outerYRadius;
+
+    trpVertices[12] = beampipe_dimensions[6].outerYRadius;
+    trpVertices[13] = beampipe_dimensions[6].outerYRadius;
+
+    trpVertices[14] = beampipe_dimensions[6].outerYRadius;
+    trpVertices[15] = -beampipe_dimensions[6].outerYRadius;
+
+    for(int i = 0; i < 16; i++){
+
+        if(trpVertices[i] > 0.0){trpVerticesInner[i] = trpVertices[i]-(pipeThickness);}
+        if(trpVertices[i] < 0.0){trpVerticesInner[i] = trpVertices[i]+(pipeThickness);}
+
+    }
+
+    EightPointSolid taper_outer((0.5*beampipe_dimensions[pieceIdx].length), trpVertices);
+    EightPointSolid taper_inner((0.5*beampipe_dimensions[pieceIdx].length), trpVerticesInner);
+
+    Box taper_entrance(beampipe_dimensions[pieceIdx].innerXRadius, beampipe_dimensions[pieceIdx].innerYRadius, (0.5*(pipeThickness + 5.0)));
+    Box taper_exit(beampipe_dimensions[pieceIdx].innerYRadius, beampipe_dimensions[pieceIdx].innerYRadius, (0.5*(pipeThickness + 5.0)));
+    SubtractionSolid hollowTaper(taper_outer, taper_inner);
+        hollowTaper = SubtractionSolid(hollowTaper, taper_entrance, Position(0.0, 0.0, (-0.5*beampipe_dimensions[pieceIdx].length)));
+    hollowTaper = SubtractionSolid(hollowTaper, taper_exit, Position(0.0, 0.0, (0.5*beampipe_dimensions[pieceIdx].length)));
+
+    Volume v_taper(Form("v_taper_%d", pieceIdx), hollowTaper, m_SS);
+    sdet.setAttributes(det, v_taper, x_det.regionStr(), x_det.limitsStr(), vis_name);
+
+    auto pv_pipe_6 = assembly.placeVolume(v_taper, Transform3D(RotationY(beampipe_dimensions[pieceIdx].rotationAngle), Position(beampipe_dimensions[pieceIdx].xCenter, beampipe_dimensions[pieceIdx].yCenter, beampipe_dimensions[pieceIdx].zCenter)));
+    pv_pipe_6.addPhysVolID("sector", 1);
+    DetElement pipe_de_6(sdet, Form("sector_pipe_%d_de", pieceIdx), 1);
+    pipe_de_6.setPlacement(pv_pipe_6);
+
+    //---------------------------------------------------------------
+
+    pieceIdx = 7; //pipe between taper and B2PF
+
+    Tube pipe_after_taper(beampipe_dimensions[pieceIdx].innerXRadius, beampipe_dimensions[pieceIdx].outerXRadius, beampipe_dimensions[pieceIdx].length/2);
+
+    Volume v_pipe_7(Form("v_pipe_7_%d", pieceIdx), pipe_after_taper, m_SS);
+    sdet.setAttributes(det, v_pipe_7, x_det.regionStr(), x_det.limitsStr(), vis_name);
+
+    auto pv_pipe_7 = assembly.placeVolume(v_pipe_7, Transform3D(RotationY(beampipe_dimensions[pieceIdx].rotationAngle), Position(beampipe_dimensions[pieceIdx].xCenter, beampipe_dimensions[pieceIdx].yCenter, beampipe_dimensions[pieceIdx].zCenter))); // 2353.06094)));
+    pv_pipe_7.addPhysVolID("sector", 1);
+    DetElement pipe_de_7(sdet, Form("sector_pipe_%d_de", pieceIdx), 1);
+    pipe_de_7.setPlacement(pv_pipe_7);
+
+
+    //--------------------------------------------------------------
+    // This is the beam tube in the B0 magnet for the hadron beam
+    // doesn't use the slope information calculated before - it stands alone
+
+    pieceIdx = 8;
+
+    Tube   b0_hadron_tube(b0_hadron_tube_inner_r, b0_hadron_tube_outer_r, b0_hadron_tube_length / 2.0);
+    Volume v_b0_hadron_tube("v_b0_hadron_tube", b0_hadron_tube, m_Be);
+    sdet.setAttributes(det, v_b0_hadron_tube, x_det.regionStr(), x_det.limitsStr(), vis_name);
+
+    auto pv_pipe_8 = assembly.placeVolume(v_b0_hadron_tube, Transform3D(RotationY(crossingAngle), Position(-16.5, 0.0, 640.0))); // 2353.06094)));
+    pv_pipe_8.addPhysVolID("sector", 1);
+    DetElement pipe_de_8(sdet, Form("sector_pipe_%d_de", pieceIdx), 1);
+    pipe_de_8.setPlacement(pv_pipe_6);
+
+    //----------------------------------------------------------------
+
+    pieceIdx = 9; //neutral exit window
+
+    Box pipeAfterB1APF_LARGE((beampipe_dimensions[0].outerXRadius+5.0), (beampipe_dimensions[0].outerYRadius+5.0), (beampipe_dimensions[0].length+5.0)/2);
+    Tube   neutral_exit_window(0.0, windowRadius, 1.0); // 1.0cm thick
+
+    IntersectionSolid finalWindow(pipeAfterB1APF_outer, neutral_exit_window, Position(160.0 * dd4hep::mm, 0.0, 0.5*beampipe_dimensions[0].length));
+
+    Volume v_neutral_exit_window("v_neutral_exit_window", finalWindow, m_Al);
+    sdet.setAttributes(det, v_neutral_exit_window, x_det.regionStr(), x_det.limitsStr(), "AnlRed");
+
+    auto pv_pipe_9 = assembly.placeVolume(v_neutral_exit_window, Transform3D(RotationY(crossingAngle), Position( beampipe_dimensions[0].xCenter + 4.0, 0.0, beampipe_dimensions[0].zCenter)));
+    pv_pipe_9.addPhysVolID("sector", 1);
+    DetElement pipe_de_9(sdet, Form("sector_pipe_%d_de", pieceIdx), 1);
+    pipe_de_9.setPlacement(pv_pipe_9);
+
+    //-----------------------------------------------------------------
+    // Build vacuum volumes here
+    //-----------------------------------------------------------------
+
+    pieceIdx = 0;
+
+    Box vacuum_main_pipe(beampipe_dimensions[pieceIdx].innerXRadius, beampipe_dimensions[pieceIdx].innerYRadius, (beampipe_dimensions[pieceIdx].length-2.0)/2);
+    Box cutout_for_OMD_station(beampipe_dimensions[pieceIdx].innerXRadius, beampipe_dimensions[pieceIdx].innerYRadius, 2.0);
+
+    SubtractionSolid final_vacuum_main_pipe(vacuum_main_pipe, cutout_for_OMD_station, Position(0.0, 0.0, (2251.0 - beampipe_dimensions[pieceIdx].zCenter)));
+    final_vacuum_main_pipe = SubtractionSolid(final_vacuum_main_pipe, cutout_for_OMD_station, Position(0.0, 0.0, (2451.0 - beampipe_dimensions[pieceIdx].zCenter)));
+
+    Volume v_vacuum_main_pipe("v_vacuum_main_pipe", final_vacuum_main_pipe, m_vac);
+    sdet.setAttributes(det, v_vacuum_main_pipe, x_det.regionStr(), x_det.limitsStr(), "AnlBlue");
+
+    auto pv_vacuum_0 = assembly.placeVolume(v_vacuum_main_pipe, Transform3D(RotationY(crossingAngle), Position( beampipe_dimensions[pieceIdx].xCenter + 4.0, 0.0, beampipe_dimensions[pieceIdx].zCenter)));
+    pv_vacuum_0.addPhysVolID("sector", 1);
+    DetElement vacuum_de_0(sdet, Form("sector_FF_vacuum_%d_de", pieceIdx), 1);
+    vacuum_de_0.setPlacement(pv_vacuum_0);
+
+    //------------------------------------------------------------------
+
+    for(int idx = 1; idx < 6; idx++){ //loop for the easier pieces to simplify
+
+        if(idx == 2 || idx == 4){ continue;} //FIXME: don't fill RP chambers with vacuum yet - still an issue with RP geometry
+
+        Box inner_vacuum(beampipe_dimensions[idx].innerXRadius, beampipe_dimensions[idx].innerYRadius, (beampipe_dimensions[idx].length)/2);
+
+        Volume v_inner_vacuum(Form("v_vacuum_%d", idx), inner_vacuum, m_vac);
+        sdet.setAttributes(det, v_inner_vacuum, x_det.regionStr(), x_det.limitsStr(), "AnlBlue");
+
+        auto pv_final = assembly.placeVolume(v_inner_vacuum, Transform3D(RotationY(beampipe_dimensions[idx].rotationAngle), Position(beampipe_dimensions[idx].xCenter,  beampipe_dimensions[idx].yCenter, beampipe_dimensions[idx].zCenter)));
+        pv_final.addPhysVolID("sector", 1);
+        DetElement final_de(sdet, Form("sector_FF_vacuum_%d_de", idx), 1);
+        final_de.setPlacement(pv_final);
+
+    }
+
+    //------------------------------------------------------------------
+
+    pieceIdx = 6;
+
+    EightPointSolid vacuum_taper((0.5*beampipe_dimensions[pieceIdx].length), trpVerticesInner);
+
+    Volume v_vacuum_taper("v_vacuum_taper", vacuum_taper, m_vac);
+    sdet.setAttributes(det, v_vacuum_taper, x_det.regionStr(), x_det.limitsStr(), "AnlBlue");
+
+    auto pv_vacuum_6 = assembly.placeVolume(v_vacuum_taper, Transform3D(RotationY(beampipe_dimensions[pieceIdx].rotationAngle), Position( beampipe_dimensions[pieceIdx].xCenter, 0.0,  beampipe_dimensions[pieceIdx].zCenter)));
+    pv_vacuum_6.addPhysVolID("sector", 1);
+    DetElement vacuum_de_6(sdet, Form("sector_FF_vacuum_%d_de", pieceIdx), 1);
+    vacuum_de_6.setPlacement(pv_vacuum_6);
+
+    //-------------------------------------------------------------------
+
+    pieceIdx = 7; //vacuum between taper and B2PF
+
+    Tube vacuum_pipe_after_taper(0.0, beampipe_dimensions[pieceIdx].innerXRadius, beampipe_dimensions[pieceIdx].length/2);
+
+    Volume v_vacuum_pipe_after_taper("v_vacuum_pipe_after_taper", vacuum_pipe_after_taper, m_vac);
+    sdet.setAttributes(det, v_vacuum_pipe_after_taper, x_det.regionStr(), x_det.limitsStr(), "AnlBlue");
+
+    auto pv_vacuum_7 = assembly.placeVolume(v_vacuum_pipe_after_taper, Transform3D(RotationY(beampipe_dimensions[pieceIdx].rotationAngle), Position(beampipe_dimensions[pieceIdx].xCenter, beampipe_dimensions[pieceIdx].yCenter, beampipe_dimensions[pieceIdx].zCenter)));
+    pv_vacuum_7.addPhysVolID("sector", 1);
+    DetElement vacuum_de_7(sdet, Form("sector_FF_vacuum_%d_de", pieceIdx), 1);
+    vacuum_de_7.setPlacement(pv_vacuum_7);
+
+    //-------------------------------------------------------------------
+
+    pv_assembly = det.pickMotherVolume(sdet).placeVolume(assembly);
+    pv_assembly.addPhysVolID("system", x_det.id()).addPhysVolID("barrel", 1);
+    sdet.setPlacement(pv_assembly);
+    assembly->GetShape()->ComputeBBox();
+    return sdet;
+}
+
+DECLARE_DETELEMENT(forwardBeamPipeBrazil, create_detector)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Introduces ACTS surfaces to the Low-Q2 tracker layers. Will allow acts methods to be used in the reconstruction but should almost certainly remain separate from the main tracking reconstruction.

I am currently going around in circles so am opening a draft PR to hopefully receive some advice on where I'm going wrong. Possibly it's an entirely ill fated attempt based which will need to be scrapped.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No