### PR TITLE
Update sensor geometry for rp

### DIFF
--- a/compact/display.xml
+++ b/compact/display.xml
@@ -50,14 +50,14 @@
 
 
     <vis name="FFTrackerVis"        ref="AnlRed" />
-    <vis name="FFTrackerSupportVis" ref="AnlBlue"             visible="true"  showDaughters="false" />
-    <vis name="FFTrackerShieldingVis" ref="AnlGray"           visible="true"  showDaughters="false" />
-    <vis name="FFTrackerServiceVis" ref="AnlGold"             visible="true"  showDaughters="false" />
+    <vis name="FFTrackerSupportVis" ref="AnlBlue"             visible="true"  showDaughters="true" />
+    <vis name="FFTrackerShieldingVis" ref="AnlLightGray"           visible="true"  showDaughters="true" />
+    <vis name="FFTrackerServiceVis" ref="AnlGold"             visible="true"  showDaughters="true" />
     <vis name="FFTrackerLayerVis"   ref="TrackerVis"          visible="true"  showDaughters="true" />
     <vis name="FFTrackerModuleVis"  ref="FFTrackerLayerVis"   visible="true"  showDaughters="true" />
     <vis name="FFTrackerSurfaceVis" ref="FFTrackerLayerVis"   visible="true"  showDaughters="true" />
     <comment> For shielded modules by default just display to module instead of 6 layers </comment>
-    <vis name="FFTrackerShieldedModuleVis" ref="FFTrackerModuleVis"   visible="true"  showDaughters="false" />
+    <vis name="FFTrackerShieldedModuleVis" ref="FFTrackerModuleVis"   visible="true"  showDaughters="true" />
 
     <comment>
       Luminosity Visualisation

--- a/compact/far_forward/roman_pots_eRD24_design.xml
+++ b/compact/far_forward/roman_pots_eRD24_design.xml
@@ -8,7 +8,7 @@
             Roman Pots Implementation updated strawman layout (only layer materials)
             Author: Alex Jentsch
             Date of first commit: June 15th, 2021
-	    Last update: Oct 4th, 2024
+	        Last update: Oct 8th, 2024
             ---------------------------------
         </comment>
 
@@ -22,23 +22,10 @@
         <constant name="ForwardRomanPotStation1_rotation" value="-0.04545*rad"/>
         <constant name="ForwardRomanPotStation2_rotation" value="-0.04545*rad"/>
 
-        <constant name="ForwardRomanPotStation1_insertionPosition" value="0.0*cm"/>
-        <constant name="ForwardRomanPotStation2_insertionPosition" value="0.0*cm"/>
-
-	<!-- -->
-	<!-- these will be moved to the beam energy configuration files in a separate PR and this comment removed -->
-	<!-- -->
-	<!--
-	<constant name="offset_central_RP_section" value ="0.27*cm"/>
-	<constant name="offset_intermediate_1_RP_section" value ="0.0*cm"/>
-	<constant name="offset_intermediate_2_RP_section" value ="0.0*cm"/>
-	<constant name="offset_outer_RP_section" value ="0.0*cm"/>
-	-->
-
         <!-- Module/layer information -->
         <!-- Each module is simply a 1.6cm wide by 1.6cm tall square -->
 
-        <!-- Module insertion positions -->
+        <!-- Module insertion positions set by beam energy config in epic/compact/fields/beamline_XXXXX.xml -->
 
         <constant name="ForwardRomanPotStation1_insertion_central" value="2.4*cm + offset_central_RP_section"/>
         <constant name="ForwardRomanPotStation2_insertion_central" value="2.4*cm + offset_central_RP_section"/>
@@ -53,7 +40,7 @@
         <constant name="ForwardRomanPotStation2_insertion_outer" value="2.4*cm + offset_outer_RP_section"/>
 
         
-        <!-- Each module is a sandwich of 1mm aluminum, 0.3mm air, 0.3mm silicon, 0.3mm inactive silicon, 0.3mm copper, and 1mm aluminum -->
+        <!-- Each module is a sandwich of 1mm aluminum, 0.3mm air, 0.3mm silicon AC-LGAD, 0.3mm inactive silicon ASIC, 0.3mm copper cooling, and 1mm aluminum -->
         <!-- Vacuum is between each module -->
 
         <!-- module size -->
@@ -97,11 +84,11 @@
                 <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
             </module>
             <module_assembly name="Station1Top">
-                <array nx="5" ny="3" module="ModuleRP1" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
-                    <position x="5.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_outer"/>
+                <array nx="6" ny="3" module="ModuleRP1" width="6*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                    <position x="6.0*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_outer"/>
                 </array>
-                <array nx="5" ny="3" module="ModuleRP1" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
-                    <position x="-5.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_outer"/>
+                <array nx="6" ny="3" module="ModuleRP1" width="6*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                    <position x="-6.0*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_outer"/>
                 </array>
                 <array nx="2" ny="3" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
                     <position x="0" y="ForwardRomanPotStation1_insertion_central"/>
@@ -120,11 +107,11 @@
                 </array>
             </module_assembly>
             <module_assembly name="Station1Bottom">
