### PR TITLE
linux-eic-shell.yml: trigger {physics,reconstruction}_benchmarks directly

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -523,21 +523,24 @@ jobs:
     strategy:
       matrix:
         detector_config: [epic_craterlake]
-        benchmark_repo: [detector_benchmarks, physics_benchmarks]
+        benchmark_repo: [detector_benchmarks, physics_benchmarks, reconstruction_benchmarks]
         include:
         - benchmark_repo: detector_benchmarks
           project_id: 399
-          secret_name: EICWEB_DETECTOR_BENCHMARK_TRIGGER
+          secret_var: EICWEB_DETECTOR_BENCHMARK_TRIGGER
         - benchmark_repo: physics_benchmarks
           project_id: 400
-          secret_name: EICWEB_PHYSICS_BENCHMARK_TRIGGER
+          secret_var: EICWEB_PHYSICS_BENCHMARK_TRIGGER
+        - benchmark_repo: reconstruction_benchmarks
+          project_id: 408
+          secret_var: EICWEB_RECONSTRUCTION_BENCHMARK_TRIGGER
     steps:
     - uses: eic/trigger-gitlab-ci@v3
       id: trigger
       with:
         url: https://eicweb.phy.anl.gov
         project_id: ${{ matrix.project_id }}
-        token: ${{ secrets[matrix.secret_name] }}
+        token: ${{ secrets[matrix.secret_var] }}
         ref_name: master
         variables: |
           DETECTOR=epic

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -517,19 +517,27 @@ jobs:
           noverlaps="$(grep -c GeomVol1002 doc/overlap_check_geant4.out || true)"
           if [[ "${noverlaps}" -gt "0" ]] ; then echo "${noverlaps} overlaps found!" && false ; fi
 
-  trigger-detector-benchmarks:
+  trigger-benchmarks:
     runs-on: ubuntu-latest
     needs: [check-overlap-tgeo, check-overlap-geant4-fast]
     strategy:
       matrix:
         detector_config: [epic_craterlake]
+        benchmark_repo: [detector_benchmarks, physics_benchmarks]
+        include:
+        - benchmark_repo: detector_benchmarks
+          project_id: 399
+          secret_name: EICWEB_DETECTOR_BENCHMARK_TRIGGER
+        - benchmark_repo: physics_benchmarks
+          project_id: 400
+          secret_name: EICWEB_PHYSICS_BENCHMARK_TRIGGER
     steps:
     - uses: eic/trigger-gitlab-ci@v3
       id: trigger
       with:
         url: https://eicweb.phy.anl.gov
-        project_id: 399
-        token: ${{ secrets.EICWEB_DETECTOR_BENCHMARK_TRIGGER }}
+        project_id: ${{ matrix.project_id }}
+        token: ${{ secrets[matrix.secret_name] }}
         ref_name: master
         variables: |
           DETECTOR=epic
@@ -547,7 +555,7 @@ jobs:
           -f state="pending" \
           -f target_url="${{ steps.trigger.outputs.web_url }}" \
           -f description="Triggered... $(TZ=America/New_York date)" \
-          -f context="eicweb/detector_benchmarks (${{ matrix.detector_config }})"
+          -f context="eicweb/${{ matrix.benchmark_repo }} (${{ matrix.detector_config }})"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Trigger physics benchmarks directly. After https://github.com/eic/detector_benchmarks/pull/23, the downstream pipelines are not triggered, so we need to trigger them ourselves. This is a good opportunity start to triggering them earlier.

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No