### PR TITLE
fix: correct warning message when using setup.sh

### DIFF
--- a/templates/thisepic.sh.in
+++ b/templates/thisepic.sh.in
@@ -7,7 +7,7 @@ export DETECTOR_CONFIG=${1:-@PROJECT_NAME@}
 ## Warn is not the right name (this script is sourced, hence $1)
 if [[ "$(basename ${BASH_SOURCE[0]})" != "thisepic.sh" ]]; then
         echo "Warning: This script will cease to exist at '$(realpath --no-symlinks ${BASH_SOURCE[0]})'."
-        echo "         Please use the version at '$(realpath --no-symlinks $(dirname ${BASH_SOURCE[0]})/thisepic.sh)'."
+        echo "         Please use the version at '$(realpath --no-symlinks $(dirname ${BASH_SOURCE[0]})/bin/thisepic.sh)'."
 fi
 
 ## Export detector libraries


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes the warning which said:
```
Warning: This script will cease to exist at '/opt/detector/epic-main/setup.sh'.
         Please use the version at '/opt/detector/epic-main/thisepic.sh'.
```
to say the following instead:
```
Warning: This script will cease to exist at '/opt/detector/epic-main/setup.sh'.
         Please use the version at '/opt/detector/epic-main/bin/thisepic.sh'.
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.