-		    <array nx="5" ny="3" module="ModuleRP1" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
-                        <position x="5.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_outer"/>
-                    </array>
-                    <array nx="5" ny="3" module="ModuleRP1" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
-                        <position x="-5.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_outer"/>
+		        <array nx="6" ny="3" module="ModuleRP1" width="6*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="6.0*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_outer"/>
+                </array>
+                    <array nx="6" ny="3" module="ModuleRP1" width="6*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="-6.0*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_outer"/>
                     </array>
                     <array nx="2" ny="3" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
                         <position x="0" y="-ForwardRomanPotStation1_insertion_central"/>
@@ -183,11 +170,11 @@
                 <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
             </module>
             <module_assembly name="Station2Top">
-                    <array nx="5" ny="3" module="ModuleRP2" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
-                        <position x="5.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_outer"/>
+                    <array nx="6" ny="3" module="ModuleRP2" width="6*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="6.0*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_outer"/>
                     </array>
-                    <array nx="5" ny="3" module="ModuleRP2" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
-                        <position x="-5.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_outer"/>
+                    <array nx="6" ny="3" module="ModuleRP2" width="6*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="-6.0*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_outer"/>
                     </array>
                     <array nx="2" ny="3" module="ModuleRP2" width="2*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
                         <position x="0" y="ForwardRomanPotStation1_insertion_central"/>
@@ -206,11 +193,11 @@
                     </array>
             </module_assembly>
             <module_assembly name="Station2Bottom">
-                    <array nx="5" ny="3" module="ModuleRP2" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
-                        <position x="5.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_outer"/>
+                    <array nx="6" ny="3" module="ModuleRP2" width="6*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="6.0*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_outer"/>
                     </array>
-                    <array nx="5" ny="3" module="ModuleRP2" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
-                        <position x="-5.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_outer"/>
+                    <array nx="6" ny="3" module="ModuleRP2" width="6*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="-6.0*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_outer"/>
                     </array>
                     <array nx="2" ny="3" module="ModuleRP2" width="2*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
                         <position x="0" y="-ForwardRomanPotStation1_insertion_central"/>

--- a/compact/far_forward/roman_pots_eRD24_design.xml
+++ b/compact/far_forward/roman_pots_eRD24_design.xml
@@ -8,7 +8,7 @@
             Roman Pots Implementation updated strawman layout (only layer materials)
             Author: Alex Jentsch
             Date of first commit: June 15th, 2021
-	        Last update: Oct 8th, 2024
+                Last update: Oct 8th, 2024
             ---------------------------------
         </comment>
 
@@ -32,14 +32,14 @@
 
         <constant name="ForwardRomanPotStation1_insertion_intermediate" value="2.4*cm + offset_intermediate_1_RP_section"/>
         <constant name="ForwardRomanPotStation2_insertion_intermediate" value="2.4*cm + offset_intermediate_1_RP_section"/>
-	
+
         <constant name="ForwardRomanPotStation1_insertion_intermediate_541" value="2.4*cm + offset_intermediate_2_RP_section"/>
         <constant name="ForwardRomanPotStation2_insertion_intermediate_541" value="2.4*cm + offset_intermediate_2_RP_section"/>
 
         <constant name="ForwardRomanPotStation1_insertion_outer" value="2.4*cm + offset_outer_RP_section"/>
         <constant name="ForwardRomanPotStation2_insertion_outer" value="2.4*cm + offset_outer_RP_section"/>
 
-        
+
         <!-- Each module is a sandwich of 1mm aluminum, 0.3mm air, 0.3mm silicon AC-LGAD, 0.3mm inactive silicon ASIC, 0.3mm copper cooling, and 1mm aluminum -->
         <!-- Vacuum is between each module -->
 
@@ -107,7 +107,7 @@
                 </array>
             </module_assembly>
             <module_assembly name="Station1Bottom">
-		        <array nx="6" ny="3" module="ModuleRP1" width="6*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <array nx="6" ny="3" module="ModuleRP1" width="6*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
                         <position x="6.0*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_outer"/>
                 </array>
                     <array nx="6" ny="3" module="ModuleRP1" width="6*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
@@ -127,7 +127,7 @@
                     </array>
                     <array nx="1" ny="3" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
                         <position x="-2.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_intermediate_541"/>
-                    </array>    
+                    </array>
             </module_assembly>
 
             <layer id="1" vis="FFTrackerLayerVis">

--- a/compact/far_forward/roman_pots_eRD24_design.xml
+++ b/compact/far_forward/roman_pots_eRD24_design.xml
@@ -174,7 +174,7 @@
                 vis="FFTrackerVis">
             <position x="ForwardRomanPotStation2_xpos" y="0" z="ForwardRomanPotStation2_zpos" />
             <rotation x="0" y="ForwardRomanPotStation1_rotation" z="0" />
-            <module name="ModuleRP2" vis="FFTrackerShieldedModuleVis" nx="2" ny="2" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
+            <module name="ModuleRP2" vis="FFTrackerShieldedModuleVis" nx="1" ny="1" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
                 <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
                 <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />
                 <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />
@@ -255,7 +255,7 @@
     <readouts>
         <readout name="ForwardRomanPotHits">
             <segmentation type="CartesianGridXY" grid_size_x="0.5*mm" grid_size_y="0.5*mm" />
