### PR TITLE
fix(ci): don't trigger geoviewer directly

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -122,29 +122,6 @@ jobs:
         sudo apt-get install -y libxml2-utils
         find install/share -name "*.xml" -exec xmllint {} \; > /dev/null
 
-  trigger-geoviewer:
-    runs-on: ubuntu-latest
-    needs:
-      - xmllint-after-build
-      - list-detector-configs
-    steps:
-    - uses: eic/trigger-gitlab-ci@v3
-      id: trigger
-      with:
-        url: https://eicweb.phy.anl.gov
-        project_id: 539
-        token: ${{ secrets.EICWEB_GEOVIEWER_TRIGGER }}
-        ref_name: main
-        variables: |
-          DETECTOR=epic
-          DETECTOR_REPOSITORYURL=${{ github.server_url }}/${{ github.repository }}
-          DETECTOR_REPOSITORYREF=${{ github.ref }}
-          DETECTOR_CONFIG=${{ needs.list-detector-configs.outputs.configs_csv }}
-          DETECTOR_VERSION=${{ github.sha }}
-          GITHUB_REPOSITORY=${{ github.repository }}
-          GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
-          GITHUB_PR=${{ github.event.pull_request.number }}
-
   check-geometry-configs:
     needs:
       - build


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Now that we trigger the geoviewer from the container job, along with other benchmarks, we don't need to trigger it directly (and it doesn't work to trigger it directly). E.g. https://eicweb.phy.anl.gov/EIC/benchmarks/geoviewer/-/jobs/3948345 triggered by https://github.com/eic/epic/actions/runs/11263980547/job/31323141281 just uses epic-main in the container, not the update-sensor-geometry-for-RP it should be using.

This PR removes the direct trigger of the geoviewer.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.