### PR TITLE
Barrel MPGDs: 2D-strip segmentation. Outer Barrel MPGD: UV segmentation.

### DIFF
--- a/compact/tracking/mpgd_barrel.xml
+++ b/compact/tracking/mpgd_barrel.xml
@@ -58,6 +58,8 @@
     <constant name="rmin2Sensor" value="MMDriftCuGround_thickness + MMDriftKapton_thickness + MMDriftCuElectrode_thickness + MMGasGap_thickness / 2" />
     <constant name="MMInnerSensor_R" value="MMInnerSector_R + rmin2Sensor" />
     <constant name="MMOuterSensor_R" value="MMOuterSector_R + rmin2Sensor" />
+    <constant name="MMInnerAperture" value="MMModuleWidth/MMInnerSensor_R" />
+    <constant name="MMOuterAperture" value="MMModuleWidth/MMOuterSensor_R" />
   </define>
 
   <detectors>
@@ -122,13 +124,19 @@
       <comment> 768 strips in phi yield a segmentation of 2pi/8/768 ~= 1mrad. Which in turn, yields ~160 um in resolution.
       </comment>
       <segmentation type="MultiSegmentation" key="sensor">
-        <comment> In preparation for a 2-sensors-w/-strip setup. Presently sensors w/ odd key values do not exist. </comment>
-        <segmentation name="InnerPhi" type="CylindricalGridPhiZ" key_value="0" grid_size_phi="1*mrad" grid_size_z="0.150*mm*sqrt(12)" radius="MMInnerSensor_R" />
-        <segmentation name="InnerZ"   type="CylindricalGridPhiZ" key_value="1" grid_size_phi="1*mrad" grid_size_z="0.150*mm*sqrt(12)" radius="MMInnerSensor_R" />
-        <segmentation name="OuterPhi" type="CylindricalGridPhiZ" key_value="2" grid_size_phi="1*mrad" grid_size_z="0.150*mm*sqrt(12)" radius="MMOuterSensor_R" />
-        <segmentation name="OuterZ"   type="CylindricalGridPhiZ" key_value="3" grid_size_phi="1*mrad" grid_size_z="0.150*mm*sqrt(12)" radius="MMOuterSensor_R" />
+        <comment> Strip segmentations ("strip" field !=0) are not used at simulation time but only in digitization at reconstruction time, see digitization class, "MPGDTrackerDigi". </comment>
+	<segmentation name="Inner" type="MultiSegmentation" key_value="0" key="strip">
+          <segmentation name="InnerPix" type="CylindricalGridPhiZ" key_value="0" grid_size_phi="1*mrad"          grid_size_z="0.150*mm*sqrt(12)" radius="MMInnerSensor_R" />
+          <segmentation name="InnerPhi" type="CylindricalGridPhiZ" key_value="1" grid_size_phi="1*mrad"          grid_size_z="MMModuleLength"    radius="MMInnerSensor_R" />
+          <segmentation name="InnerZ"   type="CylindricalGridPhiZ" key_value="2" grid_size_phi="MMInnerAperture" grid_size_z="0.150*mm*sqrt(12)" radius="MMInnerSensor_R" />
+	</segmentation>
+	<segmentation name="Outer" type="MultiSegmentation" key_value="1" key="strip">
+          <segmentation name="OuterPix" type="CylindricalGridPhiZ" key_value="0" grid_size_phi="1*mrad"          grid_size_z="0.150*mm*sqrt(12)" radius="MMOuterSensor_R" />
+          <segmentation name="OuterPhi" type="CylindricalGridPhiZ" key_value="1" grid_size_phi="1*mrad"          grid_size_z="MMModuleLength"    radius="MMOuterSensor_R" />
+          <segmentation name="OuterZ"   type="CylindricalGridPhiZ" key_value="2" grid_size_phi="MMOuterAperture" grid_size_z="0.150*mm*sqrt(12)" radius="MMOuterSensor_R" />
+	</segmentation>
       </segmentation>