-            <id>system:8,assembly:3,layer:4,module:4,sensor:4,x:32:-16,y:-16</id>
+            <id>system:8,assembly:3,layer:4,module:8,sensor:8,x:32:-16,y:-16</id>
         </readout>
     </readouts>
 

--- a/compact/far_forward/roman_pots_eRD24_design.xml
+++ b/compact/far_forward/roman_pots_eRD24_design.xml
@@ -5,9 +5,10 @@
     <define>
         <comment>
             ---------------------------------
-            Roman Pots Implementation from eRD24 RD Effort
+            Roman Pots Implementation updated strawman layout (only layer materials)
             Author: Alex Jentsch
             Date of first commit: June 15th, 2021
+	    Last update: Oct 4th, 2024
             ---------------------------------
         </comment>
 
@@ -24,42 +25,41 @@
         <constant name="ForwardRomanPotStation1_insertionPosition" value="0.0*cm"/>
         <constant name="ForwardRomanPotStation2_insertionPosition" value="0.0*cm"/>
 
+	<!-- -->
+	<!-- these will be moved to the beam energy configuration files in a separate PR and this comment removed -->
+	<!-- -->
+	
+	<constant name="offset_central_RP_section" value ="0.27*cm"/>
+	<constant name="offset_intermediate_1_RP_section" value ="0.0*cm"/>
+	<constant name="offset_intermediate_2_RP_section" value ="0.0*cm"/>
+	<constant name="offset_outer_RP_section" value ="0.0*cm"/>
+
+
         <!-- Module/layer information -->
-        <!-- Each module is simply a 3.2cm wide by 3.2cm tall square -->
+        <!-- Each module is simply a 1.6cm wide by 1.6cm tall square -->
 
         <!-- Module insertion positions -->
 
-        <constant name="ForwardRomanPotStation1_insertion_outer" value="3.2*cm"/>
-        <constant name="ForwardRomanPotStation2_insertion_outer" value="3.2*cm"/>
+        <constant name="ForwardRomanPotStation1_insertion_central" value="2.4*cm + offset_central_RP_section"/>
+        <constant name="ForwardRomanPotStation2_insertion_central" value="2.4*cm + offset_central_RP_section"/>
 
-        <!-- HIGH ACCEPTANCE VALUES -->
+        <constant name="ForwardRomanPotStation1_insertion_intermediate" value="2.4*cm + offset_intermediate_1_RP_section"/>
+        <constant name="ForwardRomanPotStation2_insertion_intermediate" value="2.4*cm + offset_intermediate_1_RP_section"/>
+	
+        <constant name="ForwardRomanPotStation1_insertion_intermediate_541" value="2.4*cm + offset_intermediate_2_RP_section"/>
+        <constant name="ForwardRomanPotStation2_insertion_intermediate_541" value="2.4*cm + offset_intermediate_2_RP_section"/>
 
-        <constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
-        <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
+        <constant name="ForwardRomanPotStation1_insertion_outer" value="2.4*cm + offset_outer_RP_section"/>
+        <constant name="ForwardRomanPotStation2_insertion_outer" value="2.4*cm + offset_outer_RP_section"/>
 
-        <constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
-        <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
-
-
-        <!-- HIGH DIVERGENCE VALUES -->
-
-        <comment>
-
-            <constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
-            <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
-
-            <constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
-            <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
-
-        </comment>
-
+        
         <!-- Each module is a sandwich of 1mm aluminum, 0.3mm air, 0.3mm silicon, 0.3mm inactive silicon, 0.3mm copper, and 1mm aluminum -->
         <!-- Vacuum is between each module -->
 
         <!-- module size -->
 
-        <constant name="ForwardRomanPot_ModuleWidth"  value="32.0*mm"/>
-        <constant name="ForwardRomanPot_ModuleHeight"   value="32.0*mm"/>
+        <constant name="ForwardRomanPot_ModuleWidth"  value="1.6*cm"/>
+        <constant name="ForwardRomanPot_ModuleHeight"   value="1.6*cm"/>
 
         <!-- materials -->
         <!-- <constant name="ForwardRomanPot_RFShieldMat"     value="StainlessSteel"/> -->
@@ -88,48 +88,59 @@
                 reflect="false" vis="FFTrackerVis">
             <position x="ForwardRomanPotStation1_xpos" y="0" z="ForwardRomanPotStation1_zpos" />
             <rotation x="0" y="ForwardRomanPotStation1_rotation" z="0" />
-            <module name="ModuleRP1" vis="FFTrackerShieldedModuleVis" nx="2" ny="2" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
+            <module name="ModuleRP1" vis="FFTrackerShieldedModuleVis" nx="1" ny="1" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
                 <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
                 <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />
                 <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />
                 <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardRomanPot_LGADThickness" sensitive="true"/>
                 <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardRomanPot_ShieldingAirLayerThickness"/>
                 <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
-                <!--<module_component material="Vacuum"       thickness="ForwardRomanPot_LayerSeparationThickness"/>-->
             </module>
             <module_assembly name="Station1Top">
