### PR TITLE
feat: initial EcalBarrelImagingTracker support

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -175,7 +175,8 @@ The unused IDs below are saved for future use.
       Unused IDs: 107-109
 
     </documentation>
-    <constant name="ECalSubAssembly_ID"   value="100"/><!-- UNUSED -->
+    <constant name="ECalSubAssembly_ID"   value="100"/><!-- DEPRECATED -->
+    <constant name="EcalSubAssembly_ID"   value="100"/>
     <constant name="ECalBarrel_ID"        value="101"/><!-- DEPRECATED -->
     <constant name="EcalBarrel_ID"        value="101"/>
     <constant name="ECalEndcapP_ID"       value="102"/><!-- DEPRECATED -->

--- a/compact/ecal/bic/bic.xml
+++ b/compact/ecal/bic/bic.xml
@@ -138,7 +138,7 @@
       calorimeterType="EM_BARREL"
       vis="EcalBarrelEnvelopeVis"
       offset="EcalBarrel_Calorimeter_offset">
-      <type_flags type="DetType_TRACKER + DetType_CALORIMETER + DetType_BARREL"/>
+      <type_flags type="DetType_TRACKER + DetType_CALORIMETER + DetType_BARREL + DetType_ELECTROMAGNETIC"/>
       <dimensions numsides="EcalBarrel_SectorRepeat"
         rmin="EcalBarrel_rmin"
         z="EcalBarrel_Calorimeter_length"/>

--- a/compact/ecal/bic/bic.xml
+++ b/compact/ecal/bic/bic.xml
@@ -117,7 +117,7 @@
 
   <detectors>
 
-    <detector id="TrackerSubAssembly_8_ID"
+    <detector id="EcalSubAssembly_ID"
       name="EcalBarrelTrackerSubAssembly"
       type="DD4hep_SubdetectorAssembly"
       vis="TrackerSubAssemblyVis">
@@ -142,12 +142,17 @@
       <dimensions numsides="EcalBarrel_SectorRepeat"
         rmin="EcalBarrel_rmin"
         z="EcalBarrel_Calorimeter_length"/>
+
+      <comment>
+        The envelope for ACTS purposes needs to include only the first layer. The following
+        definition includes the front support and is tangential to the outer edge of the
+        first tray. This allows the envelope to avoid the first SFIL.
+      </comment>
       <envelope vis="EcalBarrelImaging_envelope"
         rmin="EcalBarrel_rmin"
-        rmax="EcalBarrel_rmin + 2.0 * EcalBarrel_ImagingLayerThickness"
+        rmax="EcalBarrel_rmin + EcalBarrel_FrontSupportThickness + EcalBarrel_ImagingLayerThickness"
         length="EcalBarrel_Calorimeter_length"
         zstart="EcalBarrel_Calorimeter_zmin"
-        xoffset="0"
       />
       <sectors vis="EcalBarrelSectorVis"/>
 
@@ -392,7 +397,7 @@
   <plugins>
     <plugin name="DD4hep_ParametersPlugin">
       <argument value="EcalBarrelImaging"/>
-      <argument value="layer_pattern: str=EcalBarrelImaging_envelope"/>
+      <argument value="layer_pattern: str=envelope"/>
     </plugin>
   </plugins>
 

--- a/compact/ecal/bic/bic.xml
+++ b/compact/ecal/bic/bic.xml
@@ -117,6 +117,13 @@
 
   <detectors>
 
+    <detector id="TrackerSubAssembly_8_ID"
+      name="EcalBarrelTrackerSubAssembly"
+      type="DD4hep_SubdetectorAssembly"
+      vis="TrackerSubAssemblyVis">
+      <composite name="EcalBarrelImaging"/>
+    </detector>
+
     <comment>
       ---------------------------------------
       Imaging Layers of Barrel EM Calorimeter
@@ -131,9 +138,17 @@
       calorimeterType="EM_BARREL"
       vis="EcalBarrelEnvelopeVis"
       offset="EcalBarrel_Calorimeter_offset">
+      <type_flags type="DetType_TRACKER + DetType_CALORIMETER + DetType_BARREL"/>
       <dimensions numsides="EcalBarrel_SectorRepeat"
         rmin="EcalBarrel_rmin"
         z="EcalBarrel_Calorimeter_length"/>