-      <id>system:8,layer:4,module:12,sensor:2,phi:32:-16,z:-16</id>
+      <id>system:8,layer:4,module:12,sensor:2,strip:30:2,phi:-16,z:-16</id>
     </readout>
   </readouts>
 

--- a/compact/tracking/mpgd_barrel.xml
+++ b/compact/tracking/mpgd_barrel.xml
@@ -125,16 +125,16 @@
       </comment>
       <segmentation type="MultiSegmentation" key="sensor">
         <comment> Strip segmentations ("strip" field !=0) are not used at simulation time but only in digitization at reconstruction time, see digitization class, "MPGDTrackerDigi". </comment>
-	<segmentation name="Inner" type="MultiSegmentation" key_value="0" key="strip">
+        <segmentation name="Inner" type="MultiSegmentation" key_value="0" key="strip">
           <segmentation name="InnerPix" type="CylindricalGridPhiZ" key_value="0" grid_size_phi="1*mrad"          grid_size_z="0.150*mm*sqrt(12)" radius="MMInnerSensor_R" />
           <segmentation name="InnerPhi" type="CylindricalGridPhiZ" key_value="1" grid_size_phi="1*mrad"          grid_size_z="MMModuleLength"    radius="MMInnerSensor_R" />
           <segmentation name="InnerZ"   type="CylindricalGridPhiZ" key_value="2" grid_size_phi="MMInnerAperture" grid_size_z="0.150*mm*sqrt(12)" radius="MMInnerSensor_R" />
-	</segmentation>
-	<segmentation name="Outer" type="MultiSegmentation" key_value="1" key="strip">
+        </segmentation>
+        <segmentation name="Outer" type="MultiSegmentation" key_value="1" key="strip">
           <segmentation name="OuterPix" type="CylindricalGridPhiZ" key_value="0" grid_size_phi="1*mrad"          grid_size_z="0.150*mm*sqrt(12)" radius="MMOuterSensor_R" />
           <segmentation name="OuterPhi" type="CylindricalGridPhiZ" key_value="1" grid_size_phi="1*mrad"          grid_size_z="MMModuleLength"    radius="MMOuterSensor_R" />
           <segmentation name="OuterZ"   type="CylindricalGridPhiZ" key_value="2" grid_size_phi="MMOuterAperture" grid_size_z="0.150*mm*sqrt(12)" radius="MMOuterSensor_R" />
-	</segmentation>
+        </segmentation>
       </segmentation>
       <id>system:8,layer:4,module:12,sensor:2,strip:30:2,phi:-16,z:-16</id>
     </readout>

--- a/compact/tracking/mpgd_outerbarrel.xml
+++ b/compact/tracking/mpgd_outerbarrel.xml
@@ -162,9 +162,9 @@
     <readout name="OuterMPGDBarrelHits">
       <segmentation type="MultiSegmentation" key="strip">
         <comment> Strip segmentations ("strip" field !=0) are not used at simulation time but only in digitization at reconstruction time, see digitization class, "MPGDTrackerDigi". </comment>
-        <segmentation name="Pixels"  type="CartesianGridUV" key_value="0" grid_size_u="0.150*mm*sqrt(12)"    grid_size_v="0.150*mm*sqrt(12)"    grid_angle="M_PI*rad/4" />
-        <segmentation name="UStrips" type="CartesianGridUV" key_value="1" grid_size_u="0.150*mm*sqrt(12)"    grid_size_v="MPGDOuterStrip_range" grid_angle="M_PI*rad/4" />
-        <segmentation name="VStrips" type="CartesianGridUV" key_value="2" grid_size_u="MPGDOuterStrip_range" grid_size_v="0.150*mm*sqrt(12)"    grid_angle="M_PI*rad/4"/>
+        <segmentation name="Pixels"  type="CartesianGridUV" key_value="0" grid_size_u="0.150*mm*sqrt(12)"    grid_size_v="0.150*mm*sqrt(12)"    grid_angle="pi*rad/4" />
+        <segmentation name="UStrips" type="CartesianGridUV" key_value="1" grid_size_u="0.150*mm*sqrt(12)"    grid_size_v="MPGDOuterStrip_range" grid_angle="pi*rad/4" />
+        <segmentation name="VStrips" type="CartesianGridUV" key_value="2" grid_size_u="MPGDOuterStrip_range" grid_size_v="0.150*mm*sqrt(12)"    grid_angle="pi*rad/4"/>
       </segmentation>
       <id>system:8,layer:4,module:12,sensor:2,strip:30:2,u:-16,v:-16</id>
     </readout>

