### PR TITLE
Update beamline_5x41_H2.xml

### DIFF
--- a/compact/fields/beamline_5x41_H2.xml
+++ b/compact/fields/beamline_5x41_H2.xml
@@ -3,7 +3,7 @@
 
   <define>
 
-    <constant name="ElectronBeamEnergy" value="18*GeV"  />
+    <constant name="ElectronBeamEnergy" value="5*GeV"  />
     <constant name="IonBeamEnergy"      value="82*GeV" />
 
     <constant name="FieldScaleFactor" value="82.0/275.0"  /> <!-- only use for light ion beams!!! ASK FF EXPERTS -->


### PR DESCRIPTION
Electron beam energy in 5x41 should be 5GeV rather than 18GeV

### What kind of change does this PR introduce?
- [x] Bug fix
