### PR TITLE
feat: B0 tracker only geometry configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(${a_lib_name}
 set(TEMPLATE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/templates)
 set(TEMPLATE_XML ${PROJECT_NAME}.xml.jinja2)
 
-file(GLOB CONFIG_YMLS ${CMAKE_CURRENT_SOURCE_DIR}/configurations/*.yml)
+file(GLOB CONFIG_YMLS CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configurations/*.yml)
 foreach(config_yml ${CONFIG_YMLS})
     get_filename_component(config ${config_yml} NAME_WE)
     add_custom_target(${config}.xml ALL)

--- a/compact/far_forward/B0_tracker.xml
+++ b/compact/far_forward/B0_tracker.xml
@@ -164,6 +164,14 @@
       </layer>
     </detector>
 
+    <detector id="B0TrackerSubAssembly_ID"
+      name="B0TrackerSubAssembly"
+      type="DD4hep_SubdetectorAssembly"
+      vis="TrackerSubAssemblyVis">
+      <composite name="B0Tracker"/>
+      <composite name="B0TrackerCompanion"/>
+    </detector>
+
   </detectors>
 
   <readouts>

--- a/compact/tracking/definitions_craterlake.xml
+++ b/compact/tracking/definitions_craterlake.xml
@@ -183,13 +183,6 @@
       vis="TrackerSubAssemblyVis">
       <composite name="MPGDOuterBarrel"/>
     </detector>
-    <detector id="B0TrackerSubAssembly_ID"
-      name="B0TrackerSubAssembly"
-      type="DD4hep_SubdetectorAssembly"
-      vis="TrackerSubAssemblyVis">
-      <composite name="B0Tracker"/>
-      <composite name="B0TrackerCompanion"/>
-    </detector>
   </detectors>
 
   <documentation>

--- a/configurations/craterlake_tracking_only.yml
+++ b/configurations/craterlake_tracking_only.yml
@@ -4,17 +4,7 @@ features:
     marco:
   tracking:
     definitions_craterlake:
-    vertex_barrel:
-    silicon_barrel:
-    mpgd_barrel:
-    support_service_craterlake:
-    mpgd_outerbarrel:
-    mpgd_forward_endcap:
-    mpgd_backward_endcap:
-    silicon_disks:
-    tof_barrel:
-    tof_endcap:
   far_forward:
-    default:
+    B0_tracker:
   far_backward:
     default:


### PR DESCRIPTION
This PR adds a b0_tracker_only geometry configuration for debugging of B0 tracking issues without loading the whole shebang.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.