--- a/compact/tracking/mpgd_outerbarrel.xml
+++ b/compact/tracking/mpgd_outerbarrel.xml
@@ -27,7 +27,7 @@
     <constant name="MPGDOuterBarrel_length"                        value="MPGDOuterBarrelModule_zmin1 + MPGDOuterBarrelModule_zmin2"/>
     <constant name="MPGDOuterBarrelModule_length"                  value="0.5*(MPGDOuterBarrelModule_zmin1 + MPGDOuterBarrelModule_zmin2 + MPGDOuterBarrelModule_zoverlap)"/>
     <constant name="MPGDOuterBarrelModule_offset"                  value="(MPGDOuterBarrelModule_zmin2 - MPGDOuterBarrelModule_zmin1)/2.0"/>
-
+    <constant name="MPGDOuterStrip_range"                          value="(MPGDOuterBarrelModule_length + MPGDOuterBarrelModule_width)/2.0*sqrt(2)"/>
 
     <comment> Layer parameters </comment>
     <constant name="MPGDOuterBarrelWindow_thickness"             value="50*um"/>
@@ -39,14 +39,7 @@
     <constant name="MPGDOuterBarrelReadOutNomex_thickness"       value="50*um"/>
     <constant name="MPGDOuterBarrelReadOutKapton_thickness"      value="50*um"/>
     <constant name="MPGDOuterBarrelPCB_thickness"                value="2.8*mm"/>
-
-    <comment> Thickness values </comment>
-    <constant name="MPGDOuterBarrelCathode_thickness"          value="MPGDOuterBarrelFoilKapton_thickness + MPGDOuterBarrelFoilCu_thickness"/>
-    <constant name="MPGDOuterBarrelFoil_thickness"             value="MPGDOuterBarrelFoilKapton_thickness + MPGDOuterBarrelFoilCu_thickness"/>
-    <constant name="MPGDOuterBarrelReadOut_thickness"          value="MPGDOuterBarrelReadOutNomex_thickness + MPGDOuterBarrelReadOutElectrode_thickness + MPGDOuterBarrelReadOutKapton_thickness"/>
-    <constant name="MPGDOuterBarrelModule_thickness"           value="MPGDOuterBarrelWindow_thickness + MPGDOuterBarrelCathode_thickness +
-                                                            MPGDOuterBarrelFoil_thickness + MPGDOuterBarrelReadOut_thickness +
-                                                            MPGDOuterBarrelPCB_thickness + MPGDOuterBarrelFrame_thickness" />
+    <constant name="M_PI"                                        value="3.14159265358979323846"/>
   </define>
 
    <detectors>
@@ -168,8 +161,13 @@
 
   <readouts>
     <readout name="OuterMPGDBarrelHits">
-      <segmentation type="CartesianGridXY" grid_size_x="0.150*mm*sqrt(12)" grid_size_y="0.150*mm*sqrt(12)" />
-      <id>system:8,layer:4,module:12,sensor:2,x:32:-14,y:-18</id>
+      <segmentation type="MultiSegmentation" key="strip">
+	<comment> Strip segmentations ("strip" field !=0) are not used at simulation time but only in digitization at reconstruction time, see digitization class, "MPGDTrackerDigi". </comment>
+	<segmentation name="Pixels"  type="CartesianGridUV" key_value="0" grid_size_u="0.150*mm*sqrt(12)"    grid_size_v="0.150*mm*sqrt(12)"    grid_angle="M_PI*rad/4" />
+	<segmentation name="UStrips" type="CartesianGridUV" key_value="1" grid_size_u="0.150*mm*sqrt(12)"    grid_size_v="MPGDOuterStrip_range" grid_angle="M_PI*rad/4" />
+	<segmentation name="VStrips" type="CartesianGridUV" key_value="2" grid_size_u="MPGDOuterStrip_range" grid_size_v="0.150*mm*sqrt(12)"    grid_angle="M_PI*rad/4"/>
+      </segmentation>
+      <id>system:8,layer:4,module:12,sensor:2,strip:30:2,u:-16,v:-16</id>
     </readout>
   </readouts>
 

