### PR TITLE
Add fEMCal to the inner_detector config

### DIFF
--- a/configurations/inner_detector.yml
+++ b/configurations/inner_detector.yml
@@ -15,6 +15,7 @@ features:
     tof_barrel:
     tof_endcap:
   ecal:
+    forward_homogeneous:
     bic_default:
     backward_PbWO4:
   pid:


### PR DESCRIPTION
Would be nice to have that available for faster benchmarks.