### PR TITLE
Update material map

### DIFF
--- a/compact/tracking/definitions_craterlake.xml
+++ b/compact/tracking/definitions_craterlake.xml
@@ -200,7 +200,7 @@
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_PATH:/opt/detector"/>
       <arg value="file:calibrations/materials-map.cbor"/>
-      <arg value="url:https://eicweb.phy.anl.gov/EIC/detectors/athena/uploads/807fdbd7c54e58f22f45d6344f68eea4/material-map-24.08.cbor"/>
+      <arg value="url:https://eicweb.phy.anl.gov/-/project/473/uploads/6ba99301ba58f914a86cca1d99a5ccb2/material-map.cbor"/>
     </plugin>
   </plugins>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
update the link to new material map created by @bschmookler which addresses the artificial inconsistency introduced in 24.10 due to geometry change. See performance study at https://indico.bnl.gov/event/26553/
New map stored at https://eicweb.phy.anl.gov/EIC/detectors/athena/-/issues/153 as usual.

### What kind of change does this PR introduce?
- [ x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
N/A

### Does this PR change default behavior?
It will bring the tracking performance back to normal for any simulation with ePIC 24.10 or newer.