+      <envelope vis="EcalBarrelImaging_envelope"
+        rmin="EcalBarrel_rmin"
+        rmax="EcalBarrel_rmin + 2.0 * EcalBarrel_ImagingLayerThickness"
+        length="EcalBarrel_Calorimeter_length"
+        zstart="EcalBarrel_Calorimeter_zmin"
+        xoffset="0"
+      />
       <sectors vis="EcalBarrelSectorVis"/>
 
       <module name="AstroPix_Module"
@@ -176,6 +191,8 @@
       <layer repeat="1" vis="EcalBarrelLayerVis"
              thickness="EcalBarrel_ImagingLayerThickness"
              space_before="EcalBarrel_ScFiLayerThickness_Imaging + EcalBarrel_SpaceBetween">
+        <layer_material surface="inner" binning="binPhi,binR" bins0="30" bins1="30"/>
+        <layer_material surface="outer" binning="binPhi,binR" bins0="30" bins1="30"/>
         <frame material="CarbonFiber" fill="Air" thickness="EcalBarrel_CarbonFrameThickness" height="EcalBarrel_ImagingLayerThickness" vis="EcalBarrelSliceVis"/>
         <stave repeat="6"
                width="EcalBarrel_Stave_width"
@@ -371,5 +388,12 @@
       <id>system:8,sector:6,layer:6,slice:4,grid:10,fiber:16,z:-14</id>
     </readout>
   </readouts>
+
+  <plugins>
+    <plugin name="DD4hep_ParametersPlugin">
+      <argument value="EcalBarrelImaging"/>
+      <argument value="layer_pattern: str=EcalBarrelImaging_envelope"/>
+    </plugin>
+  </plugins>
 
 </lccdd>

--- a/compact/ecal/bic/bic.xml
+++ b/compact/ecal/bic/bic.xml
@@ -154,6 +154,21 @@
         length="EcalBarrel_Calorimeter_length"
         zstart="EcalBarrel_Calorimeter_zmin"
       />
+
+      <comment>
+        The layer material for ACTS purposes is at the top level, since the entire BIC detector
+        is treated as a single layer. The binning should likely be an integer multiple of the
+        number of sectors, and of the numer of modules.
+      </comment>
+      <layer_material surface="inner"
+                      binning="binPhi,binZ"
+                      bins0="6 * EcalBarrel_SectorRepeat"
+                      bins1="floor(2. * EcalBarrel_Stave_length / (EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin))"/>
+      <layer_material surface="outer"
+                      binning="binPhi,binZ"
+                      bins0="6 * EcalBarrel_SectorRepeat"
+                      bins1="floor(2. * EcalBarrel_Stave_length / (EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin))"/>
+
       <sectors vis="EcalBarrelSectorVis"/>
 
       <module name="AstroPix_Module"
@@ -196,8 +211,6 @@
       <layer repeat="1" vis="EcalBarrelLayerVis"
              thickness="EcalBarrel_ImagingLayerThickness"
              space_before="EcalBarrel_ScFiLayerThickness_Imaging + EcalBarrel_SpaceBetween">
-        <layer_material surface="inner" binning="binPhi,binR" bins0="30" bins1="30"/>
-        <layer_material surface="outer" binning="binPhi,binR" bins0="30" bins1="30"/>
         <frame material="CarbonFiber" fill="Air" thickness="EcalBarrel_CarbonFrameThickness" height="EcalBarrel_ImagingLayerThickness" vis="EcalBarrelSliceVis"/>
         <stave repeat="6"
                width="EcalBarrel_Stave_width"

--- a/compact/ecal/bic/bic_layer1_only.xml
+++ b/compact/ecal/bic/bic_layer1_only.xml
@@ -119,6 +119,13 @@
 
   <detectors>
 
+    <detector id="EcalSubAssembly_ID"
+      name="EcalBarrelTrackerSubAssembly"
+      type="DD4hep_SubdetectorAssembly"
+      vis="TrackerSubAssemblyVis">
+      <composite name="EcalBarrelImaging"/>
+    </detector>
+
     <comment>
       ---------------------------------------
       Imaging Layers of Barrel EM Calorimeter
@@ -133,9 +140,37 @@
       calorimeterType="EM_BARREL"
       vis="EcalBarrelEnvelopeVis"
       offset="EcalBarrel_Calorimeter_offset">
