### PR TITLE
fix: export all configs to STEP, use `part --level 1 HcalBarrel`

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -287,9 +287,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - list-detector-configs
     strategy:
-      matrix:
-        detector_config: [epic_craterlake_no_bhcal, epic_craterlake_tracking_only, epic_dirc_only, epic_drich_only, epic_imaging_only, epic_ip6, epic_lfhcal_with_insert]
+      matrix: ${{fromJson(needs.list-detector-configs.outputs.configs_json)}}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
@@ -309,6 +309,7 @@ jobs:
           declare -A detectors
           while read d ; do detectors[$d]='-l 3' ; done <<< $(npdet_to_step list $DETECTOR_PATH/${{matrix.detector_config}}.xml  | sed '/world/d;s/.*(vol: \(.*\)).*/\1/g')
           # Then tweak the levels (default is 1)
+          detectors[HcalBarrel]='-l 1'
           detectors[LFHCAL]='-l 2'
           detectors[OuterBarrelMPGDSubAssembly]='-l 4'
           # Export to one STEP file


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Due to limitations in npdet_to_step, we disabled the HcalBarrel when exporting to STEP. With npsim 1.4.0, the issue with the HcalBarrel was [resolved](https://github.com/eic/npsim/pull/23).

This PR re-enables the HcalBarrel in npdet_to_step conversion, and it simplifies the logic to export all detector configs (for consistency and predictability).

TODO:
- [x] restart CI pipeline when eic-shell nightly rolls out with npsim-1.4.0

### What kind of change does this PR introduce?
- [x] Bug fix (issue: HcalBarrel disabled in convert-to-step)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.