--- a/compact/tracking/mpgd_outerbarrel.xml
+++ b/compact/tracking/mpgd_outerbarrel.xml
@@ -39,7 +39,6 @@
     <constant name="MPGDOuterBarrelReadOutNomex_thickness"       value="50*um"/>
     <constant name="MPGDOuterBarrelReadOutKapton_thickness"      value="50*um"/>
     <constant name="MPGDOuterBarrelPCB_thickness"                value="2.8*mm"/>
-    <constant name="M_PI"                                        value="3.14159265358979323846"/>
   </define>
 
    <detectors>

--- a/compact/tracking/mpgd_outerbarrel.xml
+++ b/compact/tracking/mpgd_outerbarrel.xml
@@ -162,10 +162,10 @@
   <readouts>
     <readout name="OuterMPGDBarrelHits">
       <segmentation type="MultiSegmentation" key="strip">
-	<comment> Strip segmentations ("strip" field !=0) are not used at simulation time but only in digitization at reconstruction time, see digitization class, "MPGDTrackerDigi". </comment>
-	<segmentation name="Pixels"  type="CartesianGridUV" key_value="0" grid_size_u="0.150*mm*sqrt(12)"    grid_size_v="0.150*mm*sqrt(12)"    grid_angle="M_PI*rad/4" />
-	<segmentation name="UStrips" type="CartesianGridUV" key_value="1" grid_size_u="0.150*mm*sqrt(12)"    grid_size_v="MPGDOuterStrip_range" grid_angle="M_PI*rad/4" />
-	<segmentation name="VStrips" type="CartesianGridUV" key_value="2" grid_size_u="MPGDOuterStrip_range" grid_size_v="0.150*mm*sqrt(12)"    grid_angle="M_PI*rad/4"/>
+        <comment> Strip segmentations ("strip" field !=0) are not used at simulation time but only in digitization at reconstruction time, see digitization class, "MPGDTrackerDigi". </comment>
+        <segmentation name="Pixels"  type="CartesianGridUV" key_value="0" grid_size_u="0.150*mm*sqrt(12)"    grid_size_v="0.150*mm*sqrt(12)"    grid_angle="M_PI*rad/4" />
+        <segmentation name="UStrips" type="CartesianGridUV" key_value="1" grid_size_u="0.150*mm*sqrt(12)"    grid_size_v="MPGDOuterStrip_range" grid_angle="M_PI*rad/4" />
+        <segmentation name="VStrips" type="CartesianGridUV" key_value="2" grid_size_u="MPGDOuterStrip_range" grid_size_v="0.150*mm*sqrt(12)"    grid_angle="M_PI*rad/4"/>
       </segmentation>
       <id>system:8,layer:4,module:12,sensor:2,strip:30:2,u:-16,v:-16</id>
     </readout>

