### PR TITLE
linux-eic-shell.yml: provide PIPELINE_NAME to detector_benchmarks

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -538,6 +538,7 @@ jobs:
           DETECTOR_CONFIG=${{ matrix.detector_config }}
           GITHUB_REPOSITORY=${{ github.repository }}
           GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
+          PIPELINE_NAME=${{ github.event.pull_request.title || github.sha }}
     - run: |
         gh api \
            --method POST \


### PR DESCRIPTION
This takes advantage of https://github.com/eic/detector_benchmarks/pull/20