### PR TITLE
configurations/: enable MARCO field for central single-detector configurations

### DIFF
--- a/configurations/backward_hcal_only.yml
+++ b/configurations/backward_hcal_only.yml
@@ -1,4 +1,6 @@
 features:
+  fields:
+    marco:
   hcal:
     backward:
     backward_endcap_flux:

--- a/configurations/bhcal.yml
+++ b/configurations/bhcal.yml
@@ -1,5 +1,6 @@
 features:
-  solenoid:
   beampipe:
+  fields:
+    marco:
   hcal:
     barrel_gdml:

--- a/configurations/craterlake_tracking_only.yml
+++ b/configurations/craterlake_tracking_only.yml
@@ -1,7 +1,7 @@
 features:
+  beampipe:
   fields:
     marco:
-  beampipe:
   tracking:
     definitions_craterlake:
     vertex_barrel:

--- a/configurations/eeemcal_only.yml
+++ b/configurations/eeemcal_only.yml
@@ -1,7 +1,5 @@
 features:
-  #  beampipe:
-  tracking:
-    definitions_craterlake:
-    support_service_craterlake:
+  fields:
+    marco:
   ecal:
     backward_PbWO4:

--- a/configurations/forward_detectors.yml
+++ b/configurations/forward_detectors.yml
@@ -1,5 +1,7 @@
 features:
   beampipe:
+  fields:
+    marco:
   tracking:
     definitions_craterlake:
     vertex_barrel:

--- a/configurations/forward_detectors_with_inserts.yml
+++ b/configurations/forward_detectors_with_inserts.yml
@@ -1,5 +1,7 @@
 features:
   beampipe:
+  fields:
+    marco:
   tracking:
     definitions_craterlake:
     vertex_barrel:

--- a/configurations/inner_detector.yml
+++ b/configurations/inner_detector.yml
@@ -1,5 +1,7 @@
 features:
   beampipe:
+  fields:
+    marco:
   tracking:
     definitions_craterlake:
     vertex_barrel:

--- a/configurations/lfhcal_only.yml
+++ b/configurations/lfhcal_only.yml
@@ -1,3 +1,5 @@
 features:
+  fields:
+    marco:
   hcal:
     lfhcal_without_space_for_insert:

--- a/configurations/lfhcal_with_insert.yml
+++ b/configurations/lfhcal_with_insert.yml
@@ -1,4 +1,6 @@
 features:
+  fields:
+    marco:
   hcal:
     lfhcal_with_space_for_insert:
     forward_insert:


### PR DESCRIPTION
Simulating without field is not very useful. Most of the configurations are already doing this, we'd like to make things more consistent.