+      <type_flags type="DetType_TRACKER + DetType_CALORIMETER + DetType_BARREL + DetType_ELECTROMAGNETIC"/>
       <dimensions numsides="EcalBarrel_SectorRepeat"
         rmin="EcalBarrel_rmin"
         z="EcalBarrel_Calorimeter_length"/>
+
+      <comment>
+        The envelope for ACTS purposes needs to include only the first layer. The following
+        definition includes the front support and is tangential to the outer edge of the
+        first tray. This allows the envelope to avoid the first SFIL.
+      </comment>
+      <envelope vis="EcalBarrelImaging_envelope"
+        rmin="EcalBarrel_rmin"
+        rmax="EcalBarrel_rmin + EcalBarrel_FrontSupportThickness + EcalBarrel_ImagingLayerThickness"
+        length="EcalBarrel_Calorimeter_length"
+        zstart="EcalBarrel_Calorimeter_zmin"
+      />
+
+      <comment>
+        The layer material for ACTS purposes is at the top level, since the entire BIC detector
+        is treated as a single layer. The binning should likely be an integer multiple of the
+        number of sectors, and of the numer of modules.
+      </comment>
+      <layer_material surface="inner"
+                      binning="binPhi,binZ"
+                      bins0="6 * EcalBarrel_SectorRepeat"
+                      bins1="floor(2. * EcalBarrel_Stave_length / (EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin))"/>
+      <layer_material surface="outer"
+                      binning="binPhi,binZ"
+                      bins0="6 * EcalBarrel_SectorRepeat"
+                      bins1="floor(2. * EcalBarrel_Stave_length / (EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin))"/>
+
       <sectors vis="EcalBarrelSectorVis"/>
 
       <module name="AstroPix_Module"

--- a/configurations/craterlake_material_map.yml
+++ b/configurations/craterlake_material_map.yml
@@ -15,6 +15,8 @@ features:
     silicon_disks:
     tof_barrel:
     tof_endcap:
+  ecal:
+    bic_layer1_only:
   pid:
     dirc:
     pfrich:

--- a/src/BarrelCalorimeterImaging_geo.cpp
+++ b/src/BarrelCalorimeterImaging_geo.cpp
@@ -58,8 +58,6 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
 
   // Set detector type flag
   dd4hep::xml::setDetectorTypeFlag(x_detector, sdet);
-  auto& params [[maybe_unused]] =
-      DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(sdet);
 
   detector_physvol.addPhysVolID("system", detector_id);
   sdet.setPlacement(detector_physvol);
@@ -80,6 +78,19 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
     envelope_params.set<double>("envelope_z_max",
                                 getAttrOrDefault(x_envelope, _Unicode(envelope_z_max), 0.));
   }
+  // Add the volume boundary material if configured
+  for (xml_coll_t boundary_material(x_detector, _Unicode(boundary_material)); boundary_material; ++boundary_material) {
+    xml_comp_t x_boundary_material = boundary_material;
+    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(x_boundary_material, envelope_params,
+                                                    "boundary_material");
+  }
+  // Add the volume layer material if configured
+  for (xml_coll_t layer_material(x_detector, _Unicode(layer_material)); layer_material; ++layer_material) {
+    xml_comp_t x_layer_material = layer_material;
+    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(x_layer_material, envelope_params,
+                                                    "layer_material");
+  }
+
 
   // build a sector
   DetElement sector_element("sector0", detector_id);

--- a/src/BarrelCalorimeterImaging_geo.cpp
+++ b/src/BarrelCalorimeterImaging_geo.cpp
@@ -20,6 +20,7 @@
 #include "Math/Point2D.h"
 #include "TGeoPolygon.h"
 #include "XML/Layering.h"
+#include "XML/Utilities.h"
 #include <functional>
 
 #include "DD4hepDetectorHelper.h"
@@ -55,10 +56,38 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
   PlacedVolume detector_physvol = mother_volume.placeVolume(detector_volume, detector_tr);
   sens.setType("calorimeter");
 
