### PR TITLE
calibrations.xml: update to use latest tof.lut and pfrich.lut

### DIFF
--- a/compact/calibrations.xml
+++ b/compact/calibrations.xml
@@ -27,7 +27,7 @@
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_PATH:/opt/detector"/>
       <arg value="file:calibrations/tof.lut"/>
-      <arg value="url:https://github.com/eic/epic-data/raw/b863589baf6998acdc22f5e445a5e462bbf72b0a/tof.lut"/>
+      <arg value="url:https://github.com/eic/epic-data/raw/c0f0ec03ca98de39cb74bf03407948ea64169eb1/tof.lut"/>
     </plugin>
   </plugins>
 

--- a/compact/calibrations.xml
+++ b/compact/calibrations.xml
@@ -22,7 +22,7 @@
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_PATH:/opt/detector"/>
       <arg value="file:calibrations/pfrich.lut"/>
-      <arg value="url:https://github.com/eic/epic-data/raw/b863589baf6998acdc22f5e445a5e462bbf72b0a/pfrich.lut"/>
+      <arg value="url:https://raw.githubusercontent.com/eic/epic-data/126e57e058adddd1d044c63656eb76bc25a1aae5/pfrich.lut"/>
     </plugin>
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_PATH:/opt/detector"/>


### PR DESCRIPTION
This updates to use the latest LUT from https://github.com/eic/epic-data/pull/12
No binning change, so we don't need any file renames.