### PR TITLE
FileLoaderHelper: reduce printout verbosity

### DIFF
--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -18,7 +18,7 @@
 
 namespace fs = std::filesystem;
 
-using dd4hep::ERROR, dd4hep::WARNING, dd4hep::INFO;
+using dd4hep::ERROR, dd4hep::WARNING, dd4hep::VERBOSE, dd4hep::INFO;
 using dd4hep::printout;
 
 namespace FileLoaderHelper {

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -89,11 +89,11 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
       printout(INFO, "FileLoader", "cache " + cache_path.string());
       if (fs::exists(cache_path)) {
         auto check_path = [&](const fs::path& cache_dir_path) {
-          printout(INFO, "FileLoader", "checking " + cache_dir_path.string());
+          printout(VERBOSE, "FileLoader", "checking " + cache_dir_path.string());
           fs::path cache_hash_path = cache_dir_path / hash;
           if (fs::exists(cache_hash_path)) {
             // symlink hash to cache/.../hash
-            printout(INFO, "FileLoader",
+            printout(VERBOSE, "FileLoader",
                      "file " + file + " with hash " + hash + " found in " +
                          cache_hash_path.string());
             fs::path link_target;


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Removes lengthy output like
```
FileLoader       INFO  checking /opt/detector/epic-24.04.0/.spack/epic/repos/eic/packages/root
FileLoader       INFO  checking /opt/detector/epic-24.04.0/.spack/epic/repos/eic/packages/geant4
FileLoader       INFO  checking /opt/detector/epic-24.04.0/.spack/epic/repos/eic/packages/podio
FileLoader       INFO  checking /opt/detector/epic-24.04.0/.spack/epic/repos/eic/packages/dd4hep
FileLoader       INFO  checking /opt/detector/epic-24.04.0/.spack/epic/repos/eic/packages/epic
FileLoader       INFO  checking /opt/detector/epic-24.04.0/.spack/epic/repos/eic/packages/hepmc3
FileLoader       INFO  checking /opt/detector/epic-24.04.0/.spack/epic/archived-files
FileLoader       INFO  checking /opt/detector/epic-24.04.0/.spack/epic/archived-files/spack-build-xozo5y2
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No