+  // Set detector type flag
+  dd4hep::xml::setDetectorTypeFlag(x_detector, sdet);
+  auto& params = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(sdet);
+
+  // Add the volume boundary material if configured
+  for (xml_coll_t bmat(x_detector, _Unicode(boundary_material)); bmat; ++bmat) {
+    xml_comp_t x_boundary_material = bmat;
+    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(x_boundary_material, params,
+                                                    "boundary_material");
+  }
+
   detector_physvol.addPhysVolID("system", detector_id);
   sdet.setPlacement(detector_physvol);
 
-  // build a single sector
+  // build the envelope assembly
+  DetElement envelope_element(detector_name + "_envelope", detector_id);
+  Assembly envelope_volume(detector_name + "_envelope");
+  auto& envelope_params =
+      DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(envelope_element);
+  if (x_detector.hasChild(_Unicode(envelope))) {
+    xml_comp_t x_envelope = x_detector.child(_Unicode(envelope));
+    envelope_params.set<double>("envelope_r_min",
+                                getAttrOrDefault(x_envelope, _Unicode(envelope_r_min), 0.));
+    envelope_params.set<double>("envelope_r_max",
+                                getAttrOrDefault(x_envelope, _Unicode(envelope_r_max), 0.));
+    envelope_params.set<double>("envelope_z_min",
+                                getAttrOrDefault(x_envelope, _Unicode(envelope_z_min), 0.));
+    envelope_params.set<double>("envelope_z_max",
+                                getAttrOrDefault(x_envelope, _Unicode(envelope_z_max), 0.));
+  }
+
+  // build a sector
   DetElement sector_element("sector0", detector_id);
   Assembly sector_volume("sector");
   if (x_detector.hasChild(_Unicode(sectors))) {
@@ -210,7 +239,7 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
     for (int layer_j = 0; layer_j < layer_repeat; layer_j++) {
 
       // Make an envelope for this layer
-      std::string layer_name = Form("layer%d", layer_num);
+      std::string layer_name = detector_name + Form("_layer%d", layer_num);
       double layer_dim_x     = tan_half_dphi * layer_pos_z;
       auto layer_mat         = desc.air();
 
@@ -252,13 +281,13 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
         double stave_pitch = -2.0 * stave_pos_x / (stave_repeat - 1);
 
         // Make one stave
-        std::string stave_name = Form("stave%d", stave_num);
+        std::string stave_name = detector_name + Form("_stave%d", stave_num);
         auto stave_material    = desc.air();
         Box stave_shape(stave_dim_x, stave_dim_y, stave_dim_z);
         Volume stave_volume(stave_name, stave_shape, stave_material);
         stave_volume.setAttributes(desc, x_stave.regionStr(), x_stave.limitsStr(),
                                    x_stave.visStr());
-        DetElement stave_element(layer_element, stave_name, detector_id);
+        DetElement stave_element(stave_name, detector_id);
 
         // Loop over the slices for this stave
         double slice_pos_z = -(stave_thick / 2.);
@@ -360,12 +389,16 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
           RotationY stave_rot(layer_j % 2 == 0 ? +stave_rot_y : -stave_rot_y);
           Transform3D stave_tr(stave_rot, stave_pos);
           PlacedVolume stave_physvol = layer_volume.placeVolume(stave_volume, stave_tr);
-          stave_physvol.addPhysVolID("stave", stave_num);
-          stave_element.setPlacement(stave_physvol);
+          stave_physvol.addPhysVolID("stave", stave_num + stave_j);
+          DetElement stave_j_element =
+              (stave_j == 0)
+                  ? stave_element
+                  : stave_element.clone(detector_name + Form("_stave%d", stave_num + stave_j));
+          stave_j_element.setPlacement(stave_physvol);
+          layer_element.add(stave_j_element);
 
           // Increment X position of stave
           stave_pos_x += stave_pitch;
-          ++stave_num;
         }
       }
 
@@ -423,16 +456,24 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
 
   // Phi start for a sector.
   double phi = M_PI / nsides;
+
   // Create nsides sectors.
