### PR TITLE
Add more vacuum at z>40m

### DIFF
--- a/compact/far_forward/vacuum.xml
+++ b/compact/far_forward/vacuum.xml
@@ -53,6 +53,12 @@
                 <apperture x="B1APF_InnerRadius*2" y="B1APF_InnerRadius*2"  r="B1APF_InnerRadius"/>
         </element>
 
+        <element>
+                <placement x="B2PF_XPosition" y="0*m" z="B2PF_CenterPosition" theta="B2PF_RotationAngle" />
+                <dimensions z="B1PF_Length"  />
+                <apperture x="B2PF_InnerRadius*2" y="B2PF_InnerRadius*2"  r="B2PF_InnerRadius" />
+        </element>
+
       </detector>
   </detectors>
 

--- a/compact/far_forward/vacuum.xml
+++ b/compact/far_forward/vacuum.xml
@@ -55,7 +55,7 @@
 
         <element>
                 <placement x="B2PF_XPosition" y="0*m" z="B2PF_CenterPosition" theta="B2PF_RotationAngle" />
-                <dimensions z="B1PF_Length"  />
+                <dimensions z="B2PF_Length"  />
                 <apperture x="B2PF_InnerRadius*2" y="B2PF_InnerRadius*2"  r="B2PF_InnerRadius" />
         </element>
 

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -203,7 +203,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     Volume vpiece(piece_name, magnetPiece, m_Vac);
     sdet.setAttributes(det, vpiece, x_det.regionStr(), x_det.limitsStr(), vis_name);
 
-    auto pv = assembly.placeVolume(
+    assembly.placeVolume(
         vpiece, Transform3D(RotationY(rotation_magnet[pieceIdx]),
                             Position(x_elem_magnet[pieceIdx], y_elem_magnet[pieceIdx],
                                      z_elem_magnet[pieceIdx])));
@@ -227,7 +227,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     Volume vpiece(piece_name, gapPiece, m_Vac);
     sdet.setAttributes(det, vpiece, x_det.regionStr(), x_det.limitsStr(), vis_name);
 
-    auto pv = assembly.placeVolume(
+    assembly.placeVolume(
         vpiece, Transform3D(RotationY(angle_elem_gap[correctIdx]),
                             Position(x_gap[correctIdx], 0.0, z_gap[correctIdx])));
   }
@@ -252,8 +252,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     Volume specialGap_v(piece_name, specialGap, m_Vac);
     sdet.setAttributes(det, specialGap_v, x_det.regionStr(), x_det.limitsStr(), vis_name);
 
-    auto pv =
-        assembly.placeVolume(specialGap_v, Transform3D(RotationY(crossingAngle),
+    assembly.placeVolume(specialGap_v, Transform3D(RotationY(crossingAngle),
                                                        Position(specialGap_x, 0.0, specialGap_z)));
   }
 
@@ -276,7 +275,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     sdet.setAttributes(det, vpiece, x_det.regionStr(), x_det.limitsStr(),
                        "InvisibleNoDaughters"); // make invisible instead of AnlBlue
 
-    auto pv = assembly.placeVolume(vpiece, Transform3D(RotationY(rotation_magnet[pieceIdx]),
+    assembly.placeVolume(vpiece, Transform3D(RotationY(rotation_magnet[pieceIdx]),
                                                        Position(endGap_x, 0.0, endGap_z)));
   }
   //----------------------------------------------------

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -265,7 +265,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     int pieceIdx           = numMagnets - 1; // last B2PF magnet
     std::string piece_name = Form("GapVacuum%d", numGaps + numMagnets + 1);
     double endGapLength    = (10000.0 - z_end[pieceIdx]) / cos(rotation_magnet[pieceIdx]);
-    endGapLength    = endGapLength - 4 * radii_magnet[pieceIdx] * tan(rotation_magnet[pieceIdx]);
+    endGapLength    = endGapLength - 4 * radii_magnet[pieceIdx] * tan(-rotation_magnet[pieceIdx]); // shift to keep the tube inside the physical volume
     double endGap_z = 0.5 * endGapLength * cos(rotation_magnet[pieceIdx]) + z_end[pieceIdx];
     double endGap_x = 0.5 * endGapLength * sin(rotation_magnet[pieceIdx]) + x_end[pieceIdx];
 

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -207,10 +207,6 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
         vpiece, Transform3D(RotationY(rotation_magnet[pieceIdx]),
                             Position(x_elem_magnet[pieceIdx], y_elem_magnet[pieceIdx],
                                      z_elem_magnet[pieceIdx])));
-    pv.addPhysVolID("sector", 1);
-
-    DetElement de(sdet, Form("sector%d_de", pieceIdx), 1);
-    de.setPlacement(pv);
   }
 
   //--------------------------
@@ -234,10 +230,6 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     auto pv = assembly.placeVolume(
         vpiece, Transform3D(RotationY(angle_elem_gap[correctIdx]),
                             Position(x_gap[correctIdx], 0.0, z_gap[correctIdx])));
-    pv.addPhysVolID("sector", 1);
-
-    DetElement de(sdet, Form("sector%d_de", pieceIdx), 1);
-    de.setPlacement(pv);
   }
 
   //--------------------------------------------------------------
