### PR TITLE
feat: export down to AstroPix chips in EcalBarrelImaging STEP

### DIFF
--- a/.github/workflows/convert-to-step.yml
+++ b/.github/workflows/convert-to-step.yml
@@ -32,6 +32,7 @@ jobs:
           declare -A detectors
           while read d ; do detectors[$d]='-l 3' ; done <<< $(npdet_to_step list $DETECTOR_PATH/${{matrix.detector_config}}.xml  | sed '/world/d;s/.*(vol: \(.*\)).*/\1/g')
           # Then tweak the levels (default is 1)
+          detectors[EcalBarrelImaging]='-l 4'
           detectors[HcalBarrel]='-l 1'
           detectors[LFHCAL]='-l 2'
           detectors[OuterBarrelMPGDSubAssembly]='-l 4'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds the AstroPix chips as lowest level detail in the EcalBarrelImaging STEP files.

Increases file size of epic_imaging_only.stp from 440 kB to 650 kB. But now includes the AstroPix instead of solid trays.
![image](https://github.com/user-attachments/assets/142edbfd-56be-45c2-a43f-d48aa596686d)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.