### PR TITLE
HcalEndcapPInsert: Replace Tungsten layers with Steel layers

### DIFF
--- a/compact/hcal/forward_insert.xml
+++ b/compact/hcal/forward_insert.xml
@@ -49,8 +49,7 @@
              HcalEndcapPInsertAirThickness "
     />
     <constant name="HcalEndcapPInsertBackplateThickness"    value="HcalEndcapPInsertAbsorberThickness"/>
-    <constant name="HcalEndcapPInsertLayer_NTungstenRepeat" value="10"/>
-    <constant name="HcalEndcapPInsertLayer_NSteelRepeat"    value="54"/>
+    <constant name="HcalEndcapPInsertLayer_NSteelRepeat"    value="65"/>
   </define>
 
   <detectors>
@@ -58,7 +57,7 @@
       ### Forward (Positive Z) Endcap Insert for Hadronic Calorimeter
       Insert goes in the middle of the forward endcap HCal -- around the beampipe
 
-      Insert is 1 front layer of Steel/Sc, 10 layers of W/Sc, 54 layers of Steel/Sc + 1 backplate of steel
+      Insert is 65 layers of Steel/Sc + 1 backplate of steel
       Each of the layers (sans backplate) includes air gaps (front and back of each layer),
       ESR foil (front and back of scintillator), a PCB, and an aluminum scitnillator cover
 
@@ -84,27 +83,6 @@
       <backplate thickness="HcalEndcapPInsertBackplateThickness"/>
       <comment> Front layer to match front walls of LFHCAL modules </comment>
       <comment> Slices will be ordered according to the slice order listed here </comment>
-      <layer repeat="1" thickness="HcalEndcapPInsertFrontLayerThickness" vis="InvisibleWithDaughters">
-        <slice material="Steel235" thickness="LFHCAL_FrontWallThickness" vis="LFHCAL8MModVis" />
-        <slice material="Air" thickness="HcalEndcapPInsertAirThickness"/>
-        <slice material="Aluminum" thickness="HcalEndcapPInsertScintillatorCoverThickness" vis="AnlProcess_Blue"/>
-        <slice material="Polystyrene" thickness="HcalEndcapPInsertESRFoilThickness" vis="AnlGray"/>
-        <slice material="Polystyrene" thickness="HcalEndcapPInsertPolystyreneThickness" sensitive="true" limits="cal_limits" vis="AnlLightGray"/>
-        <slice material="Polystyrene" thickness="HcalEndcapPInsertESRFoilThickness" vis="AnlGray"/>
-        <slice material="Fr4" thickness="HcalEndcapPInsertPCBThickness"/>
-        <slice material="Air" thickness="HcalEndcapPInsertAirThickness"/>
-      </layer>
-      <comment> Tungsten/Scintillator layers </comment>
-      <layer repeat="HcalEndcapPInsertLayer_NTungstenRepeat" thickness="HcalEndcapPInsertSingleLayerThickness" vis="InvisibleWithDaughters">
-        <slice material="Tungsten" thickness="HcalEndcapPInsertAbsorberThickness" vis="LFHCAL4MModVis" />
-        <slice material="Air" thickness="HcalEndcapPInsertAirThickness"/>
-        <slice material="Aluminum" thickness="HcalEndcapPInsertScintillatorCoverThickness" vis="AnlProcess_Blue"/>
-        <slice material="Polystyrene" thickness="HcalEndcapPInsertESRFoilThickness" vis="AnlGray"/>
-        <slice material="Polystyrene" thickness="HcalEndcapPInsertPolystyreneThickness" sensitive="true" limits="cal_limits" vis="AnlLightGray"/>
-        <slice material="Polystyrene" thickness="HcalEndcapPInsertESRFoilThickness" vis="AnlGray"/>
-        <slice material="Fr4" thickness="HcalEndcapPInsertPCBThickness"/>
-        <slice material="Air" thickness="HcalEndcapPInsertAirThickness"/>
-      </layer>
       <comment> Steel/Sc layers </comment>
       <layer repeat="HcalEndcapPInsertLayer_NSteelRepeat" thickness="HcalEndcapPInsertSingleLayerThickness" vis="InvisibleWithDaughters">
         <slice material="Steel235" thickness="HcalEndcapPInsertAbsorberThickness" vis="LFHCAL8MModVis"/>

--- a/compact/hcal/forward_insert.xml
+++ b/compact/hcal/forward_insert.xml
@@ -49,7 +49,7 @@
              HcalEndcapPInsertAirThickness "
     />
     <constant name="HcalEndcapPInsertBackplateThickness"    value="HcalEndcapPInsertAbsorberThickness"/>
-    <constant name="HcalEndcapPInsertLayer_NSteelRepeat"    value="65"/>
+    <constant name="HcalEndcapPInsertLayer_NSteelRepeat"    value="64"/>
   </define>
 
   <detectors>
@@ -57,7 +57,7 @@
       ### Forward (Positive Z) Endcap Insert for Hadronic Calorimeter
       Insert goes in the middle of the forward endcap HCal -- around the beampipe
 
-      Insert is 65 layers of Steel/Sc + 1 backplate of steel
+      Insert is 1 front layer of Steel/Sc + 64 layers of Steel/Sc + 1 backplate of steel
       Each of the layers (sans backplate) includes air gaps (front and back of each layer),
       ESR foil (front and back of scintillator), a PCB, and an aluminum scitnillator cover
 
@@ -83,6 +83,16 @@
       <backplate thickness="HcalEndcapPInsertBackplateThickness"/>
       <comment> Front layer to match front walls of LFHCAL modules </comment>
       <comment> Slices will be ordered according to the slice order listed here </comment>
+       <layer repeat="1" thickness="HcalEndcapPInsertFrontLayerThickness" vis="InvisibleWithDaughters">
+        <slice material="Steel235" thickness="LFHCAL_FrontWallThickness" vis="LFHCAL8MModVis" />
+        <slice material="Air" thickness="HcalEndcapPInsertAirThickness"/>
+        <slice material="Aluminum" thickness="HcalEndcapPInsertScintillatorCoverThickness" vis="AnlProcess_Blue"/>
+        <slice material="Polystyrene" thickness="HcalEndcapPInsertESRFoilThickness" vis="AnlGray"/>
+        <slice material="Polystyrene" thickness="HcalEndcapPInsertPolystyreneThickness" sensitive="true" limits="cal_limits" vis="AnlLightGray"/>
+        <slice material="Polystyrene" thickness="HcalEndcapPInsertESRFoilThickness" vis="AnlGray"/>
+        <slice material="Fr4" thickness="HcalEndcapPInsertPCBThickness"/>
+        <slice material="Air" thickness="HcalEndcapPInsertAirThickness"/>
+      </layer>
       <comment> Steel/Sc layers </comment>
       <layer repeat="HcalEndcapPInsertLayer_NSteelRepeat" thickness="HcalEndcapPInsertSingleLayerThickness" vis="InvisibleWithDaughters">
         <slice material="Steel235" thickness="HcalEndcapPInsertAbsorberThickness" vis="LFHCAL8MModVis"/>


### PR DESCRIPTION
Use only steel absorbers (replace tungsten layers with steel)

### Briefly, what does this PR introduce?
Changes the materials used in the calorimeter insert to use only steel layers for the aborbers, rather than using tungsten.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other: update to materials used in the detector

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
This could cause issues with EICrecon, since the sampling fraction will need to be changed in the code.  
### Does this PR change default behavior?
Yes.  