-                <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="(6*ForwardRomanPot_ModuleWidth)/2.0" y="ForwardRomanPotStation1_insertion_outer"/>
+                <array nx="5" ny="3" module="ModuleRP1" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                    <position x="5.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_outer"/>
                 </array>
-                <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="ForwardRomanPotStation1_insertion_outer"/>
+                <array nx="5" ny="3" module="ModuleRP1" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                    <position x="-5.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_outer"/>
                 </array>
-                <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
+                <array nx="2" ny="3" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
                     <position x="0" y="ForwardRomanPotStation1_insertion_central"/>
                 </array>
-                <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
+                <array nx="1" ny="3" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                    <position x="1.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_intermediate"/>
                 </array>
-                <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
+                <array nx="1" ny="3" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                    <position x="-1.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_intermediate"/>
+                </array>
+                <array nx="1" ny="3" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                    <position x="2.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_intermediate_541"/>
+                </array>
+                <array nx="1" ny="3" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                    <position x="-2.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_intermediate_541"/>
                 </array>
             </module_assembly>
             <module_assembly name="Station1Bottom">
-                <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="(4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0" y="-ForwardRomanPotStation1_insertion_outer"/>
-                </array>
-                <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="-ForwardRomanPotStation1_insertion_outer"/>
-                </array>
-                <array nx="2" ny="2" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="0" y="-ForwardRomanPotStation1_insertion_central"/>
-                </array>
-                <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
-                </array>
-                <array nx="1" ny="2" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
-                </array>
+		    <array nx="5" ny="3" module="ModuleRP1" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="5.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_outer"/>
+                    </array>
+                    <array nx="5" ny="3" module="ModuleRP1" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="-5.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_outer"/>
+                    </array>
+                    <array nx="2" ny="3" module="ModuleRP1" width="2*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="0" y="-ForwardRomanPotStation1_insertion_central"/>
+                    </array>
+                    <array nx="1" ny="3" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="1.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_intermediate"/>
+                    </array>
+                    <array nx="1" ny="3" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="-1.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_intermediate"/>
+                    </array>
+                    <array nx="1" ny="3" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="2.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_intermediate_541"/>
+                    </array>
+                    <array nx="1" ny="3" module="ModuleRP1" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="-2.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_intermediate_541"/>
+                    </array>    
             </module_assembly>
 
             <layer id="1" vis="FFTrackerLayerVis">
@@ -163,7 +174,7 @@
                 vis="FFTrackerVis">
             <position x="ForwardRomanPotStation2_xpos" y="0" z="ForwardRomanPotStation2_zpos" />
             <rotation x="0" y="ForwardRomanPotStation1_rotation" z="0" />
-            <module name="Module1" vis="FFTrackerShieldedModuleVis" nx="2" ny="2" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
+            <module name="ModuleRP2" vis="FFTrackerShieldedModuleVis" nx="2" ny="2" width="ForwardRomanPot_ModuleWidth" height="ForwardRomanPot_ModuleHeight">
                 <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
                 <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ThermalStripThickness" />
                 <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardRomanPot_ASICThickness"  />
@@ -172,38 +183,50 @@
                 <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardRomanPot_RFShieldThickness"/>
             </module>
             <module_assembly name="Station2Top">
-                <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="(4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0" y="ForwardRomanPotStation1_insertion_outer"/>
-                </array>
-                <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="ForwardRomanPotStation1_insertion_outer"/>
-                </array>
-                <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="0" y="ForwardRomanPotStation1_insertion_central"/>
-                </array>
-                <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
-                </array>
-                <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="ForwardRomanPotStation1_insertion_intermediate"/>
-                </array>
+                    <array nx="5" ny="3" module="ModuleRP2" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="5.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_outer"/>
+                    </array>
+                    <array nx="5" ny="3" module="ModuleRP2" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="-5.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_outer"/>
+                    </array>
+                    <array nx="2" ny="3" module="ModuleRP2" width="2*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="0" y="ForwardRomanPotStation1_insertion_central"/>
+                    </array>
+                    <array nx="1" ny="3" module="ModuleRP2" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="1.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_intermediate"/>
+                    </array>
+                    <array nx="1" ny="3" module="ModuleRP2" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="-1.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_intermediate"/>
+                    </array>
+                    <array nx="1" ny="3" module="ModuleRP2" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="2.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_intermediate_541"/>
+                    </array>
+                    <array nx="1" ny="3" module="ModuleRP2" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="-2.5*ForwardRomanPot_ModuleWidth" y="ForwardRomanPotStation1_insertion_intermediate_541"/>
+                    </array>
             </module_assembly>
             <module_assembly name="Station2Bottom">
