### PR TITLE
[Backport 24.05] fix: correct warning message when using setup.sh

### DIFF
--- a/templates/thisepic.sh.in
+++ b/templates/thisepic.sh.in
@@ -7,7 +7,7 @@ export DETECTOR_CONFIG=${1:-@PROJECT_NAME@}
 ## Warn is not the right name (this script is sourced, hence $1)
 if [[ "$(basename ${BASH_SOURCE[0]})" != "thisepic.sh" ]]; then
         echo "Warning: This script will cease to exist at '$(realpath --no-symlinks ${BASH_SOURCE[0]})'."
-        echo "         Please use the version at '$(realpath --no-symlinks $(dirname ${BASH_SOURCE[0]})/thisepic.sh)'."
+        echo "         Please use the version at '$(realpath --no-symlinks $(dirname ${BASH_SOURCE[0]})/bin/thisepic.sh)'."
 fi
 
 ## Export detector libraries


### PR DESCRIPTION
# Description
Backport of #734 to `24.05`.