@@ -263,10 +255,6 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     auto pv =
         assembly.placeVolume(specialGap_v, Transform3D(RotationY(crossingAngle),
                                                        Position(specialGap_x, 0.0, specialGap_z)));
-    pv.addPhysVolID("sector", 1);
-
-    DetElement de(sdet, Form("sector%d_de", numGaps + numMagnets), 1);
-    de.setPlacement(pv);
   }
 
   //----------------------------------------------------
@@ -290,11 +278,6 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 
     auto pv = assembly.placeVolume(vpiece, Transform3D(RotationY(rotation_magnet[pieceIdx]),
                                                        Position(endGap_x, 0.0, endGap_z)));
-
-    pv.addPhysVolID("sector", 1);
-
-    DetElement de(sdet, Form("sector%d_de", numGaps + numMagnets + 1), 1);
-    de.setPlacement(pv);
   }
   //----------------------------------------------------
 

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -45,6 +45,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   //----------------------------------------------
 
   bool makeIP_B0pfVacuum = true; //This is for the special gap location between IP and b0pf
+  bool make_B2pf_EW_Vacuum = true; //This is for the gap after b2pf
 
   //information for actual FF magnets, with magnet centers as reference
   vector<double> radii_magnet;
@@ -101,7 +102,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   int numMagnets = radii_magnet.size(); //number of actual FF magnets between IP and FF detectors
   int numGaps =
       numMagnets -
-      1; //number of gaps between magnets (excluding the IP to B0pf transition -- special case)
+      2; //number of gaps between magnets (excluding the IP to B0pf transition -- special case, and the gao after B1apf)
 
   //-------------------------------------------
   // override numbers for the first element -->
@@ -270,6 +271,30 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 
   //----------------------------------------------------
 
+  //--------------------------------------------------------------
+  //make and place vacuum volume after the FF detector array up to end of the world
+  //--------------------------------------------------------------
+  if(make_B2pf_EW_Vacuum){
+
+        int pieceIdx = numMagnets-1; // last B2PF magnet
+        std::string piece_name      = Form("GapVacuum%d", numGaps + numMagnets + 1);
+        double endGapLength = (10000.0 - z_end[pieceIdx]) /  cos(rotation_magnet[pieceIdx]);
+        double endGap_z = 0.5*endGapLength*cos(rotation_magnet[pieceIdx]) + z_end[pieceIdx];
+        double endGap_x = 0.5*endGapLength*sin(rotation_magnet[pieceIdx]) + x_end[pieceIdx];
+
+        Tube vacuum_endWorld(piece_name, 0.0, 4*radii_magnet[pieceIdx], endGapLength/2); // make larger tube than inner magnet radius
+        Volume vpiece(piece_name, vacuum_endWorld, m_Vac);
+        sdet.setAttributes(det, vpiece, x_det.regionStr(), x_det.limitsStr(), "InvisibleNoDaughters"); // make invisible instead of AnlBlue
+
+        auto pv = assembly.placeVolume(vpiece, Transform3D(RotationY(rotation_magnet[pieceIdx]), Position(endGap_x, 0.0, endGap_z)));
+
+        pv.addPhysVolID("sector", 1);
+
+        DetElement de(sdet, Form("sector%d_de", numGaps + numMagnets + 1), 1);
+        de.setPlacement(pv);
+  }
+  //----------------------------------------------------
+ 
   pv_assembly = det.pickMotherVolume(sdet).placeVolume(assembly);
   pv_assembly.addPhysVolID("system", x_det.id()).addPhysVolID("barrel", 1);
   sdet.setPlacement(pv_assembly);

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -265,6 +265,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     int pieceIdx           = numMagnets - 1; // last B2PF magnet
     std::string piece_name = Form("GapVacuum%d", numGaps + numMagnets + 1);
     double endGapLength    = (10000.0 - z_end[pieceIdx]) / cos(rotation_magnet[pieceIdx]);