-                <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="(4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0" y="-ForwardRomanPotStation1_insertion_outer"/>
-                </array>
-                <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="-ForwardRomanPotStation1_insertion_outer"/>
-                </array>
-                <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="0" y="-ForwardRomanPotStation1_insertion_central"/>
-                </array>
-                <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
-                </array>
-                <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
-                    <position x="-3.0*ForwardRomanPot_ModuleWidth/2.0" y="-ForwardRomanPotStation1_insertion_intermediate"/>
-                </array>
+                    <array nx="5" ny="3" module="ModuleRP2" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="5.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_outer"/>
+                    </array>
+                    <array nx="5" ny="3" module="ModuleRP2" width="5*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="-5.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_outer"/>
+                    </array>
+                    <array nx="2" ny="3" module="ModuleRP2" width="2*ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="0" y="-ForwardRomanPotStation1_insertion_central"/>
+                    </array>
+                    <array nx="1" ny="3" module="ModuleRP2" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="1.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_intermediate"/>
+                    </array>
+                    <array nx="1" ny="3" module="ModuleRP2" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="-1.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_intermediate"/>
+                    </array>
+                    <array nx="1" ny="3" module="ModuleRP2" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="2.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_intermediate_541"/>
+                    </array>
+                    <array nx="1" ny="3" module="ModuleRP2" width="ForwardRomanPot_ModuleWidth" height="3*ForwardRomanPot_ModuleHeight">
+                        <position x="-2.5*ForwardRomanPot_ModuleWidth" y="-ForwardRomanPotStation1_insertion_intermediate_541"/>
+                    </array>
             </module_assembly>
 
 

--- a/compact/far_forward/roman_pots_eRD24_design.xml
+++ b/compact/far_forward/roman_pots_eRD24_design.xml
@@ -28,12 +28,12 @@
 	<!-- -->
 	<!-- these will be moved to the beam energy configuration files in a separate PR and this comment removed -->
 	<!-- -->
-	
+	<!--
 	<constant name="offset_central_RP_section" value ="0.27*cm"/>
 	<constant name="offset_intermediate_1_RP_section" value ="0.0*cm"/>
 	<constant name="offset_intermediate_2_RP_section" value ="0.0*cm"/>
 	<constant name="offset_outer_RP_section" value ="0.0*cm"/>
-
+	-->
 
         <!-- Module/layer information -->
         <!-- Each module is simply a 1.6cm wide by 1.6cm tall square -->

--- a/compact/fields/beamline_10x100.xml
+++ b/compact/fields/beamline_10x100.xml
@@ -53,5 +53,15 @@
     <constant name="B2PF_Bmax" value="-1.74139319*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
+    
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="0.71*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="0.55*cm"/>
+    <constant name="offset_intermediate_2_RP_section" value ="0.0*cm"/>
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
 
   </define>

--- a/compact/fields/beamline_10x100.xml
+++ b/compact/fields/beamline_10x100.xml
@@ -53,10 +53,10 @@
     <constant name="B2PF_Bmax" value="-1.74139319*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
-    
+
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
+    They are not perfectly ten-sigma for reasons of physical geometry.
     </comment>
 
     <constant name="offset_central_RP_section" value ="0.71*cm"/>

--- a/compact/fields/beamline_10x110_H2.xml
+++ b/compact/fields/beamline_10x110_H2.xml
@@ -54,5 +54,17 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
+    
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    
+    Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="0.71*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="0.55*cm"/>
+    <constant name="offset_intermediate_2_RP_section" value ="0.0*cm"/>
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
 
   </define>

--- a/compact/fields/beamline_10x110_H2.xml
+++ b/compact/fields/beamline_10x110_H2.xml
@@ -54,11 +54,11 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
-    
+
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
-    
+    They are not perfectly ten-sigma for reasons of physical geometry.
+
     Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
     </comment>
 

--- a/compact/fields/beamline_10x275.xml
+++ b/compact/fields/beamline_10x275.xml
@@ -56,7 +56,7 @@
 
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
+    They are not perfectly ten-sigma for reasons of physical geometry.
     </comment>
 
     <constant name="offset_central_RP_section" value ="0.27*cm"/>

--- a/compact/fields/beamline_10x275.xml
+++ b/compact/fields/beamline_10x275.xml
@@ -54,4 +54,14 @@
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
 
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="0.27*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="0.0*cm"/>
+    <constant name="offset_intermediate_2_RP_section" value ="0.0*cm"/>
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
+
   </define>

--- a/compact/fields/beamline_18x110_Au.xml
+++ b/compact/fields/beamline_18x110_Au.xml
@@ -54,5 +54,17 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
+    
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    
+    Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="0.71*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="0.55*cm"/>
+    <constant name="offset_intermediate_2_RP_section" value ="0.0*cm"/>
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
 
   </define>

--- a/compact/fields/beamline_18x110_Au.xml
+++ b/compact/fields/beamline_18x110_Au.xml
@@ -54,11 +54,11 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
-    
+
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
-    
+    They are not perfectly ten-sigma for reasons of physical geometry.
+
     Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
     </comment>
 

--- a/compact/fields/beamline_18x110_H2.xml
+++ b/compact/fields/beamline_18x110_H2.xml
@@ -54,5 +54,17 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
+    
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    
+    Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="0.71*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="0.55*cm"/>
+    <constant name="offset_intermediate_2_RP_section" value ="0.0*cm"/>
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
 
   </define>

--- a/compact/fields/beamline_18x110_H2.xml
+++ b/compact/fields/beamline_18x110_H2.xml
@@ -54,11 +54,11 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
-    
+
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
-    
+    They are not perfectly ten-sigma for reasons of physical geometry.
+
     Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
     </comment>
 

