### PR TITLE
calibrations.xml: add hpdirc_positive.lut

### DIFF
--- a/compact/calibrations.xml
+++ b/compact/calibrations.xml
@@ -9,6 +9,11 @@
       <arg value="file:calibrations/onnx/identity_gemm_w1x1_b1.onnx"/>
       <arg value="url:https://github.com/eic/epic-data/raw/27ef75b2b6108b5e72d3ab891f32aeeb3770c7bd/onnx/identity_gemm_w1x1_b1.onnx"/>
     </plugin>
+    <plugin name="epic_FileLoader">
+      <arg value="cache:$DETECTOR_PATH:/opt/detector"/>
+      <arg value="file:calibrations/hpdirc_positive.lut"/>
+      <arg value="url:https://raw.githubusercontent.com/nathanwbrei/fastpid/66acf386f368d8fe95cbf157407492e92344ee7f/hpdirc_positive.lut"/>
+    </plugin>
   </plugins>
 
 </lccdd>


### PR DESCRIPTION
Adds hpDIRC LUT to support https://github.com/eic/EICrecon/pull/1365
I pick @nathanwbrei 's fork over https://github.com/rdom/fastpid since the file got a minor update
```diff
diff --git a/hpdirc_positive.lut b/hpdirc_positive.lut
index a0c5841..ac5b96d 100644
--- a/hpdirc_positive.lut
+++ b/hpdirc_positive.lut
@@ -1,3 +1,21 @@
+# PDG code of the particle (e 11, pi 211, K 321, p 2212)
+11 211 321 2212
+
+# Charge (-1,1)
+1
+
+# Momentum [GeV/c]
+0.20 10.2 0.2
+
+# Polar angle [deg]
+25.0 161.0 1.0
+
+# Azimuthal angle [deg]
+0.0 30.5 0.5
+
+# Outputs columns are P[e], P[pi], P[K], P[p]
+# We ignore muons for now
+
 11 1 0.20 25.00 0.00 0.0000 0.0000 0.0000 0.0000
 11 1 0.20 25.00 0.50 0.0000 0.0000 0.0000 0.0000
 11 1 0.20 25.00 1.00 0.0000 0.0000 0.0000 0.0000

```