-  for (int i = 0; i < nsides; i++, phi -= dphi) { // i is sector number
+  for (int sector_num = 0; sector_num < nsides; sector_num++, phi -= dphi) {
     // Compute the sector position
     Transform3D tr(RotationZYX(0, phi, M_PI * 0.5), Translation3D(0, 0, 0));
-    PlacedVolume sector_physvol = detector_volume.placeVolume(sector_volume, tr);
-    sector_physvol.addPhysVolID("sector", i + 1);
-    DetElement sd = (i == 0) ? sector_element : sector_element.clone(Form("sector%d", i));
+    PlacedVolume sector_physvol = envelope_volume.placeVolume(sector_volume, tr);
+    sector_physvol.addPhysVolID("sector", sector_num + 1);
+    DetElement sd = (sector_num == 0)
+                        ? sector_element
+                        : sector_element.clone(detector_name + Form("_sector%d", sector_num));
     sd.setPlacement(sector_physvol);
-    sdet.add(sd);
+    envelope_element.add(sd);
   }
+
+  // Place envelope
+  PlacedVolume envelope_physvol = detector_volume.placeVolume(envelope_volume);
+  envelope_element.setPlacement(envelope_physvol);
+  sdet.add(envelope_element);
 
   return sdet;
 }

--- a/src/BarrelCalorimeterImaging_geo.cpp
+++ b/src/BarrelCalorimeterImaging_geo.cpp
@@ -58,7 +58,8 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
 
   // Set detector type flag
   dd4hep::xml::setDetectorTypeFlag(x_detector, sdet);
-  auto& params [[maybe_unused]] = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(sdet);
+  auto& params [[maybe_unused]] =
+      DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(sdet);
 
   detector_physvol.addPhysVolID("system", detector_id);
   sdet.setPlacement(detector_physvol);
@@ -385,9 +386,8 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
           PlacedVolume stave_physvol = layer_volume.placeVolume(stave_volume, stave_tr);
           stave_physvol.addPhysVolID("stave", stave_num + stave_j);
           DetElement stave_j_element =
-              (stave_j == 0)
-                  ? stave_element
-                  : stave_element.clone(Form("stave%d", stave_num + stave_j));
+              (stave_j == 0) ? stave_element
+                             : stave_element.clone(Form("stave%d", stave_num + stave_j));
           stave_j_element.setPlacement(stave_physvol);
           layer_element.add(stave_j_element);
 
@@ -457,9 +457,8 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
     Transform3D tr(RotationZYX(0, phi, M_PI * 0.5), Translation3D(0, 0, 0));
     PlacedVolume sector_physvol = envelope_volume.placeVolume(sector_volume, tr);
     sector_physvol.addPhysVolID("sector", sector_num + 1);
-    DetElement sd = (sector_num == 0)
-                        ? sector_element
-                        : sector_element.clone(Form("sector%d", sector_num));
+    DetElement sd =
+        (sector_num == 0) ? sector_element : sector_element.clone(Form("sector%d", sector_num));
     sd.setPlacement(sector_physvol);
     envelope_element.add(sd);
   }

--- a/src/BarrelCalorimeterImaging_geo.cpp
+++ b/src/BarrelCalorimeterImaging_geo.cpp
@@ -79,18 +79,19 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
                                 getAttrOrDefault(x_envelope, _Unicode(envelope_z_max), 0.));
   }
   // Add the volume boundary material if configured
-  for (xml_coll_t boundary_material(x_detector, _Unicode(boundary_material)); boundary_material; ++boundary_material) {
+  for (xml_coll_t boundary_material(x_detector, _Unicode(boundary_material)); boundary_material;
+       ++boundary_material) {
     xml_comp_t x_boundary_material = boundary_material;
     DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(x_boundary_material, envelope_params,
                                                     "boundary_material");
   }
   // Add the volume layer material if configured
-  for (xml_coll_t layer_material(x_detector, _Unicode(layer_material)); layer_material; ++layer_material) {
+  for (xml_coll_t layer_material(x_detector, _Unicode(layer_material)); layer_material;
+       ++layer_material) {
     xml_comp_t x_layer_material = layer_material;
     DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(x_layer_material, envelope_params,
                                                     "layer_material");
   }
-
 
   // build a sector
   DetElement sector_element("sector0", detector_id);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds tracking support to the first AstroPix layer of the Barrel Imaging Calorimeter (well, technically all of the layers).

With this geometry, and with https://github.com/eic/epic/pull/710, we now see the hits from the first layer of the BIC be part of reconstructed tracks (BIC first layer is avg at 84 cm rmin + 0.5 cm inner support plate + 0.75 cm to middle of tray):
![image](https://github.com/user-attachments/assets/f206d580-1ec1-4c8e-9cf4-179a539aa7fd)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.