--- a/compact/fields/beamline_18x110_He3.xml
+++ b/compact/fields/beamline_18x110_He3.xml
@@ -54,5 +54,17 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
+    
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    
+    Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="0.71*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="0.55*cm"/>
+    <constant name="offset_intermediate_2_RP_section" value ="0.0*cm"/>
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
 
   </define>

--- a/compact/fields/beamline_18x110_He3.xml
+++ b/compact/fields/beamline_18x110_He3.xml
@@ -54,11 +54,11 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
-    
+
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
-    
+    They are not perfectly ten-sigma for reasons of physical geometry.
+
     Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
     </comment>
 

--- a/compact/fields/beamline_18x110_Pb.xml
+++ b/compact/fields/beamline_18x110_Pb.xml
@@ -54,5 +54,17 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
+    
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    
+    Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="0.71*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="0.55*cm"/>
+    <constant name="offset_intermediate_2_RP_section" value ="0.0*cm"/>
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
 
   </define>

--- a/compact/fields/beamline_18x110_Pb.xml
+++ b/compact/fields/beamline_18x110_Pb.xml
@@ -54,11 +54,11 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
-    
+
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
-    
+    They are not perfectly ten-sigma for reasons of physical geometry.
+
     Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
     </comment>
 

--- a/compact/fields/beamline_18x275.xml
+++ b/compact/fields/beamline_18x275.xml
@@ -55,4 +55,15 @@
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
 
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="0.27*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="0.0*cm"/>
+    <constant name="offset_intermediate_2_RP_section" value ="0.0*cm"/>
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
+
+
   </define>

--- a/compact/fields/beamline_18x275.xml
+++ b/compact/fields/beamline_18x275.xml
@@ -57,7 +57,7 @@
 
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
+    They are not perfectly ten-sigma for reasons of physical geometry.
     </comment>
 
     <constant name="offset_central_RP_section" value ="0.27*cm"/>

--- a/compact/fields/beamline_5x100.xml
+++ b/compact/fields/beamline_5x100.xml
@@ -53,5 +53,15 @@
     <constant name="B2PF_Bmax" value="-1.74139319*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
+    
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="0.71*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="0.55*cm"/>
+    <constant name="offset_intermediate_2_RP_section" value ="0.0*cm"/>
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
 
   </define>

--- a/compact/fields/beamline_5x100.xml
+++ b/compact/fields/beamline_5x100.xml
@@ -53,10 +53,10 @@
     <constant name="B2PF_Bmax" value="-1.74139319*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
-    
+
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
+    They are not perfectly ten-sigma for reasons of physical geometry.
     </comment>
 
     <constant name="offset_central_RP_section" value ="0.71*cm"/>

--- a/compact/fields/beamline_5x110_H2.xml
+++ b/compact/fields/beamline_5x110_H2.xml
@@ -54,5 +54,17 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
+    
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    
+    Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="0.71*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="0.55*cm"/>
+    <constant name="offset_intermediate_2_RP_section" value ="0.0*cm"/>
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
 
   </define>

--- a/compact/fields/beamline_5x110_H2.xml
+++ b/compact/fields/beamline_5x110_H2.xml
@@ -54,11 +54,11 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
-    
+
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
-    
+    They are not perfectly ten-sigma for reasons of physical geometry.
+
     Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
     </comment>
 

--- a/compact/fields/beamline_5x41.xml
+++ b/compact/fields/beamline_5x41.xml
@@ -53,10 +53,10 @@
     <constant name="B2PF_Bmax"  value="-0.71381565*tesla"/>
     <constant name="Q0EF_BMax"  value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
-    
+
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
+    They are not perfectly ten-sigma for reasons of physical geometry.
     </comment>
 
     <constant name="offset_central_RP_section" value ="2.96*cm"/>

--- a/compact/fields/beamline_5x41.xml
+++ b/compact/fields/beamline_5x41.xml
@@ -53,5 +53,15 @@
     <constant name="B2PF_Bmax"  value="-0.71381565*tesla"/>
     <constant name="Q0EF_BMax"  value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
+    
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="2.96*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="2.75*cm"/> <!-- rough extrapolation -->
+    <constant name="offset_intermediate_2_RP_section" value ="1.80*cm"/> <!-- rough extrapolation -->
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
 
   </define>

--- a/compact/fields/beamline_5x41_H2.xml
+++ b/compact/fields/beamline_5x41_H2.xml
@@ -54,5 +54,17 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
+    
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    
+    Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="2.96*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="2.75*cm"/> <!-- rough extrapolation -->
+    <constant name="offset_intermediate_2_RP_section" value ="1.80*cm"/> <!-- rough extrapolation -->
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
 
   </define>

--- a/compact/fields/beamline_5x41_H2.xml
+++ b/compact/fields/beamline_5x41_H2.xml
@@ -54,11 +54,11 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
-    
+
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
-    
+    They are not perfectly ten-sigma for reasons of physical geometry.
+
     Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
     </comment>
 

--- a/compact/fields/beamline_5x41_He3.xml
+++ b/compact/fields/beamline_5x41_He3.xml
@@ -54,5 +54,17 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
+    
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    
+    Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="2.96*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="2.75*cm"/> <!-- rough extrapolation -->
+    <constant name="offset_intermediate_2_RP_section" value ="1.80*cm"/> <!-- rough extrapolation -->
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
 
   </define>

