### PR TITLE
Bic geo adjustment

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -550,7 +550,7 @@ Service gaps in FW direction (before endcapP ECAL) and BW direction (before endc
     <constant name="EcalEndcapN_rmin"               value="9.*cm"/>    <!-- Currently fix value hardcoded -->
     <constant name="EcalEndcapN_rmax"               value="63.*cm"/>   <!-- Currently fix value hardcoded -->
 
-    <constant name="EcalBarrel_rmin"                value="max(81.*cm, CentralTrackingRegion_rmax + BarrelPIDRegion_thickness + BarrelExtraSpace_thickness)"/> <!-- FIXME hardcoded max -->
+    <constant name="EcalBarrel_rmin"                value="max(82.*cm, CentralTrackingRegion_rmax + BarrelPIDRegion_thickness + BarrelExtraSpace_thickness)"/>
     <constant name="EcalBarrelRegion_thickness"     value="Solenoid_rmin-EcalBarrel_rmin"/>
     <constant name="EcalBarrel_inner_margin"        value="2*cm"/>
     <constant name="EcalBarrel_rmax"                value="EcalBarrel_rmin + EcalBarrelRegion_thickness"/>

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -42,8 +42,8 @@
     <constant name="EcalBarrel_CopperThickness"       value="100*um"/>
     <constant name="EcalBarrel_KaptonThickness"       value="200*um"/>
     <constant name="EcalBarrel_EpoxyThickness"        value="100*um"/>
-    <constant name="EcalBarrel_CarbonThickness"       value="0.5*mm"/>
-    <constant name="EcalBarrel_CarbonSpacerWidth"     value="4*mm"/>
+    <constant name="EcalBarrel_CarbonFrameThickness"  value="2*mm"/>
+    <constant name="EcalBarrel_CarbonStaveThickness"  value="0.5*mm"/>
 
     <constant name="EcalBarrel_AstroPix_width"        value="2*cm"/>
     <constant name="EcalBarrel_AstroPix_length"       value="2*cm"/>
@@ -57,7 +57,7 @@
 
     <constant name="EcalBarrel_Stave_width"           value="EcalBarrel_AstroPix_width + 2. * EcalBarrel_AstroPix_margin"/>
     <constant name="EcalBarrel_Stave_length"          value="EcalBarrel_Calorimeter_length"/>
-    <constant name="EcalBarrel_Stave_thickness"       value="EcalBarrel_AstroPix_thickness + EcalBarrel_CarbonThickness"/>
+    <constant name="EcalBarrel_Stave_thickness"       value="EcalBarrel_AstroPix_thickness + EcalBarrel_CarbonStaveThickness"/>
     <constant name="EcalBarrel_StaveTilt_angle"       value="10*degree"/>
     <constant name="EcalBarrel_Stave_ModuleRepeat"    value="floor(EcalBarrel_Calorimeter_length / (EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin))"/>
 
@@ -73,18 +73,17 @@
     <constant name="EcalBarrel_RadiatorThickness"      value="EcalBarrel_FiberZSpacing * 17"/>
     <constant name="EcalBarrel_TotalFiberLayers_num"   value="12"/>
     <constant name="EcalBarrel_RadiatorEdgeThickness"  value="0.61*mm"/>
-    <constant name="EcalBarrel_AluminumPlateThickness" value="1*mm"/>
     <constant name="EcalBarrel_SectorRepeat"           value="EcalBarrelSectorsN"/>
     <constant name="EcalBarrel_AvailThickness"         value="EcalBarrelRegion_thickness - EcalBarrel_BackSupportThickness - EcalBarrel_FrontSupportThickness"/>
 
-    <constant name="EcalBarrel_ImagingLayerThickness"  value="1.5*cm"/>
+    <constant name="EcalBarrel_ImagingLayerThickness"  value="1.7*cm"/>
 
     <constant name="EcalBarrel_ImagingLayerThickness_WithoutFrame"
       value="EcalBarrel_ImagingLayerThickness
-      - 2*EcalBarrel_CarbonThickness"/>
+      - 2*EcalBarrel_CarbonFrameThickness"/>
 
     <constant name="EcalBarrel_ScFiLayerThickness_Imaging"
-      value="EcalBarrel_RadiatorThickness + 2*EcalBarrel_RadiatorEdgeThickness + 2*EcalBarrel_AluminumPlateThickness"/>
+      value="EcalBarrel_RadiatorThickness + 2*EcalBarrel_RadiatorEdgeThickness"/>
 
     <comment>
       Adjusting size of the ScFi back chunk to match number of imaging layers
@@ -154,11 +153,7 @@
       <layer repeat="1" vis="EcalBarrelLayerVis"
              thickness="EcalBarrel_ImagingLayerThickness"
              space_before="EcalBarrel_FrontSupportThickness">
-        <barrel_envelope
-          inner_r="EcalBarrel_rmin - EcalBarrel_Stave_thickness"
-          outer_r="EcalBarrel_rmin + EcalBarrel_Stave_thickness"
-          z_length="EcalBarrel_Calorimeter_length"/>
-        <frame material="CarbonFiber" fill="Air" thickness="EcalBarrel_CarbonThickness" height="EcalBarrel_ImagingLayerThickness" vis="EcalBarrelSliceVis"/>
+        <frame material="CarbonFiber" fill="Air" thickness="EcalBarrel_CarbonFrameThickness" height="EcalBarrel_ImagingLayerThickness" vis="EcalBarrelSliceVis"/>
         <stave repeat="6"
                width="EcalBarrel_Stave_width"
                length="EcalBarrel_Stave_length"
@@ -176,14 +171,14 @@
       <layer repeat="1" vis="EcalBarrelLayerVis"
              thickness="EcalBarrel_ImagingLayerThickness"
              space_before="EcalBarrel_ScFiLayerThickness_Imaging + EcalBarrel_SpaceBetween">
-        <frame material="CarbonFiber" fill="Air" thickness="EcalBarrel_CarbonThickness" height="EcalBarrel_ImagingLayerThickness" vis="EcalBarrelSliceVis"/>
+        <frame material="CarbonFiber" fill="Air" thickness="EcalBarrel_CarbonFrameThickness" height="EcalBarrel_ImagingLayerThickness" vis="EcalBarrelSliceVis"/>
       </layer>
 
       <layer repeat="2" vis="EcalBarrelLayerVis"
              thickness="EcalBarrel_ImagingLayerThickness"
              space_between="EcalBarrel_ScFiLayerThickness_Imaging + EcalBarrel_SpaceBetween"
              space_before="EcalBarrel_ScFiLayerThickness_Imaging + EcalBarrel_SpaceBetween">
-        <frame material="CarbonFiber" fill="Air" thickness="EcalBarrel_CarbonThickness" height="EcalBarrel_ImagingLayerThickness" vis="EcalBarrelSliceVis"/>
+        <frame material="CarbonFiber" fill="Air" thickness="EcalBarrel_CarbonFrameThickness" height="EcalBarrel_ImagingLayerThickness" vis="EcalBarrelSliceVis"/>
         <stave repeat="6"
                width="EcalBarrel_Stave_width"
                length="EcalBarrel_Stave_length"
@@ -201,14 +196,14 @@
       <layer repeat="1" vis="EcalBarrelLayerVis"
              thickness="EcalBarrel_ImagingLayerThickness"
              space_before="EcalBarrel_ScFiLayerThickness_Imaging + EcalBarrel_SpaceBetween">
-        <frame material="CarbonFiber" fill="Air" thickness="EcalBarrel_CarbonThickness" height="EcalBarrel_ImagingLayerThickness" vis="EcalBarrelSliceVis"/>
+        <frame material="CarbonFiber" fill="Air" thickness="EcalBarrel_CarbonFrameThickness" height="EcalBarrel_ImagingLayerThickness" vis="EcalBarrelSliceVis"/>
       </layer>
 
       <layer repeat="EcalBarrelImagingLayers_num-5" vis="EcalBarrelLayerVis"
              thickness="EcalBarrel_ImagingLayerThickness"
              space_between="EcalBarrel_ScFiLayerThickness_Imaging + EcalBarrel_SpaceBetween"
              space_before="EcalBarrel_ScFiLayerThickness_Imaging + EcalBarrel_SpaceBetween">
-        <frame material="CarbonFiber" fill="Air" thickness="EcalBarrel_CarbonThickness" height="EcalBarrel_ImagingLayerThickness" vis="EcalBarrelSliceVis"/>
+        <frame material="CarbonFiber" fill="Air" thickness="EcalBarrel_CarbonFrameThickness" height="EcalBarrel_ImagingLayerThickness" vis="EcalBarrelSliceVis"/>
         <stave repeat="7"
                width="EcalBarrel_Stave_width"
                length="EcalBarrel_Stave_length"
@@ -245,7 +240,6 @@
       <layer repeat="EcalBarrelImagingLayers_num-1" vis="EcalBarrelLayerVis"
              space_between="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween"
              space_before="EcalBarrel_FrontSupportThickness + EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween/2.">
-        <slice material="Aluminum" thickness="EcalBarrel_AluminumPlateThickness" vis="EcalBarrelSliceVis"/>
         <slice material="SciFiPb_PbGlue_Edge" thickness="EcalBarrel_RadiatorEdgeThickness" vis="EcalBarrelSliceVis"/>
         <slice material="SciFiPb_PbGlue" thickness="EcalBarrel_RadiatorThickness" vis="EcalBarrelFiberLayerVis">
           <fiber material="SciFiPb_Scintillator"
@@ -260,12 +254,10 @@
           </fiber>
         </slice>
         <slice material="SciFiPb_PbGlue_Edge" thickness="EcalBarrel_RadiatorEdgeThickness" vis="EcalBarrelSliceVis"/>
-        <slice material="Aluminum" thickness="EcalBarrel_AluminumPlateThickness" vis="EcalBarrelSliceVis"/>
       </layer>
 
       <layer repeat="1" vis="EcalBarrelLayerVis"
              space_before="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween">
-        <slice material="Aluminum" thickness="EcalBarrel_AluminumPlateThickness" vis="EcalBarrelSliceVis"/>
         <slice material="SciFiPb_PbGlue_Edge" thickness="EcalBarrel_RadiatorEdgeThickness" vis="EcalBarrelSliceVis"/>
         <slice material="SciFiPb_PbGlue" thickness="EcalBarrel_RadiatorThickness" vis="EcalBarrelFiberLayerVis">
           <fiber material="SciFiPb_Scintillator"

--- a/compact/ecal/barrel_interlayers.xml
+++ b/compact/ecal/barrel_interlayers.xml
@@ -21,15 +21,14 @@
     <constant name="EcalBarrelImagingLayers_num"     value="6"/>
     <comment>
       Active part of the calorimeter is
-      215 cm long in e-going
-      221.5 cm long in p-going
-      -42 cm offset
+      435 cm long
+      -41.25 cm offset
     </comment>
     <constant name="EcalBarrel_Calorimeter_zmin"
-      value="min(260.25*cm, EcalBarrelBackward_zmax)"/>
+      value="min(258.75*cm, EcalBarrelBackward_zmax)"/>
     <constant name="EcalBarrel_Calorimeter_zmax"
       value="min(176.25*cm, EcalBarrelForward_zmax)"/>
-    <constant name="EcalBarrel_Readout_zmin"          value="275.25*cm"/>
+    <constant name="EcalBarrel_Readout_zmin"          value="273.75*cm"/>
     <constant name="EcalBarrel_Readout_zmax"          value="191.25*cm"/>
     <constant name="EcalBarrel_Calorimeter_length"
       value="EcalBarrel_Calorimeter_zmax + EcalBarrel_Calorimeter_zmin"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Changes the size of Barrel ECal to the current envelope r=82 cm, length in z = 435 cm (active SciFi/Pb matrix).
Removes the Aluminum support planes of SciFi/Pb, and replaces them with thicker Carbon Fiber planes according to the newest geometry. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature 
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
yes