### PR TITLE
DIRC: avoid hardcoding number of glued bars

### DIFF
--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -63,7 +63,7 @@
     <constant name="DIRCBar_height"         value="17 * mm"/>
     <constant name="DIRCBar_width"          value="(DIRCPrism_width - (DIRCBar_count_y - 1) * DIRCBar_gap) / DIRCBar_count_y"/>
     <constant name="DIRCGlue_thickness"     value="0.05 * mm"/>
-    <constant name="DIRCBar_length"         value="(DIRCBarAssm_length - 4 * DIRCGlue_thickness)/4"/>
+    <constant name="DIRCBar_length"         value="(DIRCBarAssm_length - DIRCBar_count_z * DIRCGlue_thickness)/DIRCBar_count_z"/>
     <constant name="DIRCBar_center"         value="(DIRC_rmin + DIRC_rmax)/2" comment="Radial position of center of bar"/>
 
   </define>

--- a/src/DIRC_geo.cpp
+++ b/src/DIRC_geo.cpp
@@ -88,7 +88,7 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens) {
 
   // Envelope for bars + mirror
   Box Envelope_box("Envelope_box", (mirror_height + 1 * mm) / 2, 5 * (bar_width + 0.15 * mm),
-                   2 * (bar_length + glue_thickness) + 0.5 * mirror_thickness);
+                   0.5 * bar_repeat_z * (bar_length + glue_thickness) + 0.5 * mirror_thickness);
   Volume Envelope_box_vol("Envelope_box_vol", Envelope_box, desc.material("AirOptical"));
   dirc_module.placeVolume(Envelope_box_vol, Position(0, 0, 0.5 * mirror_thickness));
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This should not change the baseline geometry, but this allows to play with alternative values of the `DIRCBar_count_z` constant, which is set to 4 by default.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No