--- a/compact/fields/beamline_5x41_He3.xml
+++ b/compact/fields/beamline_5x41_He3.xml
@@ -54,11 +54,11 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
-    
+
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
-    
+    They are not perfectly ten-sigma for reasons of physical geometry.
+
     Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
     </comment>
 

--- a/compact/fields/beamline_5x41_He4.xml
+++ b/compact/fields/beamline_5x41_He4.xml
@@ -54,5 +54,17 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
+    
+    <comment>
+    These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
+    They are not perfectly ten-sigma for reasons of physical geometry. 
+    
+    Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
+    </comment>
+
+    <constant name="offset_central_RP_section" value ="2.96*cm"/>
+    <constant name="offset_intermediate_1_RP_section" value ="2.75*cm"/> <!-- rough extrapolation -->
+    <constant name="offset_intermediate_2_RP_section" value ="1.80*cm"/> <!-- rough extrapolation -->
+    <constant name="offset_outer_RP_section" value ="0.0*cm"/>
 
   </define>

--- a/compact/fields/beamline_5x41_He4.xml
+++ b/compact/fields/beamline_5x41_He4.xml
@@ -54,11 +54,11 @@
     <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
-    
+
     <comment>
     These are the ten-sigma cuts for the Roman pots, translated to the physical layout we currently have.
-    They are not perfectly ten-sigma for reasons of physical geometry. 
-    
+    They are not perfectly ten-sigma for reasons of physical geometry.
+
     Nuclei currently based on nearest per-nucleon proton energy (needs eventual update from machine).
     </comment>
 

--- a/src/ForwardRomanPot_geo.cpp
+++ b/src/ForwardRomanPot_geo.cpp
@@ -32,8 +32,8 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   for (xml_coll_t mi(x_det, _U(module)); mi; ++mi, ++m_id) {
     xml_comp_t x_mod           = mi;
     string m_nam               = x_mod.nameStr();
-    double mod_width           = getAttrOrDefault<double>(x_mod, _U(width), 3.2 * cm);
-    double mod_height          = getAttrOrDefault<double>(x_mod, _U(height), 3.2 * cm);
+    double mod_width           = getAttrOrDefault<double>(x_mod, _U(width), 1.6 * cm);
+    double mod_height          = getAttrOrDefault<double>(x_mod, _U(height), 1.6 * cm);
     double mod_total_thickness = 0.;
 
     xml_coll_t ci(x_mod, _U(module_component));
@@ -43,8 +43,8 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
     Box m_solid(mod_width / 2.0, mod_height / 2.0, mod_total_thickness / 2.0);
     Volume m_volume(m_nam, m_solid, vacuum);
     //set to AnlGold temporarily for future RP troubleshooting
-    //m_volume.setVisAttributes(description.visAttributes(x_mod.visStr()));
-    m_volume.setVisAttributes(description.visAttributes("AnlGold"));
+    m_volume.setVisAttributes(description.visAttributes(x_mod.visStr()));
+    //m_volume.setVisAttributes(description.visAttributes("AnlGold"));
 
     double comp_z_pos = -mod_total_thickness / 2.0;
     int n_sensor      = 1;
@@ -99,8 +99,8 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       double nx              = getAttrOrDefault<double>(x_array, _Unicode(nx), 1);
       double ny              = getAttrOrDefault<double>(x_array, _Unicode(ny), 1);
       double dz              = getAttrOrDefault<double>(x_array, _Unicode(dz), 0 * mm);
-      double arr_width       = getAttrOrDefault<double>(x_array, _Unicode(width), 3.2 * cm);
-      double arr_height      = getAttrOrDefault<double>(x_array, _Unicode(height), 3.2 * cm);
+      double arr_width       = getAttrOrDefault<double>(x_array, _Unicode(width), 1.6 * cm);
+      double arr_height      = getAttrOrDefault<double>(x_array, _Unicode(height), 1.6 * cm);
       std::string arr_module = getAttrOrDefault<std::string>(x_array, _Unicode(module), "");
       // TODO: add check here
       auto arr_vol         = modules[arr_module];
@@ -120,6 +120,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
           if (x_pos) {
             arr_pos += Position(x_pos.x(0), x_pos.y(0), x_pos.z(0));
           }
+		  		  
           DetElement mod_de(ma_de, ma_name + std::string("_mod") + std::to_string(i_mod), i_mod);
           pv = ma_vol.placeVolume(arr_vol, arr_pos);
           pv.addPhysVolID("module", i_mod);
@@ -127,6 +128,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
           for (size_t ic = 0; ic < sensVols.size(); ++ic) {
             PlacedVolume sens_pv = sensVols[ic];
             DetElement comp_de(mod_de, std::string("de_") + sens_pv.volume().name(), ic + 1);
+			//comp_de.setVisAttributes(description, "AnlGold", arr_vol);
             comp_de.setPlacement(sens_pv);
             // Acts::ActsExtension* sensorExtension = new Acts::ActsExtension();
             //// sensorExtension->addType("sensor", "detector");
@@ -163,7 +165,6 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       string comp_assembly = getAttrOrDefault<std::string>(x_comp, _Unicode(assembly), "");
 
       auto comp_vol = module_assemblies[comp_assembly];
-      // auto de       = ;
       auto comp_de =
           module_assembly_delements[comp_assembly].clone(comp_assembly + std::to_string(l_num));
       if (c_pos) {

--- a/src/ForwardRomanPot_geo.cpp
+++ b/src/ForwardRomanPot_geo.cpp
@@ -42,9 +42,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
     Box m_solid(mod_width / 2.0, mod_height / 2.0, mod_total_thickness / 2.0);
     Volume m_volume(m_nam, m_solid, vacuum);
-    //set to AnlGold temporarily for future RP troubleshooting
     m_volume.setVisAttributes(description.visAttributes(x_mod.visStr()));
-    //m_volume.setVisAttributes(description.visAttributes("AnlGold"));
 
     double comp_z_pos = -mod_total_thickness / 2.0;
     int n_sensor      = 1;
@@ -128,14 +126,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
           for (size_t ic = 0; ic < sensVols.size(); ++ic) {
             PlacedVolume sens_pv = sensVols[ic];
             DetElement comp_de(mod_de, std::string("de_") + sens_pv.volume().name(), ic + 1);
-			//comp_de.setVisAttributes(description, "AnlGold", arr_vol);
             comp_de.setPlacement(sens_pv);
-            // Acts::ActsExtension* sensorExtension = new Acts::ActsExtension();
-            //// sensorExtension->addType("sensor", "detector");
-            // comp_de.addExtension<Acts::ActsExtension>(sensorExtension);
-            //// comp_de.setAttributes(description, sens_pv.volume(),
-            /// x_layer.regionStr(), / x_layer.limitsStr(), /
-            /// xml_det_t(xmleles[m_nam]).visStr());
           }
         }
       }
@@ -161,7 +152,6 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       xml_comp_t x_comp = ci;
       xml_comp_t c_pos  = x_comp.position(false);
 
-      // string     ma_name = x_comp.nameStr();
       string comp_assembly = getAttrOrDefault<std::string>(x_comp, _Unicode(assembly), "");
 
       auto comp_vol = module_assemblies[comp_assembly];
@@ -176,25 +166,13 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       comp_de.setPlacement(pv);
       layer.add(comp_de);
       i_assembly++;
-      // DetElement det = module > 1 ? stave.clone(_toString(module,"stave%d"))
-      // : stave; Transform3D trafo(RotationZYX(0, rotY, rotX),
-      // Translation3D(-posX, -posY, 0)); PlacedVolume pv =
-      // envelopeVolume.placeVolume(sectVolume,trafo);
-      //// Not a valid volID: pv.addPhysVolID("stave", 0);
-      // pv.addPhysVolID("module", module);
-      // det.setPlacement(pv);
-      // parent.add(det);
     }
     pv = assembly.placeVolume(l_vol, l_pos);
     pv.addPhysVolID("layer", l_num);
   }
 