+    endGapLength = endGapLength - 4 * radii_magnet[pieceIdx] * tan(rotation_magnet[pieceIdx]);
     double endGap_z        = 0.5 * endGapLength * cos(rotation_magnet[pieceIdx]) + z_end[pieceIdx];
     double endGap_x        = 0.5 * endGapLength * sin(rotation_magnet[pieceIdx]) + x_end[pieceIdx];
 

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -203,10 +203,10 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     Volume vpiece(piece_name, magnetPiece, m_Vac);
     sdet.setAttributes(det, vpiece, x_det.regionStr(), x_det.limitsStr(), vis_name);
 
-    assembly.placeVolume(
-        vpiece, Transform3D(RotationY(rotation_magnet[pieceIdx]),
-                            Position(x_elem_magnet[pieceIdx], y_elem_magnet[pieceIdx],
-                                     z_elem_magnet[pieceIdx])));
+    assembly.placeVolume(vpiece,
+                         Transform3D(RotationY(rotation_magnet[pieceIdx]),
+                                     Position(x_elem_magnet[pieceIdx], y_elem_magnet[pieceIdx],
+                                              z_elem_magnet[pieceIdx])));
   }
 
   //--------------------------
@@ -227,9 +227,8 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     Volume vpiece(piece_name, gapPiece, m_Vac);
     sdet.setAttributes(det, vpiece, x_det.regionStr(), x_det.limitsStr(), vis_name);
 
-    assembly.placeVolume(
-        vpiece, Transform3D(RotationY(angle_elem_gap[correctIdx]),
-                            Position(x_gap[correctIdx], 0.0, z_gap[correctIdx])));
+    assembly.placeVolume(vpiece, Transform3D(RotationY(angle_elem_gap[correctIdx]),
+                                             Position(x_gap[correctIdx], 0.0, z_gap[correctIdx])));
   }
 
   //--------------------------------------------------------------
@@ -253,7 +252,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     sdet.setAttributes(det, specialGap_v, x_det.regionStr(), x_det.limitsStr(), vis_name);
 
     assembly.placeVolume(specialGap_v, Transform3D(RotationY(crossingAngle),
-                                                       Position(specialGap_x, 0.0, specialGap_z)));
+                                                   Position(specialGap_x, 0.0, specialGap_z)));
   }
 
   //----------------------------------------------------
@@ -276,7 +275,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
                        "InvisibleNoDaughters"); // make invisible instead of AnlBlue
 
     assembly.placeVolume(vpiece, Transform3D(RotationY(rotation_magnet[pieceIdx]),
-                                                       Position(endGap_x, 0.0, endGap_z)));
+                                             Position(endGap_x, 0.0, endGap_z)));
   }
   //----------------------------------------------------
 

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -265,7 +265,10 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     int pieceIdx           = numMagnets - 1; // last B2PF magnet
     std::string piece_name = Form("GapVacuum%d", numGaps + numMagnets + 1);
     double endGapLength    = (10000.0 - z_end[pieceIdx]) / cos(rotation_magnet[pieceIdx]);
-    endGapLength    = endGapLength - 4 * radii_magnet[pieceIdx] * tan(-rotation_magnet[pieceIdx]); // shift to keep the tube inside the physical volume
+    endGapLength =
+        endGapLength -
+        4 * radii_magnet[pieceIdx] *
+            tan(-rotation_magnet[pieceIdx]); // shift to keep the tube inside the physical volume
     double endGap_z = 0.5 * endGapLength * cos(rotation_magnet[pieceIdx]) + z_end[pieceIdx];
     double endGap_x = 0.5 * endGapLength * sin(rotation_magnet[pieceIdx]) + x_end[pieceIdx];
 

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -44,7 +44,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   // make it easier to update later.
   //----------------------------------------------
 
-  bool makeIP_B0pfVacuum = true; //This is for the special gap location between IP and b0pf
+  bool makeIP_B0pfVacuum   = true; //This is for the special gap location between IP and b0pf
   bool make_B2pf_EW_Vacuum = true; //This is for the gap after b2pf
 
   //information for actual FF magnets, with magnet centers as reference
@@ -274,27 +274,30 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   //--------------------------------------------------------------
   //make and place vacuum volume after the FF detector array up to end of the world
   //--------------------------------------------------------------