--- a/src/MPGDCylinderBarrelTracker_geo.cpp
+++ b/src/MPGDCylinderBarrelTracker_geo.cpp
@@ -522,7 +522,9 @@ static Ref_t create_MPGDCylinderBarrelTracker(Detector& description, xml_h e,
       mod_elt.setPlacement(pv);
       // ***** SENSITIVE COMPONENT
       PlacedVolume& sens_pv = sensitives[iV];
-      DetElement comp_de(mod_elt, std::string("de_") + sens_pv.volume().name() + _toString(8 * iz + iphi, "%02d"), nModules);
+      DetElement comp_de(
+          mod_elt, std::string("de_") + sens_pv.volume().name() + _toString(8 * iz + iphi, "%02d"),
+          nModules);
       comp_de.setPlacement(sens_pv);
       auto& comp_de_params =
           DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(comp_de);

--- a/src/MPGDCylinderBarrelTracker_geo.cpp
+++ b/src/MPGDCylinderBarrelTracker_geo.cpp
@@ -30,7 +30,7 @@ using ROOT::Math::XYVector;
 
 /** Micromegas Barrel Tracker with space frame
  *
- * - Designed to process "mpgd_barrel.xml" ("mpgd_barrel_ver1" as of 2024/02).
+ * - Designed to process "mpgd_barrel.xml".
  *
  * - Derived from "BarrelTrackerWithFrame_geo.cpp".
  *
@@ -317,10 +317,9 @@ static Ref_t create_MPGDCylinderBarrelTracker(Detector& description, xml_h e,
   double total_length = 0; // Total length including frames
   for (int iSM = 0; iSM < nStaveModels; iSM++) {
     // "sensor_number" = Bit field in cellID identifying the sensitive surface.
-    // We intend to use it to set up two discrimination schemes:
-    // i) Stave model w/ its distinctive radius.
-    // ii) Readout coordinate: phi or Z.
-    int sensor_number      = 2 * iSM;
+    // It is used to set up the MultiSegmentation discrimination scheme
+    // catering for the distinct radii of the inner/outer sectors.
+    int sensor_number      = iSM;
     StaveModel& staveModel = staveModels[iSM];
     // phi range, when excluding frames
     double stave_rmin = staveModel.rmin;
@@ -417,7 +416,7 @@ static Ref_t create_MPGDCylinderBarrelTracker(Detector& description, xml_h e,
           throw runtime_error("Logics error in building modules.");
         }
         sensitiveComp = &x_comp; // TODO: Add second sensitive
-        pv.addPhysVolID("sensor", sensor_number++);
+        pv.addPhysVolID("sensor", sensor_number);
         c_vol.setSensitiveDetector(sens);
         sensitives.push_back(pv);
 
@@ -501,7 +500,7 @@ static Ref_t create_MPGDCylinderBarrelTracker(Detector& description, xml_h e,
       double x1, y1; // Coordinates of the centre of curvature of
       x1                 = rc * std::cos(phic);
       y1                 = rc * std::sin(phic);
-      string module_name = _toString(10 * iz + iphi, "module%02d");
+      string module_name = _toString(8 * iz + iphi, "module%02d");
       DetElement mod_elt(lay_elt, module_name, nModules);
       printout(DEBUG, "MPGDCylinderBarrelTracker",
                "System %d Layer \"%s\",id=%d Module \"%s\",id=%d: x,y,r: %7.4f,%7.4f,%7.4f cm",
@@ -523,7 +522,7 @@ static Ref_t create_MPGDCylinderBarrelTracker(Detector& description, xml_h e,
       mod_elt.setPlacement(pv);
       // ***** SENSITIVE COMPONENT
       PlacedVolume& sens_pv = sensitives[iV];
-      DetElement comp_de(mod_elt, std::string("de_") + sens_pv.volume().name(), nModules);
+      DetElement comp_de(mod_elt, std::string("de_") + sens_pv.volume().name() + _toString(8 * iz + iphi, "%02d"), nModules);
       comp_de.setPlacement(sens_pv);
       auto& comp_de_params =
           DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(comp_de);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- Provision for 2D-strip readout for CyMBaL and Outer Barrel MPGDs.
- UV, as opposed to XY, readout for Outer Barrel MPGD.

### What kind of change does this PR introduce?
- [x] Other: New features.

### Please check if this PR fulfills the following:
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
- 2D-strip is not activated with current digitization factory => No change whatsoever.
- UV: Hit spatial distributions change slightly.

### Does this PR change default behavior?
No statistically significant change.