-  // pv = description.pickMotherVolume(sdet).placeVolume(assembly,
-  // Position(pos.x(), pos.y(), pos.z()));
   Transform3D posAndRot(RotationZYX(rot.z(), rot.y(), rot.x()),
                         Position(pos.x(), pos.y(), pos.z()));
-  // pv = description.pickMotherVolume(sdet).placeVolume(assembly,
-  // Position(pos.x(), pos.y(), pos.z()));
   pv = description.pickMotherVolume(sdet).placeVolume(assembly, posAndRot);
   pv.addPhysVolID("system", x_det.id()); // Set the subdetector system ID.
   sdet.setPlacement(pv);

--- a/src/ForwardRomanPot_geo.cpp
+++ b/src/ForwardRomanPot_geo.cpp
@@ -118,7 +118,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
           if (x_pos) {
             arr_pos += Position(x_pos.x(0), x_pos.y(0), x_pos.z(0));
           }
-		  		  
+
           DetElement mod_de(ma_de, ma_name + std::string("_mod") + std::to_string(i_mod), i_mod);
           pv = ma_vol.placeVolume(arr_vol, arr_pos);
           pv.addPhysVolID("module", i_mod);


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR introduces changing RP geometry for the various beam energies, and updates the sensor size for the AC-LGADs to what we are planning to build.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ x] Tests for the changes have been added (see PDF)
- [ x] Documentation has been added / updated
- [x ] Changes have been communicated to collaborators

Changes will be presented at meetings on Monday and Tuesday (Oct 14th and 15th)

See slides here: https://www.dropbox.com/scl/fi/43mhwxeyvluku0w1ojqfr/new_roman_pots_geometry_10_9_2024.pdf?rlkey=w0wc0gzrk4d03e8uh9w8s0tq5&dl=0

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No changes to user code needed, but users need to be careful to select the correct geometry when running dd4hep AND EICrecon. (https://chat.epic-eic.org/main/pl/rptqecge1jyctkkwa1454zy1mw)

I will hopefully address this issue in a PR immediately following this one.

### Does this PR change default behavior?

Yes, the low-pT acceptances at the Roman pots will be much closer to reality now, and will vary with beam energy, as they should.