-  if(make_B2pf_EW_Vacuum){
+  if (make_B2pf_EW_Vacuum) {
 
-        int pieceIdx = numMagnets-1; // last B2PF magnet
-        std::string piece_name      = Form("GapVacuum%d", numGaps + numMagnets + 1);
-        double endGapLength = (10000.0 - z_end[pieceIdx]) /  cos(rotation_magnet[pieceIdx]);
-        double endGap_z = 0.5*endGapLength*cos(rotation_magnet[pieceIdx]) + z_end[pieceIdx];
-        double endGap_x = 0.5*endGapLength*sin(rotation_magnet[pieceIdx]) + x_end[pieceIdx];
+    int pieceIdx           = numMagnets - 1; // last B2PF magnet
+    std::string piece_name = Form("GapVacuum%d", numGaps + numMagnets + 1);
+    double endGapLength    = (10000.0 - z_end[pieceIdx]) / cos(rotation_magnet[pieceIdx]);
+    double endGap_z        = 0.5 * endGapLength * cos(rotation_magnet[pieceIdx]) + z_end[pieceIdx];
+    double endGap_x        = 0.5 * endGapLength * sin(rotation_magnet[pieceIdx]) + x_end[pieceIdx];
 
-        Tube vacuum_endWorld(piece_name, 0.0, 4*radii_magnet[pieceIdx], endGapLength/2); // make larger tube than inner magnet radius
-        Volume vpiece(piece_name, vacuum_endWorld, m_Vac);
-        sdet.setAttributes(det, vpiece, x_det.regionStr(), x_det.limitsStr(), "InvisibleNoDaughters"); // make invisible instead of AnlBlue
+    Tube vacuum_endWorld(piece_name, 0.0, 4 * radii_magnet[pieceIdx],
+                         endGapLength / 2); // make larger tube than inner magnet radius
+    Volume vpiece(piece_name, vacuum_endWorld, m_Vac);
+    sdet.setAttributes(det, vpiece, x_det.regionStr(), x_det.limitsStr(),
+                       "InvisibleNoDaughters"); // make invisible instead of AnlBlue
 
-        auto pv = assembly.placeVolume(vpiece, Transform3D(RotationY(rotation_magnet[pieceIdx]), Position(endGap_x, 0.0, endGap_z)));
+    auto pv = assembly.placeVolume(vpiece, Transform3D(RotationY(rotation_magnet[pieceIdx]),
+                                                       Position(endGap_x, 0.0, endGap_z)));
 
-        pv.addPhysVolID("sector", 1);
+    pv.addPhysVolID("sector", 1);
 
-        DetElement de(sdet, Form("sector%d_de", numGaps + numMagnets + 1), 1);
-        de.setPlacement(pv);
+    DetElement de(sdet, Form("sector%d_de", numGaps + numMagnets + 1), 1);
+    de.setPlacement(pv);
   }
   //----------------------------------------------------
- 
+
   pv_assembly = det.pickMotherVolume(sdet).placeVolume(assembly);
   pv_assembly.addPhysVolID("system", x_det.id()).addPhysVolID("barrel", 1);
   sdet.setPlacement(pv_assembly);

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -265,9 +265,9 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     int pieceIdx           = numMagnets - 1; // last B2PF magnet
     std::string piece_name = Form("GapVacuum%d", numGaps + numMagnets + 1);
     double endGapLength    = (10000.0 - z_end[pieceIdx]) / cos(rotation_magnet[pieceIdx]);
-    endGapLength = endGapLength - 4 * radii_magnet[pieceIdx] * tan(rotation_magnet[pieceIdx]);
-    double endGap_z        = 0.5 * endGapLength * cos(rotation_magnet[pieceIdx]) + z_end[pieceIdx];
-    double endGap_x        = 0.5 * endGapLength * sin(rotation_magnet[pieceIdx]) + x_end[pieceIdx];
+    endGapLength    = endGapLength - 4 * radii_magnet[pieceIdx] * tan(rotation_magnet[pieceIdx]);
+    double endGap_z = 0.5 * endGapLength * cos(rotation_magnet[pieceIdx]) + z_end[pieceIdx];
+    double endGap_x = 0.5 * endGapLength * sin(rotation_magnet[pieceIdx]) + x_end[pieceIdx];
 
     Tube vacuum_endWorld(piece_name, 0.0, 4 * radii_magnet[pieceIdx],
                          endGapLength / 2); // make larger tube than inner magnet radius


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This RP will fill the hadron line downstream with a vacuum to allow faster simulation of ion fragments.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other: This makes the simulation run faster in case of eA collisions in which ions (or ion fragments) are defined as stable particles and propagate downstream the Hadron beamline (x10 improvement).

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators: Presented at the FF WG meeting on May 14 https://indico.bnl.gov/event/23379/#15-forward-detectors-with-epic 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Besides the execution time, this PR should keep the results unchanged. 


### Does this PR change default behavior?
no