### PR TITLE
modify MPGD BOT ACTS tolerance

### DIFF
--- a/compact/tracking/mpgd_outerbarrel.xml
+++ b/compact/tracking/mpgd_outerbarrel.xml
@@ -149,7 +149,7 @@
 </module>
 <comment> Layout for MPGD DIRC layers </comment>
   <layer module="MPGDOuterBarrelModule" id="0" vis="TrackerSupportVis">
-          <envelope_tolerance r_min="-50*mm" r_max="0*mm" z_min="0*mm" z_max="0*mm"/>
+          <envelope_tolerance r_min="0*mm" r_max="0*mm" z_min="0*mm" z_max="0*mm"/>
     <layer_material surface="inner" binning="binPhi,binZ" bins0="MPGDOuterBarrelModule_count*10" bins1="100" />
     <layer_material surface="outer" binning="binPhi,binZ" bins0="MPGDOuterBarrelModule_count*10" bins1="100" />
     <rphi_layout


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fixes the [issue #1659 in EICrecon](https://github.com/eic/EICrecon/issues/1659) where the last tracker hit was not being used in CKF.

[2024_11_06.pdf](https://github.com/user-attachments/files/17661610/2024_11_06.pdf)

### What kind of change does this PR introduce?
- [ x] Bug fix: [EICrecon issue#1659](https://github.com/eic/EICrecon/issues/1659)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No breaking changes. Analyzers will now see all outer barrel MPGD hits included in the CKF.

### Does this PR change default behavior?
No