### PR TITLE
fix: remove FileLoader symlink unconditionally

### DIFF
--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -75,8 +75,8 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
     return;
   }
 
-  if (fs::exists(fs::symlink_status(hash_path)) && !fs::exists(fs::status(hash_path))) {
-    printout(INFO, "FileLoader", "removing broken \"" + hash_path.string() + "\" symlink");
+  if (fs::exists(fs::symlink_status(hash_path))) {
+    printout(INFO, "FileLoader", "removing symlink \"" + hash_path.string() + "\"");
     remove(hash_path);
   }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR modifies the FileLoader to remove the hash symlink unconditionally, whether broken or not. This should fix an issue where the symlink exists, points to another symlink, and that is a dead link.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: permission denied error)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.