### PR TITLE
6.3.1 Far-Backwards Lattice

### DIFF
--- a/compact/far_backward/beamline_extension_electron.xml
+++ b/compact/far_backward/beamline_extension_electron.xml
@@ -11,9 +11,9 @@
   <detectors>
 
     <comment> Electron side extended beam pipe volumes </comment>
-    <!-- Beam pipe going from Q3eR to B7eR -->
+    <!-- Beam pipe going from Q3eR to Q6eR -->
     <detector
-    name="Pipe_Q3eR_to_B7eR"
+    name="Pipe_Q3eR_to_Q6eR"
     type="BeamPipeChain"
     wall_thickness="2*mm">
       <pipe id="0" name="Pipe_in_SQ3eR"
@@ -25,44 +25,56 @@
       <pipe id="2" name="Pipe_in_Q3eR"
         xcenter="Q3eR_CenterX" zcenter="Q3eR_CenterZ"
         length="Q3eR_Length" theta="Q3eR_Theta"
-        rout1="Q3eR_InnerRadius" rout2="Q3eR_InnerRadius">
+        rout1="Q3eR_InnerRadius" rout2="Q3eR_InnerRadius"
+        limits="kill_limits">
       </pipe>
-      <pipe id="3" name="Pipe_Q3eR_to_Q4eR"/>
-      <pipe id="4" name="Pipe_in_Q4eR"
+      <pipe id="3" name="Pipe_Q3eR_to_SQ4eR"/>
+      <pipe id="4" name="Pipe_in_SQ4eR"
+        xcenter="SQ4eR_CenterX" zcenter="SQ4eR_CenterZ"
+        length="SQ4eR_Length" theta="SQ4eR_Theta"
+        rout1="SQ4eR_InnerRadius" rout2="SQ4eR_InnerRadius"
+        limits="kill_limits">
+      </pipe>
+      <pipe id="5" name="Pipe_SQ4eR_to_Q4eR"/>
+      <pipe id="6" name="Pipe_in_Q4eR"
         xcenter="Q4eR_CenterX" zcenter="Q4eR_CenterZ"
         length="Q4eR_Length" theta="Q4eR_Theta"
         rout1="Q4eR_InnerRadius" rout2="Q4eR_InnerRadius"
         limits="kill_limits">
       </pipe>
-      <pipe id="5" name="Pipe_Q4eR_to_B3eR"/>
-      <pipe id="6" name="Pipe_in_B3eR"
+      <pipe id="7" name="Pipe_Q4eR_to_SQ5eR"/>
+      <pipe id="8" name="Pipe_in_SQ5eR"
+        xcenter="SQ5eR_CenterX" zcenter="SQ5eR_CenterZ"
+        length="SQ5eR_Length" theta="SQ5eR_Theta"
+        rout1="SQ5eR_InnerRadius" rout2="SQ5eR_InnerRadius"
+        limits="kill_limits">
+      </pipe>
+      <pipe id="9" name="Pipe_SQ5eR_to_Q5eR"/>
+      <pipe id="10" name="Pipe_in_Q5eR"
+        xcenter="Q5eR_CenterX" zcenter="Q5eR_CenterZ"
+        length="Q5eR_Length" theta="Q5eR_Theta"
+        rout1="Q5eR_InnerRadius" rout2="Q5eR_InnerRadius"
+        limits="kill_limits">
+      </pipe>
+      <pipe id="11" name="Pipe_Q5eR_to_B3eR"/>
+      <pipe id="12" name="Pipe_in_B3eR"
         xcenter="B3eR_CenterX" zcenter="B3eR_CenterZ"
         length="B3eR_Length" theta="B3eR_Theta"
         rout1="B3eR_InnerRadius" rout2="B3eR_InnerRadius">
       </pipe>
-      <pipe id="7" name="Pipe_B3eR_to_B4eR"/>
-      <pipe id="8" name="Pipe_in_B4eR"
-        xcenter="B4eR_CenterX" zcenter="B4eR_CenterZ"
-        length="B4eR_Length" theta="B4eR_Theta"
-        rout1="B4eR_InnerRadius" rout2="B4eR_InnerRadius">
+      <pipe id="13" name="Pipe_B3eR_to_SQ6eR"/>
+      <pipe id="8" name="Pipe_in_SQ6eR"
+        xcenter="SQ6eR_CenterX" zcenter="SQ6eR_CenterZ"
+        length="SQ6eR_Length" theta="SQ6eR_Theta"
+        rout1="SQ6eR_InnerRadius" rout2="SQ6eR_InnerRadius"
+        limits="kill_limits">
       </pipe>
-      <pipe id="9" name="Pipe_B4eR_to_B5eR"/>
-      <pipe id="10" name="Pipe_in_B5eR"
-        xcenter="B5eR_CenterX" zcenter="B5eR_CenterZ"
-        length="B5eR_Length" theta="B5eR_Theta"
-        rout1="B5eR_InnerRadius" rout2="B5eR_InnerRadius">
-      </pipe>
-      <pipe id="11" name="Pipe_B5eR_to_B6eR"/>
-      <pipe id="12" name="Pipe_in_B6eR"
-        xcenter="B6eR_CenterX" zcenter="B6eR_CenterZ"
-        length="B6eR_Length" theta="B6eR_Theta"
-        rout1="B6eR_InnerRadius" rout2="B6eR_InnerRadius">
-      </pipe>
-      <pipe id="13" name="Pipe_B6eR_to_B7eR"/>
-      <pipe id="14" name="Pipe_in_B7eR"
-        xcenter="B7eR_CenterX" zcenter="B7eR_CenterZ"
-        length="B7eR_Length" theta="B7eR_Theta"
-        rout1="B7eR_InnerRadius" rout2="B7eR_InnerRadius">
+      <pipe id="9" name="Pipe_SQ6eR_to_Q6eR"/>
+      <pipe id="10" name="Pipe_in_Q6eR"
+        xcenter="Q6eR_CenterX" zcenter="Q6eR_CenterZ"
+        length="Q6eR_Length" theta="Q6eR_Theta"
+        rout1="Q6eR_InnerRadius" rout2="Q6eR_InnerRadius"
+        limits="kill_limits">
       </pipe>
     </detector>
 
@@ -72,29 +84,33 @@
     name="Magnets_Q4eR_to_B7eR"
     type="CylindricalMagnetChain"
     vis="RedVis">
-      <magnet id="0" name="Magnet_Q4eR"
+      <magnet id="0" name="Magnet_SQ4eR"
+        x="SQ4eR_CenterX" y="0" z="SQ4eR_CenterZ" theta="SQ4eR_Theta"
+        length="SQ4eR_Length" rin="SQ4eR_InnerRadius" rout="SQ4eR_OuterRadius">
+      </magnet>
+      <magnet id="1" name="Magnet_Q4eR"
         x="Q4eR_CenterX" y="0" z="Q4eR_CenterZ" theta="Q4eR_Theta"
         length="Q4eR_Length" rin="Q4eR_InnerRadius" rout="Q4eR_OuterRadius">
       </magnet>
-      <magnet id="1" name="Magnet_B3eR"
+      <magnet id="2" name="Magnet_SQ5eR"
+        x="SQ5eR_CenterX" y="0" z="SQ5eR_CenterZ" theta="SQ5eR_Theta"
+        length="SQ5eR_Length" rin="SQ5eR_InnerRadius" rout="SQ5eR_OuterRadius">
+      </magnet>
+      <magnet id="3" name="Magnet_Q5eR"
+        x="Q5eR_CenterX" y="0" z="Q5eR_CenterZ" theta="Q5eR_Theta"
+        length="Q5eR_Length" rin="Q5eR_InnerRadius" rout="Q5eR_OuterRadius">
+      </magnet>
+      <magnet id="4" name="Magnet_B3eR"
         x="B3eR_CenterX" y="0" z="B3eR_CenterZ" theta="B3eR_Theta"
         length="B3eR_Length" rin="B3eR_InnerRadius" rout="B3eR_OuterRadius">
       </magnet>
-      <magnet id="2" name="Magnet_B4eR"
-        x="B4eR_CenterX" y="0" z="B4eR_CenterZ" theta="B4eR_Theta"
-        length="B4eR_Length" rin="B4eR_InnerRadius" rout="B4eR_OuterRadius">
+      <magnet id="5" name="Magnet_SQ6eR"
+        x="SQ6eR_CenterX" y="0" z="SQ6eR_CenterZ" theta="SQ6eR_Theta"
+        length="SQ6eR_Length" rin="SQ6eR_InnerRadius" rout="SQ6eR_OuterRadius">
       </magnet>
-      <magnet id="3" name="Magnet_B5eR"
-        x="B5eR_CenterX" y="0" z="B5eR_CenterZ" theta="B5eR_Theta"
-        length="B5eR_Length" rin="B5eR_InnerRadius" rout="B5eR_OuterRadius">
-      </magnet>
-      <magnet id="4" name="Magnet_B6eR"
-        x="B6eR_CenterX" y="0" z="B6eR_CenterZ" theta="B6eR_Theta"
-        length="B6eR_Length" rin="B6eR_InnerRadius" rout="B6eR_OuterRadius">
-      </magnet>
-      <magnet id="5" name="Magnet_B7eR"
-        x="B7eR_CenterX" y="0" z="B7eR_CenterZ" theta="B7eR_Theta"
-        length="B7eR_Length" rin="B7eR_InnerRadius" rout="B7eR_OuterRadius">
+      <magnet id="6" name="Magnet_Q6eR"
+        x="Q6eR_CenterX" y="0" z="Q6eR_CenterZ" theta="Q6eR_Theta"
+        length="Q6eR_Length" rin="Q6eR_InnerRadius" rout="Q6eR_OuterRadius">
       </magnet>
     </detector>
 

--- a/compact/far_backward/beamline_extension_electron.xml
+++ b/compact/far_backward/beamline_extension_electron.xml
@@ -25,36 +25,31 @@
       <pipe id="2" name="Pipe_in_Q3eR"
         xcenter="Q3eR_CenterX" zcenter="Q3eR_CenterZ"
         length="Q3eR_Length" theta="Q3eR_Theta"
-        rout1="Q3eR_InnerRadius" rout2="Q3eR_InnerRadius"
-        limits="kill_limits">
+        rout1="Q3eR_InnerRadius" rout2="Q3eR_InnerRadius">
       </pipe>
       <pipe id="3" name="Pipe_Q3eR_to_SQ4eR"/>
       <pipe id="4" name="Pipe_in_SQ4eR"
         xcenter="SQ4eR_CenterX" zcenter="SQ4eR_CenterZ"
         length="SQ4eR_Length" theta="SQ4eR_Theta"
-        rout1="SQ4eR_InnerRadius" rout2="SQ4eR_InnerRadius"
-        limits="kill_limits">
+        rout1="SQ4eR_InnerRadius" rout2="SQ4eR_InnerRadius">
       </pipe>
       <pipe id="5" name="Pipe_SQ4eR_to_Q4eR"/>
       <pipe id="6" name="Pipe_in_Q4eR"
         xcenter="Q4eR_CenterX" zcenter="Q4eR_CenterZ"
         length="Q4eR_Length" theta="Q4eR_Theta"
-        rout1="Q4eR_InnerRadius" rout2="Q4eR_InnerRadius"
-        limits="kill_limits">
+        rout1="Q4eR_InnerRadius" rout2="Q4eR_InnerRadius">
       </pipe>
       <pipe id="7" name="Pipe_Q4eR_to_SQ5eR"/>
       <pipe id="8" name="Pipe_in_SQ5eR"
         xcenter="SQ5eR_CenterX" zcenter="SQ5eR_CenterZ"
         length="SQ5eR_Length" theta="SQ5eR_Theta"
-        rout1="SQ5eR_InnerRadius" rout2="SQ5eR_InnerRadius"
-        limits="kill_limits">
+        rout1="SQ5eR_InnerRadius" rout2="SQ5eR_InnerRadius">
       </pipe>
       <pipe id="9" name="Pipe_SQ5eR_to_Q5eR"/>
       <pipe id="10" name="Pipe_in_Q5eR"
         xcenter="Q5eR_CenterX" zcenter="Q5eR_CenterZ"
         length="Q5eR_Length" theta="Q5eR_Theta"
-        rout1="Q5eR_InnerRadius" rout2="Q5eR_InnerRadius"
-        limits="kill_limits">
+        rout1="Q5eR_InnerRadius" rout2="Q5eR_InnerRadius">
       </pipe>
       <pipe id="11" name="Pipe_Q5eR_to_B3eR"/>
       <pipe id="12" name="Pipe_in_B3eR"
@@ -63,18 +58,46 @@
         rout1="B3eR_InnerRadius" rout2="B3eR_InnerRadius">
       </pipe>
       <pipe id="13" name="Pipe_B3eR_to_SQ6eR"/>
-      <pipe id="8" name="Pipe_in_SQ6eR"
+      <pipe id="14" name="Pipe_in_SQ6eR"
         xcenter="SQ6eR_CenterX" zcenter="SQ6eR_CenterZ"
         length="SQ6eR_Length" theta="SQ6eR_Theta"
-        rout1="SQ6eR_InnerRadius" rout2="SQ6eR_InnerRadius"
-        limits="kill_limits">
+        rout1="SQ6eR_InnerRadius" rout2="SQ6eR_InnerRadius">
       </pipe>
-      <pipe id="9" name="Pipe_SQ6eR_to_Q6eR"/>
-      <pipe id="10" name="Pipe_in_Q6eR"
+      <pipe id="15" name="Pipe_SQ6eR_to_Q6eR"/>
+      <pipe id="16" name="Pipe_in_Q6eR"
         xcenter="Q6eR_CenterX" zcenter="Q6eR_CenterZ"
         length="Q6eR_Length" theta="Q6eR_Theta"
-        rout1="Q6eR_InnerRadius" rout2="Q6eR_InnerRadius"
-        limits="kill_limits">
+        rout1="Q6eR_InnerRadius" rout2="Q6eR_InnerRadius">
+      </pipe>
+      <pipe id="17" name="Pipe_Q6eR_to_SQ7eR"/>
+      <pipe id="18" name="Pipe_in_SQ7eR"
+        xcenter="SQ7eR_CenterX" zcenter="SQ7eR_CenterZ"
+        length="SQ7eR_Length" theta="SQ7eR_Theta"
+        rout1="SQ7eR_InnerRadius" rout2="SQ7eR_InnerRadius">
+      </pipe>
+      <pipe id="19" name="Pipe_SQ7eR_to_Q7eR"/>
+      <pipe id="20" name="Pipe_in_Q7eR"
+        xcenter="Q7eR_CenterX" zcenter="Q7eR_CenterZ"
+        length="Q7eR_Length" theta="Q7eR_Theta"
+        rout1="Q7eR_InnerRadius" rout2="Q7eR_InnerRadius">
+      </pipe>
+      <pipe id="21" name="Pipe_Q7eR_to_SQ8eR"/>
+      <pipe id="22" name="Pipe_in_SQ8eR"
+        xcenter="SQ8eR_CenterX" zcenter="SQ8eR_CenterZ"
+        length="SQ8eR_Length" theta="SQ8eR_Theta"
+        rout1="SQ8eR_InnerRadius" rout2="SQ8eR_InnerRadius">
+      </pipe>
+      <pipe id="23" name="Pipe_SQ8eR_to_Q8eR"/>
+      <pipe id="24" name="Pipe_in_Q8eR"
+        xcenter="Q8eR_CenterX" zcenter="Q8eR_CenterZ"
+        length="Q8eR_Length" theta="Q8eR_Theta"
+        rout1="Q8eR_InnerRadius" rout2="Q8eR_InnerRadius">
+      </pipe>
+      <pipe id="25" name="Pipe_Q8eR_to_C1eR"/>
+      <pipe id="26" name="Pipe_in_C1eR"
+        xcenter="C1eR_CenterX" zcenter="C1eR_CenterZ"
+        length="C1eR_Length" theta="C1eR_Theta"
+        rout1="C1eR_InnerRadius" rout2="C1eR_InnerRadius">
       </pipe>
     </detector>
 
@@ -112,6 +135,27 @@
         x="Q6eR_CenterX" y="0" z="Q6eR_CenterZ" theta="Q6eR_Theta"
         length="Q6eR_Length" rin="Q6eR_InnerRadius" rout="Q6eR_OuterRadius">
       </magnet>
+      <magnet id="7" name="Magnet_SQ7eR"
+        x="SQ7eR_CenterX" y="0" z="SQ7eR_CenterZ" theta="SQ7eR_Theta"
+        length="SQ7eR_Length" rin="SQ7eR_InnerRadius" rout="SQ7eR_OuterRadius">
+      </magnet>
+      <magnet id="8" name="Magnet_Q7eR"
+        x="Q7eR_CenterX" y="0" z="Q7eR_CenterZ" theta="Q7eR_Theta"
+        length="Q7eR_Length" rin="Q7eR_InnerRadius" rout="Q7eR_OuterRadius">
+      </magnet>
+      <magnet id="9" name="Magnet_SQ8eR"
+        x="SQ8eR_CenterX" y="0" z="SQ8eR_CenterZ" theta="SQ8eR_Theta"
+        length="SQ8eR_Length" rin="SQ8eR_InnerRadius" rout="SQ8eR_OuterRadius">
+      </magnet>
+      <magnet id="10" name="Magnet_Q8eR"
+        x="Q8eR_CenterX" y="0" z="Q8eR_CenterZ" theta="Q8eR_Theta"
+        length="Q8eR_Length" rin="Q8eR_InnerRadius" rout="Q8eR_OuterRadius">
+      </magnet>
+      <magnet id="11" name="Magnet_C1eR"
+        x="C1eR_CenterX" y="0" z="C1eR_CenterZ" theta="C1eR_Theta"
+        length="C1eR_Length" rin="C1eR_InnerRadius" rout="C1eR_OuterRadius">
+      </magnet>
+
     </detector>
 
   </detectors>

--- a/compact/far_backward/beamline_extension_electron.xml
+++ b/compact/far_backward/beamline_extension_electron.xml
@@ -106,7 +106,7 @@
     <detector
     name="Magnets_Q4eR_to_B7eR"
     type="CylindricalMagnetChain"
-    vis="RedVis">
+    vis="FFMagnetVis">
       <magnet id="0" name="Magnet_SQ4eR"
         x="SQ4eR_CenterX" y="0" z="SQ4eR_CenterZ" theta="SQ4eR_Theta"
         length="SQ4eR_Length" rin="SQ4eR_InnerRadius" rout="SQ4eR_OuterRadius">

--- a/compact/far_backward/beamline_extension_electron.xml
+++ b/compact/far_backward/beamline_extension_electron.xml
@@ -16,44 +16,50 @@
     name="Pipe_Q3eR_to_B7eR"
     type="BeamPipeChain"
     wall_thickness="2*mm">
-      <pipe id="0" name="Pipe_in_Q3eR"
-        xcenter="Q3eR_XPosition" zcenter="Q3eR_CenterPosition"
+      <pipe id="0" name="Pipe_in_SQ3eR"
+        xcenter="SQ3eR_XPosition" zcenter="SQ3eR_CenterPosition"
+        length="SQ3eR_Length" theta="SQ3eR_Theta"
+        rout1="SQ3eR_InnerRadius" rout2="SQ3eR_InnerRadius">
+      </pipe>
+      <pipe id="1" name="Pipe_SQ3eR_to_Q3eR"/>
+      <pipe id="2" name="Pipe_in_Q3eR"
+        xcenter="Q3eR_CenterX" zcenter="Q3eR_CenterZ"
         length="Q3eR_Length" theta="Q3eR_Theta"
         rout1="Q3eR_InnerRadius" rout2="Q3eR_InnerRadius">
       </pipe>
-      <pipe id="1" name="Pipe_Q3eR_to_Q4eR"/>
-      <pipe id="2" name="Pipe_in_Q4eR"
+      <pipe id="3" name="Pipe_Q3eR_to_Q4eR"/>
+      <pipe id="4" name="Pipe_in_Q4eR"
         xcenter="Q4eR_CenterX" zcenter="Q4eR_CenterZ"
         length="Q4eR_Length" theta="Q4eR_Theta"
         rout1="Q4eR_InnerRadius" rout2="Q4eR_InnerRadius"
         limits="kill_limits">
       </pipe>
-      <pipe id="3" name="Pipe_Q4eR_to_B3eR"/>
-      <pipe id="4" name="Pipe_in_B3eR"
+      <pipe id="5" name="Pipe_Q4eR_to_B3eR"/>
+      <pipe id="6" name="Pipe_in_B3eR"
         xcenter="B3eR_CenterX" zcenter="B3eR_CenterZ"
         length="B3eR_Length" theta="B3eR_Theta"
         rout1="B3eR_InnerRadius" rout2="B3eR_InnerRadius">
       </pipe>
-      <pipe id="5" name="Pipe_B3eR_to_B4eR"/>
-      <pipe id="6" name="Pipe_in_B4eR"
+      <pipe id="7" name="Pipe_B3eR_to_B4eR"/>
+      <pipe id="8" name="Pipe_in_B4eR"
         xcenter="B4eR_CenterX" zcenter="B4eR_CenterZ"
         length="B4eR_Length" theta="B4eR_Theta"
         rout1="B4eR_InnerRadius" rout2="B4eR_InnerRadius">
       </pipe>
-      <pipe id="7" name="Pipe_B4eR_to_B5eR"/>
-      <pipe id="8" name="Pipe_in_B5eR"
+      <pipe id="9" name="Pipe_B4eR_to_B5eR"/>
+      <pipe id="10" name="Pipe_in_B5eR"
         xcenter="B5eR_CenterX" zcenter="B5eR_CenterZ"
         length="B5eR_Length" theta="B5eR_Theta"
         rout1="B5eR_InnerRadius" rout2="B5eR_InnerRadius">
       </pipe>
-      <pipe id="9" name="Pipe_B5eR_to_B6eR"/>
-      <pipe id="10" name="Pipe_in_B6eR"
+      <pipe id="11" name="Pipe_B5eR_to_B6eR"/>
+      <pipe id="12" name="Pipe_in_B6eR"
         xcenter="B6eR_CenterX" zcenter="B6eR_CenterZ"
         length="B6eR_Length" theta="B6eR_Theta"
         rout1="B6eR_InnerRadius" rout2="B6eR_InnerRadius">
       </pipe>
-      <pipe id="11" name="Pipe_B6eR_to_B7eR"/>
-      <pipe id="12" name="Pipe_in_B7eR"
+      <pipe id="13" name="Pipe_B6eR_to_B7eR"/>
+      <pipe id="14" name="Pipe_in_B7eR"
         xcenter="B7eR_CenterX" zcenter="B7eR_CenterZ"
         length="B7eR_Length" theta="B7eR_Theta"
         rout1="B7eR_InnerRadius" rout2="B7eR_InnerRadius">

--- a/compact/far_backward/beamline_extension_hadron.xml
+++ b/compact/far_backward/beamline_extension_hadron.xml
@@ -13,7 +13,7 @@
 
     <comment> Hadron side beam magnet volumes </comment>
 
-    <detector name="Magnet_Q2PR" type="ip6_CylindricalDipoleMagnet" vis="RedVis">
+    <detector name="Magnet_Q2PR" type="ip6_CylindricalDipoleMagnet" vis="FFMagnetVis">
       <placement  x="(Q2PR_StartX+Q2PR_EndX)/2" y="0" z="(Q2PR_StartZ+Q2PR_EndZ)/2" theta="Q1BPR_Theta"/>
       <dimensions x="Q2PR_InnerRadius*4" y="Q2PR_InnerRadius*4" z="Q2PR_Length" r="2.0*Q2PR_InnerRadius"/>
       <apperture  x="Q2PR_InnerRadius*2" y="Q2PR_InnerRadius*2" r="Q2PR_InnerRadius"/>

--- a/compact/far_backward/beamline_tracking.xml
+++ b/compact/far_backward/beamline_tracking.xml
@@ -40,20 +40,20 @@
 
         <slice
         pipe_id="5"
-        grandmother="Pipe_Q3eR_to_B7eR"
+        grandmother="Pipe_Q3eR_to_Q6eR"
         mother="Pipe_in_Q3eR_vacuum"
         name="Pipe_in_Q3eR_tracker_start"
         end="false"/>
 
         <slice
         pipe_id="6"
-        grandmother="Pipe_Q3eR_to_B7eR"
+        grandmother="Pipe_Q3eR_to_Q6eR"
         mother="Pipe_in_Q3eR_vacuum"
         name="Pipe_in_Q3eR_tracker_end"/>
 
         <slice
         pipe_id="7"
-        grandmother="Pipe_Q3eR_to_B7eR"
+        grandmother="Pipe_Q3eR_to_Q6eR"
         mother="Pipe_in_Q4eR_vacuum"
         name="Pipe_in_Q4eR_tracker"/>
 
@@ -62,8 +62,8 @@
     <detector
         type="BeamPipeStop"
         name="Backwards_Pipe_Stop"
-        grandmother="Pipe_Q3eR_to_B7eR"
-        mother="Pipe_Q4eR_to_B3eR_vacuum"
+        grandmother="Pipe_Q3eR_to_Q6eR"
+        mother="Pipe_in_Q6eR_vacuum"
     />
 
   </detectors>

--- a/compact/far_backward/definitions.xml
+++ b/compact/far_backward/definitions.xml
@@ -32,25 +32,36 @@
     <constant name="B2BeR_CenterPosition" value="-19.50*m"/>
     <constant name="B2BeR_Theta"          value="0.01*rad"/>
 
-    <constant name="Q3eR_InnerRadius"     value="64*mm"/>
-    <constant name="Q3eR_Length"          value="0.25*m"/>
-    <constant name="Q3eR_StartZ"          value="-42.04775868*m"/>
-    <constant name="Q3eR_StartX"          value="-0.451264664*m"/>
-    <constant name="Q3eR_EndZ"            value="-42.29759669*m"/>
-    <constant name="Q3eR_EndX"            value="-0.456264331*m"/>
-    <constant name="Q3eR_XPosition"       value="-0.45376*m"/>
-    <constant name="Q3eR_Theta"           value="0.02*rad"/>
-    <constant name="Q3eR_CenterPosition"  value="-42.1726*m"/>
+    <constant name="SQ3eR_InnerRadius"     value="64*mm"/>
+    <constant name="SQ3eR_Length"          value="0.25*m"/>
+    <constant name="SQ3eR_StartZ"          value="-42.04775868*m"/>
+    <constant name="SQ3eR_StartX"          value="-0.451264664*m"/>
+    <constant name="SQ3eR_EndZ"            value="-42.29759669*m"/>
+    <constant name="SQ3eR_EndX"            value="-0.456264331*m"/>
+    <constant name="SQ3eR_XPosition"       value="-0.45376*m"/>
+    <constant name="SQ3eR_Theta"           value="0.02*rad"/>
+    <constant name="SQ3eR_CenterPosition"  value="-42.1726*m"/>
 
-    <comment> Note: Placements for Q4eR, B3eR, B4eR, B5eR, B6eR, B7eR
-              are approximate (valid to within ~1 cm).
-              Should be updated with detailed input from the accelerator group
-    </comment>
+    <comment> Electron Beamline Extension </comment>
 
-    <constant name="Q4eR_CenterZ"         value="-45.32*m"/>
-    <constant name="Q4eR_CenterX"         value="-0.58*m"/>
+    <constant name="Q3eR_CenterZ"         value="-42.7473*m"/>
+    <constant name="Q3eR_CenterX"         value="-0.46526*m"/>
+    <constant name="Q3eR_Length"          value="0.6*m"/>
+    <constant name="Q3eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
+    <constant name="Q3eR_OuterRadius"     value="0.2*m"/>
+    <constant name="Q3eR_Theta"           value="SQ3eR_Theta"/>
+
+    <constant name="SQ4eR_CenterZ"         value="-46.6786*m"/>
+    <constant name="SQ4eR_CenterX"         value="-0.91721*m"/>
+    <constant name="SQ4eR_Length"          value="0.25*m"/>
+    <constant name="SQ4eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
+    <constant name="SQ4eR_OuterRadius"     value="0.2*m"/>
+    <constant name="SQ4eR_Theta"           value="Q3eR_Theta"/>
+
+    <constant name="Q4eR_CenterZ"         value="-47.2534*m"/>
+    <constant name="Q4eR_CenterX"         value="-0.93331*m"/>
     <constant name="Q4eR_Length"          value="0.6*m"/>
-    <constant name="Q4eR_InnerRadius"     value="0.05*m"/>
+    <constant name="Q4eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
     <constant name="Q4eR_OuterRadius"     value="0.2*m"/>
     <constant name="Q4eR_Theta"           value="Q3eR_Theta"/>
 
@@ -177,7 +188,7 @@
     <constant name="Vacuum_BB_MinY"       value="-1.5*m"/>
     <constant name="Vacuum_BB_MaxY"       value="1.5*m"/>
     <constant name="Vacuum_BB_MinZ"       value="B2BeR_CenterPosition-B2BeR_Length/2"/>
-    <constant name="Vacuum_BB_MaxZ"       value="Q3eR_EndZ"/>
+    <constant name="Vacuum_BB_MaxZ"       value="SQ3eR_EndZ"/>
 
     <constant name="Beam_Theta"           value="Q3eR_Theta"/>
 
@@ -186,13 +197,13 @@
     <comment> Dipole focal point in global coordinates </comment>
     <constant name="Dipole_Focus_X"       value="0.0*mm"/>
     <constant name="Dipole_Focus_Y"       value="0.0*mm"/>
-    <constant name="Dipole_Focus_Z"       value="Q3eR_CenterPosition-Q3eR_XPosition/tan(Beam_Theta)"/>
+    <constant name="Dipole_Focus_Z"       value="SQ3eR_CenterPosition-SQ3eR_XPosition/tan(Beam_Theta)"/>
 
     <comment> Central pipe dimensions </comment>
-    <constant name="Beam_Length"          value="(Dipole_Focus_Z-Q3eR_StartZ)/cos(Beam_Theta)"/>
-    <constant name="Beam_WidthR"          value="Q3eR_InnerRadius"/>
-    <constant name="Beam_WidthL"          value="Q3eR_InnerRadius"/>
-    <constant name="Beam_Height"          value="Q3eR_InnerRadius"/>
+    <constant name="Beam_Length"          value="(Dipole_Focus_Z-SQ3eR_StartZ)/cos(Beam_Theta)"/>
+    <constant name="Beam_WidthR"          value="SQ3eR_InnerRadius"/>
+    <constant name="Beam_WidthL"          value="SQ3eR_InnerRadius"/>
+    <constant name="Beam_Height"          value="SQ3eR_InnerRadius"/>
 
     <comment> Entry box joining magnets, lumi and tagger systems </comment>
     <constant name="Exit_Height"          value="B2BeR_InnerRadius"/>
@@ -213,7 +224,7 @@
 
     <constant name="Tagger1_Min_Theta"    value="0.03*rad"/>
     <constant name="Tagger1_Max_Theta"    value="0.0420*rad"/>
-    <constant name="Tagger1_Min_Offset"   value="Q3eR_InnerRadius"/>
+    <constant name="Tagger1_Min_Offset"   value="SQ3eR_InnerRadius"/>
 
     <constant name="Tagger2_Width"        value="147.84*mm"/>
     <constant name="Tagger2_Height"       value="150.0*mm"/>
@@ -224,7 +235,7 @@
 
     <constant name="Tagger2_Min_Theta"    value="0.022*rad"/>
     <constant name="Tagger2_Max_Theta"    value="Tagger1_Min_Theta+0.000*rad"/>
-    <constant name="Tagger2_Min_Offset"   value="Q3eR_InnerRadius+Backwards_Box_Wall"/>
+    <constant name="Tagger2_Min_Offset"   value="SQ3eR_InnerRadius+Backwards_Box_Wall"/>
 
 
     <!--  -->

--- a/compact/far_backward/definitions.xml
+++ b/compact/far_backward/definitions.xml
@@ -94,11 +94,46 @@
     <constant name="SQ6eR_Theta"           value="0.023175959"/>
 
     <constant name="Q6eR_CenterZ"         value="-56.2383*m"/>
-    <constant name="Q6eR_CenterX"         value="-0.774347*m"/>
+    <constant name="Q6eR_CenterX"         value="-0.74347*m"/>
     <constant name="Q6eR_Length"          value="1.2*m"/>
     <constant name="Q6eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
     <constant name="Q6eR_OuterRadius"     value="0.2*m"/>
     <constant name="Q6eR_Theta"           value="SQ6eR_Theta"/>
+
+    <constant name="SQ7eR_CenterZ"         value="-59.8605*m"/>
+    <constant name="SQ7eR_CenterX"         value="-0.82743*m"/>
+    <constant name="SQ7eR_Length"          value="0.25*m"/>
+    <constant name="SQ7eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
+    <constant name="SQ7eR_OuterRadius"     value="0.2*m"/>
+    <constant name="SQ7eR_Theta"           value="SQ6eR_Theta"/>
+
+    <constant name="Q7eR_CenterZ"         value="-60.7348*m"/>
+    <constant name="Q7eR_CenterX"         value="-0.84770*m"/>
+    <constant name="Q7eR_Length"          value="1.2*m"/>
+    <constant name="Q7eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
+    <constant name="Q7eR_OuterRadius"     value="0.2*m"/>
+    <constant name="Q7eR_Theta"           value="SQ6eR_Theta"/>
+
+    <constant name="SQ8eR_CenterZ"         value="-64.3570*m"/>
+    <constant name="SQ8eR_CenterX"         value="-0.93167*m"/>
+    <constant name="SQ8eR_Length"          value="0.25*m"/>
+    <constant name="SQ8eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
+    <constant name="SQ8eR_OuterRadius"     value="0.2*m"/>
+    <constant name="SQ8eR_Theta"           value="SQ6eR_Theta"/>
+
+    <constant name="Q8eR_CenterZ"         value="-65.2313*m"/>
+    <constant name="Q8eR_CenterX"         value="-0.95913*m"/>
+    <constant name="Q8eR_Length"          value="1.2*m"/>
+    <constant name="Q8eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
+    <constant name="Q8eR_OuterRadius"     value="0.2*m"/>
+    <constant name="Q8eR_Theta"           value="SQ6eR_Theta"/>
+
+    <constant name="C1eR_CenterZ"         value="-68.3290*m"/>
+    <constant name="C1eR_CenterX"         value="-1.02374*m"/>
+    <constant name="C1eR_Length"          value="4*m"/>
+    <constant name="C1eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
+    <constant name="C1eR_OuterRadius"     value="0.2*m"/>
+    <constant name="C1eR_Theta"           value="SQ6eR_Theta"/>
 
 
     <comment> Hadron magnet dimensions and positions </comment>

--- a/compact/far_backward/definitions.xml
+++ b/compact/far_backward/definitions.xml
@@ -15,7 +15,7 @@
     <comment> Electron magnet dimensions and positions </comment>
 
     <constant name="Q1eR_InnerRadius"     value="64.3*mm"/>
-    <constant name="Q1eR_Length"          value="1.883*m"/>
+    <constant name="Q1eR_Length"          value="1.8*m"/>
     <constant name="Q1eR_CenterPosition"  value="-6.2*m"/>
 
     <constant name="Q2eR_InnerRadius"     value="77.0*mm"/>

--- a/compact/far_backward/definitions.xml
+++ b/compact/far_backward/definitions.xml
@@ -14,31 +14,33 @@
 
     <comment> Electron magnet dimensions and positions </comment>
 
-    <constant name="Q1eR_InnerRadius"     value="67.5*mm"/>
-    <constant name="Q1eR_Length"          value="1.78*m"/>
+    <constant name="Q1eR_InnerRadius"     value="64.3*mm"/>
+    <constant name="Q1eR_Length"          value="1.883*m"/>
     <constant name="Q1eR_CenterPosition"  value="-6.2*m"/>
 
-    <constant name="Q2eR_InnerRadius"     value="78.0*mm"/>
+    <constant name="Q2eR_InnerRadius"     value="77.0*mm"/>
     <constant name="Q2eR_Length"          value="1.4*m"/>
     <constant name="Q2eR_CenterPosition"  value="-8.3*m"/>
 
-    <constant name="B2AeR_InnerRadius"    value="90.0*mm"/>
+    <constant name="B2AeR_InnerRadius"    value="98.0*mm"/>
     <constant name="B2AeR_Length"         value="1.78*m"/>
     <constant name="B2AeR_CenterPosition" value="-10.5*m"/>
 
-    <constant name="B2BeR_InnerRadius"    value="111.0*mm"/>
-    <constant name="B2BeR_Length"         value="3.18*m"/>
-    <constant name="B2BeR_CenterPosition" value="-13.275*m"/>
+    <constant name="B2BeR_InnerRadius"    value="98.0*mm"/>
+    <constant name="B2BeR_Length"         value="5.500092*m"/>
+    <constant name="B2BeR_Center_x"       value="-27.5*mm"/>
+    <constant name="B2BeR_CenterPosition" value="-19.50*m"/>
+    <constant name="B2BeR_Theta"          value="0.01*rad"/>
 
-    <constant name="Q3eR_InnerRadius"     value="0.05*m"/>
-    <constant name="Q3eR_Length"          value="0.6*m"/>
-    <constant name="Q3eR_StartZ"          value="-37.696067*m"/>
-    <constant name="Q3eR_StartX"          value="-0.460027*m"/>
-    <constant name="Q3eR_EndZ"            value="-38.295969*m"/>
-    <constant name="Q3eR_EndX"            value="-0.470873*m"/>
-    <constant name="Q3eR_XPosition"       value="-0.46545*m"/>
-    <constant name="Q3eR_Theta"           value="0.0180766389*rad"/>
-    <constant name="Q3eR_CenterPosition"  value="-37.996018*m"/>
+    <constant name="Q3eR_InnerRadius"     value="64*mm"/>
+    <constant name="Q3eR_Length"          value="0.25*m"/>
+    <constant name="Q3eR_StartZ"          value="-42.04775868*m"/>
+    <constant name="Q3eR_StartX"          value="-0.451264664*m"/>
+    <constant name="Q3eR_EndZ"            value="-42.29759669*m"/>
+    <constant name="Q3eR_EndX"            value="-0.456264331*m"/>
+    <constant name="Q3eR_XPosition"       value="-0.45376*m"/>
+    <constant name="Q3eR_Theta"           value="0.02*rad"/>
+    <constant name="Q3eR_CenterPosition"  value="-42.1726*m"/>
 
     <comment> Note: Placements for Q4eR, B3eR, B4eR, B5eR, B6eR, B7eR
               are approximate (valid to within ~1 cm).
@@ -184,7 +186,7 @@
     <comment> Dipole focal point in global coordinates </comment>
     <constant name="Dipole_Focus_X"       value="0.0*mm"/>
     <constant name="Dipole_Focus_Y"       value="0.0*mm"/>
-    <constant name="Dipole_Focus_Z"       value="Q3eR_StartZ-Q3eR_StartX/tan(Beam_Theta)"/>
+    <constant name="Dipole_Focus_Z"       value="Q3eR_CenterPosition-Q3eR_XPosition/tan(Beam_Theta)"/>
 
     <comment> Central pipe dimensions </comment>
     <constant name="Beam_Length"          value="(Dipole_Focus_Z-Q3eR_StartZ)/cos(Beam_Theta)"/>
@@ -195,7 +197,7 @@
     <comment> Entry box joining magnets, lumi and tagger systems </comment>
     <constant name="Exit_Height"          value="B2BeR_InnerRadius"/>
     <constant name="Exit_Width"           value="B2BeR_InnerRadius"/>
-    <constant name="Exit_Theta"           value="0.07*rad"/>
+    <constant name="Exit_Theta"           value="0.10*rad"/>
 
     <comment> Timepix4 ASIC dimensions </comment>
     <constant name="Timepix4height"       value="28.16*mm"/>
@@ -209,8 +211,8 @@
     <constant name="Tag_Cal_1_Depth"      value="300*mm"/>
     <constant name="Tagger1_Length"       value="Tag_Tracker_1_Depth"/>
 
-    <constant name="Tagger1_Min_Theta"    value="0.0262*rad"/>
-    <constant name="Tagger1_Max_Theta"    value="0.0410*rad"/>
+    <constant name="Tagger1_Min_Theta"    value="0.03*rad"/>
+    <constant name="Tagger1_Max_Theta"    value="0.0420*rad"/>
     <constant name="Tagger1_Min_Offset"   value="Q3eR_InnerRadius"/>
 
     <constant name="Tagger2_Width"        value="147.84*mm"/>
@@ -220,7 +222,7 @@
     <constant name="Tag_Cal_2_Depth"      value="Tag_Cal_1_Depth"/>
     <constant name="Tagger2_Length"       value="Tag_Tracker_2_Depth"/>
 
-    <constant name="Tagger2_Min_Theta"    value="0.02*rad"/>
+    <constant name="Tagger2_Min_Theta"    value="0.022*rad"/>
     <constant name="Tagger2_Max_Theta"    value="Tagger1_Min_Theta+0.000*rad"/>
     <constant name="Tagger2_Min_Offset"   value="Q3eR_InnerRadius+Backwards_Box_Wall"/>
 
@@ -231,7 +233,7 @@
     <constant name="LumiBeamDiv_pref"     value="5 * 211e-6*rad"/>
 
     <!-- Lumi Exit Window -->
-    <constant name="LumiWin_Zstart"       value="-18.5*m"/>
+    <constant name="LumiWin_Zstart"       value="-25.5*m"/>
     <constant name="LumiWin_thickness"    value="1*cm"/>
     <constant name="LumiWin_R"            value="4*cm"/> <!-- opening radius of tagger box -->
     <constant name="LumiWin_Z"            value="LumiWin_Zstart - LumiWin_thickness/2."/>

--- a/compact/far_backward/definitions.xml
+++ b/compact/far_backward/definitions.xml
@@ -51,54 +51,54 @@
     <constant name="Q3eR_OuterRadius"     value="0.2*m"/>
     <constant name="Q3eR_Theta"           value="SQ3eR_Theta"/>
 
-    <constant name="SQ4eR_CenterZ"         value="-46.6786*m"/>
-    <constant name="SQ4eR_CenterX"         value="-0.91721*m"/>
+    <constant name="SQ4eR_CenterZ"         value="-46.6698*m"/>
+    <constant name="SQ4eR_CenterX"         value="-0.54376*m"/>
     <constant name="SQ4eR_Length"          value="0.25*m"/>
     <constant name="SQ4eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
     <constant name="SQ4eR_OuterRadius"     value="0.2*m"/>
     <constant name="SQ4eR_Theta"           value="Q3eR_Theta"/>
 
-    <constant name="Q4eR_CenterZ"         value="-47.2534*m"/>
-    <constant name="Q4eR_CenterX"         value="-0.93331*m"/>
+    <constant name="Q4eR_CenterZ"         value="-47.2444*m"/>
+    <constant name="Q4eR_CenterX"         value="-0.55526*m"/>
     <constant name="Q4eR_Length"          value="0.6*m"/>
     <constant name="Q4eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
     <constant name="Q4eR_OuterRadius"     value="0.2*m"/>
     <constant name="Q4eR_Theta"           value="Q3eR_Theta"/>
 
-    <constant name="B3eR_CenterZ"         value="-50.01*m"/>
-    <constant name="B3eR_CenterX"         value="-0.67*m"/>
-    <constant name="B3eR_Length"          value="1.2*m"/>
-    <constant name="B3eR_InnerRadius"     value="0.05*m"/>
+    <constant name="SQ5eR_CenterZ"         value="-51.1668*m"/>
+    <constant name="SQ5eR_CenterX"         value="-0.63375*m"/>
+    <constant name="SQ5eR_Length"          value="0.25*m"/>
+    <constant name="SQ5eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
+    <constant name="SQ5eR_OuterRadius"     value="0.2*m"/>
+    <constant name="SQ5eR_Theta"           value="Q3eR_Theta"/>
+
+    <constant name="Q5eR_CenterZ"         value="-51.7415*m"/>
+    <constant name="Q5eR_CenterX"         value="-0.64525*m"/>
+    <constant name="Q5eR_Length"          value="0.6*m"/>
+    <constant name="Q5eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
+    <constant name="Q5eR_OuterRadius"     value="0.2*m"/>
+    <constant name="Q5eR_Theta"           value="Q3eR_Theta"/>
+
+    <constant name="B3eR_CenterZ"         value="-53.6402*m"/>
+    <constant name="B3eR_CenterX"         value="-0.68395*m"/>
+    <constant name="B3eR_Length"          value="0.8914*m"/>
+    <constant name="B3eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
     <constant name="B3eR_OuterRadius"     value="0.24*m"/>
-    <constant name="B3eR_Theta"           value="Q3eR_Theta*7/8"/>
+    <constant name="B3eR_Theta"           value="0.02159242"/>
 
-    <constant name="B4eR_CenterZ"         value="-55*m"/>
-    <constant name="B4eR_CenterX"         value="-0.79*m"/>
-    <constant name="B4eR_Length"          value="1.2*m"/>
-    <constant name="B4eR_InnerRadius"     value="0.05*m"/>
-    <constant name="B4eR_OuterRadius"     value="0.24*m"/>
-    <constant name="B4eR_Theta"           value="Q3eR_Theta*6/8"/>
+    <constant name="SQ6eR_CenterZ"         value="-55.3639*m"/>
+    <constant name="SQ6eR_CenterX"         value="-0.7232*m"/>
+    <constant name="SQ6eR_Length"          value="0.25*m"/>
+    <constant name="SQ6eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
+    <constant name="SQ6eR_OuterRadius"     value="0.2*m"/>
+    <constant name="SQ6eR_Theta"           value="0.023175959"/>
 
-    <constant name="B5eR_CenterZ"         value="-59.98*m"/>
-    <constant name="B5eR_CenterX"         value="-0.93*m"/>
-    <constant name="B5eR_Length"          value="1.2*m"/>
-    <constant name="B5eR_InnerRadius"     value="0.05*m"/>
-    <constant name="B5eR_OuterRadius"     value="0.24*m"/>
-    <constant name="B5eR_Theta"           value="Q3eR_Theta*5/8"/>
-
-    <constant name="B6eR_CenterZ"         value="-64.97*m"/>
-    <constant name="B6eR_CenterX"         value="-1.05*m"/>
-    <constant name="B6eR_Length"          value="1.2*m"/>
-    <constant name="B6eR_InnerRadius"     value="0.05*m"/>
-    <constant name="B6eR_OuterRadius"     value="0.24*m"/>
-    <constant name="B6eR_Theta"           value="Q3eR_Theta*4/8"/>
-
-    <constant name="B7eR_CenterZ"         value="-69.96*m"/>
-    <constant name="B7eR_CenterX"         value="-1.19*m"/>
-    <constant name="B7eR_Length"          value="1.2*m"/>
-    <constant name="B7eR_InnerRadius"     value="0.05*m"/>
-    <constant name="B7eR_OuterRadius"     value="0.24*m"/>
-    <constant name="B7eR_Theta"           value="Q3eR_Theta*3/8"/>
+    <constant name="Q6eR_CenterZ"         value="-56.2383*m"/>
+    <constant name="Q6eR_CenterX"         value="-0.774347*m"/>
+    <constant name="Q6eR_Length"          value="1.2*m"/>
+    <constant name="Q6eR_InnerRadius"     value="SQ3eR_InnerRadius"/>
+    <constant name="Q6eR_OuterRadius"     value="0.2*m"/>
+    <constant name="Q6eR_Theta"           value="SQ6eR_Theta"/>
 
 
     <comment> Hadron magnet dimensions and positions </comment>

--- a/compact/far_backward/magnets.xml
+++ b/compact/far_backward/magnets.xml
@@ -66,9 +66,15 @@
       <coil dx="2*cm" dy="1.5*cm" /><!--unchecked-->
     </detector>
 
+    <detector name="Magnets_SQ3eR" type="ip6_CylindricalDipoleMagnet" vis="FFMagnetVis">
+      <placement  x="SQ3eR_XPosition" y="0" z="SQ3eR_CenterPosition" theta="Q3eR_Theta"/>
+      <dimensions x="SQ3eR_InnerRadius*4" y="SQ3eR_InnerRadius*4" z="SQ3eR_Length" r="1.5*SQ3eR_InnerRadius"/>
+      <apperture  x="SQ3eR_InnerRadius*2" y="SQ3eR_InnerRadius*2" r="SQ3eR_InnerRadius"/>
+      <coil dx="2*cm" dy="1.5*cm" /><!--unchecked-->
+    </detector>
 
     <detector name="Magnets_Q3eR" type="ip6_CylindricalDipoleMagnet" vis="FFMagnetVis">
-      <placement  x="Q3eR_XPosition" y="0" z="Q3eR_CenterPosition" theta="Q3eR_Theta"/>
+      <placement  x="Q3eR_CenterX" y="0" z="Q3eR_CenterZ" theta="Q3eR_Theta"/>
       <dimensions x="Q3eR_InnerRadius*4" y="Q3eR_InnerRadius*4" z="Q3eR_Length" r="1.5*Q3eR_InnerRadius"/>
       <apperture  x="Q3eR_InnerRadius*2" y="Q3eR_InnerRadius*2" r="Q3eR_InnerRadius"/>
       <coil dx="2*cm" dy="1.5*cm" /><!--unchecked-->
@@ -96,7 +102,8 @@
 
     <field name="Magnet_Q3eR_Field" type="MultipoleMagnet">
       <shape type="Tube" rmax="Q3eR_InnerRadius" dz="Q3eR_Length/2"/>
-      <position x="0" y="0" z="Q3eR_CenterPosition"/>
+      <position x="Q3eR_CenterX" y="0" z="Q3eR_CenterZ"/>
+      <rotation x="0" y="Q3eR_Theta" z="0"/>
       <coefficient/>
       <coefficient coefficient="Q3eR_Gradient"/>
     </field>

--- a/compact/far_backward/magnets.xml
+++ b/compact/far_backward/magnets.xml
@@ -37,8 +37,8 @@
       </pipe>
       <pipe id="6" name="Pipe_B2AeR_to_B2BeR"/>
       <pipe id="7" name="Pipe_in_B2BeR"
-        xcenter="0" zcenter="B2BeR_CenterPosition"
-        length="B2BeR_Length" theta="0"
+        xcenter="B2BeR_Center_x" zcenter="B2BeR_CenterPosition"
+        length="B2BeR_Length" theta="B2BeR_Theta"
         rout1="B2BeR_InnerRadius" rout2="B2BeR_InnerRadius">
       </pipe>
     </detector>
@@ -59,28 +59,19 @@
       <coil dx="2*cm" dy="1.5*cm" /><!--unchecked-->
     </detector>
 
-    <detector name="Magnet_B2AeR" type="ip6_CylindricalDipoleMagnet" vis="FFMagnetVis">
-      <placement  x="0" y="0" z="B2AeR_CenterPosition" theta="0*rad"/>
-      <dimensions x="B2AeR_InnerRadius*4" y="B2AeR_InnerRadius*4" z="B2AeR_Length" r="1.5*B2AeR_InnerRadius"/>
-      <apperture  x="B2AeR_InnerRadius*2" y="B2AeR_InnerRadius*2" r="B2AeR_InnerRadius"/>
-      <coil dx="2*cm" dy="1.5*cm" /><!--unchecked-->
-    </detector>
-
     <detector name="Magnet_B2BeR" type="ip6_CylindricalDipoleMagnet" vis="FFMagnetVis">
-      <placement  x="0" y="0" z="B2BeR_CenterPosition" theta="0*rad"/>
+      <placement  x="B2BeR_Center_x" y="0" z="B2BeR_CenterPosition" theta="B2BeR_Theta"/>
       <dimensions x="B2BeR_InnerRadius*4" y="B2BeR_InnerRadius*4" z="B2BeR_Length" r="1.5*B2BeR_InnerRadius"/>
       <apperture  x="B2BeR_InnerRadius*2" y="B2BeR_InnerRadius*2" r="B2BeR_InnerRadius"/>
       <coil dx="2*cm" dy="1.5*cm" /><!--unchecked-->
     </detector>
 
-    <detector
-    name="Magnets_Q3eR"
-    type="CylindricalMagnetChain"
-    vis="RedVis">
-      <magnet id="0" name="Magnet_Q3eR"
-        x="(Q3eR_StartX+Q3eR_EndX)/2" y="0" z="(Q3eR_StartZ+Q3eR_EndZ)/2" theta="Q3eR_Theta"
-        length="Q3eR_Length" rin="Q3eR_InnerRadius" rout="4*Q3eR_InnerRadius">
-      </magnet>
+
+    <detector name="Magnets_Q3eR" type="ip6_CylindricalDipoleMagnet" vis="FFMagnetVis">
+      <placement  x="Q3eR_XPosition" y="0" z="Q3eR_CenterPosition" theta="Q3eR_Theta"/>
+      <dimensions x="Q3eR_InnerRadius*4" y="Q3eR_InnerRadius*4" z="Q3eR_Length" r="1.5*Q3eR_InnerRadius"/>
+      <apperture  x="Q3eR_InnerRadius*2" y="Q3eR_InnerRadius*2" r="Q3eR_InnerRadius"/>
+      <coil dx="2*cm" dy="1.5*cm" /><!--unchecked-->
     </detector>
 
   </detectors>

--- a/compact/far_forward/electron_beamline.xml
+++ b/compact/far_forward/electron_beamline.xml
@@ -56,7 +56,7 @@
     </detector>
 
     <!-- Q0eF magnet -->
-    <detector name="Q0EF" type="ip6_CylindricalDipoleMagnet" vis="RedVis">
+    <detector name="Q0EF" type="ip6_CylindricalDipoleMagnet" vis="FFMagnetVis">
       <placement  x="0" y="0" z="(Q0EF_StartZ+Q0EF_EndZ)/2." theta="0"/>
       <dimensions x="Q0EF_InnerRadius*4" y="Q0EF_InnerRadius*4" z="Q0EF_StartZ-Q0EF_EndZ" r="1.9*Q0EF_InnerRadius" />
       <apperture  x="Q0EF_InnerRadius*2" y="Q0EF_InnerRadius*2" r="Q0EF_InnerRadius" />
@@ -72,7 +72,7 @@
     </detector>
 
     <!-- Q1eF magnet -->
-    <detector name="Q1EF" type="ip6_CylindricalDipoleMagnet" vis="RedVis">
+    <detector name="Q1EF" type="ip6_CylindricalDipoleMagnet" vis="FFMagnetVis">
       <placement  x="0" y="0" z="(Q1EF_StartZ+Q1EF_EndZ)/2." theta="0"/>
       <dimensions x="Q1EF_InnerRadius*4" y="Q1EF_InnerRadius*4" z="Q1EF_StartZ-Q1EF_EndZ" r="1.9*Q1EF_InnerRadius" />
       <apperture  x="Q1EF_InnerRadius*2" y="Q1EF_InnerRadius*2" r="Q1EF_InnerRadius" />

--- a/compact/fields/beamline_10x100.xml
+++ b/compact/fields/beamline_10x100.xml
@@ -10,18 +10,17 @@
 
     <comment>
        Backwards Fields
-       Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/
+       Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
     </comment>
 
-
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_10x100.xml
+++ b/compact/fields/beamline_10x100.xml
@@ -15,12 +15,17 @@
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.111625"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_10x100.xml
+++ b/compact/fields/beamline_10x100.xml
@@ -18,14 +18,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.111625"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_10x110_H2.xml
+++ b/compact/fields/beamline_10x110_H2.xml
@@ -15,12 +15,17 @@
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.111625"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_10x110_H2.xml
+++ b/compact/fields/beamline_10x110_H2.xml
@@ -14,14 +14,13 @@
        Relevent values in the tables scale linearly with beam energy
     </comment>
 
-
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_10x110_H2.xml
+++ b/compact/fields/beamline_10x110_H2.xml
@@ -18,14 +18,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.111625"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_10x275.xml
+++ b/compact/fields/beamline_10x275.xml
@@ -10,18 +10,17 @@
 
     <comment>
        Backwards Fields
-       Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/
+       Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
     </comment>
 
-
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_10x275.xml
+++ b/compact/fields/beamline_10x275.xml
@@ -15,12 +15,17 @@
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.111625"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_10x275.xml
+++ b/compact/fields/beamline_10x275.xml
@@ -18,14 +18,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.111625"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_18x110_Au.xml
+++ b/compact/fields/beamline_18x110_Au.xml
@@ -18,14 +18,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.119551"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_18x110_Au.xml
+++ b/compact/fields/beamline_18x110_Au.xml
@@ -15,12 +15,17 @@
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.119551"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_18x110_Au.xml
+++ b/compact/fields/beamline_18x110_Au.xml
@@ -10,18 +10,17 @@
 
     <comment>
        Backwards Fields
-       Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/
+       Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
     </comment>
 
-
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_18x110_H2.xml
+++ b/compact/fields/beamline_18x110_H2.xml
@@ -15,12 +15,17 @@
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.119551"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_18x110_H2.xml
+++ b/compact/fields/beamline_18x110_H2.xml
@@ -10,18 +10,17 @@
 
     <comment>
        Backwards Fields
-       Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/
+       Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
     </comment>
 
-
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_18x110_H2.xml
+++ b/compact/fields/beamline_18x110_H2.xml
@@ -18,14 +18,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.119551"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
     <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_18x110_He3.xml
+++ b/compact/fields/beamline_18x110_He3.xml
@@ -18,14 +18,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.119551"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_18x110_He3.xml
+++ b/compact/fields/beamline_18x110_He3.xml
@@ -15,12 +15,17 @@
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.119551"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_18x110_He3.xml
+++ b/compact/fields/beamline_18x110_He3.xml
@@ -10,18 +10,17 @@
 
     <comment>
        Backwards Fields
-       Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/
+       Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
     </comment>
 
-
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_18x110_Pb.xml
+++ b/compact/fields/beamline_18x110_Pb.xml
@@ -18,14 +18,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.119551"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_18x110_Pb.xml
+++ b/compact/fields/beamline_18x110_Pb.xml
@@ -15,12 +15,17 @@
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.119551"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_18x110_Pb.xml
+++ b/compact/fields/beamline_18x110_Pb.xml
@@ -10,18 +10,17 @@
 
     <comment>
        Backwards Fields
-       Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/
+       Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
     </comment>
 
-
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_18x275.xml
+++ b/compact/fields/beamline_18x275.xml
@@ -12,15 +12,21 @@
        Backwards Fields
        Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
+
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.119551"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_18x275.xml
+++ b/compact/fields/beamline_18x275.xml
@@ -16,12 +16,12 @@
 
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"        value="0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_18x275.xml
+++ b/compact/fields/beamline_18x275.xml
@@ -19,14 +19,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.119551"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_18x275.xml
+++ b/compact/fields/beamline_18x275.xml
@@ -10,23 +10,21 @@
 
     <comment>
        Backwards Fields
-       Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/
+       Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
     </comment>
-
 
     <!-- Beamline -->
     <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
     <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
     <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
     <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>
     <constant name="LumiAnalyzerMag_B"  value="1/1.2*tesla"/>
-
 
     <comment>
        Forward Fields

--- a/compact/fields/beamline_5x100.xml
+++ b/compact/fields/beamline_5x100.xml
@@ -15,12 +15,17 @@
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.090322"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_5x100.xml
+++ b/compact/fields/beamline_5x100.xml
@@ -10,18 +10,17 @@
 
     <comment>
        Backwards Fields
-       Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/
+       Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
     </comment>
 
-
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"  />
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"  />
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"      />
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"      />
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_5x100.xml
+++ b/compact/fields/beamline_5x100.xml
@@ -18,14 +18,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.090322"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_5x110_H2.xml
+++ b/compact/fields/beamline_5x110_H2.xml
@@ -15,12 +15,17 @@
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.090322"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_5x110_H2.xml
+++ b/compact/fields/beamline_5x110_H2.xml
@@ -10,18 +10,17 @@
 
     <comment>
        Backwards Fields
-       Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/
+       Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
     </comment>
 
-
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_5x110_H2.xml
+++ b/compact/fields/beamline_5x110_H2.xml
@@ -18,14 +18,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.090322"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_5x41.xml
+++ b/compact/fields/beamline_5x41.xml
@@ -15,12 +15,17 @@
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.090322"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_5x41.xml
+++ b/compact/fields/beamline_5x41.xml
@@ -10,18 +10,17 @@
 
     <comment>
        Backwards Fields
-       Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/
+       Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
     </comment>
 
-
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"  />
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"  />
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"      />
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"      />
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_5x41.xml
+++ b/compact/fields/beamline_5x41.xml
@@ -18,14 +18,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.090322"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B"     value="1/1.2*tesla"/>

--- a/compact/fields/beamline_5x41_H2.xml
+++ b/compact/fields/beamline_5x41_H2.xml
@@ -15,12 +15,17 @@
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.090322"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_5x41_H2.xml
+++ b/compact/fields/beamline_5x41_H2.xml
@@ -10,18 +10,17 @@
 
     <comment>
        Backwards Fields
-       Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/
+       Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
     </comment>
 
-
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_5x41_H2.xml
+++ b/compact/fields/beamline_5x41_H2.xml
@@ -18,14 +18,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.090322"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_5x41_He3.xml
+++ b/compact/fields/beamline_5x41_He3.xml
@@ -15,12 +15,17 @@
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.090322"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_5x41_He3.xml
+++ b/compact/fields/beamline_5x41_He3.xml
@@ -10,18 +10,17 @@
 
     <comment>
        Backwards Fields
-       Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/
+       Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
     </comment>
 
-
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_5x41_He3.xml
+++ b/compact/fields/beamline_5x41_He3.xml
@@ -18,14 +18,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.090322"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_5x41_He4.xml
+++ b/compact/fields/beamline_5x41_He4.xml
@@ -15,12 +15,17 @@
     </comment>
 
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_K1L"       value="-0.41401"/>
+    <constant name="Q2eR_K1L"       value="0.316408"/>
+    <constant name="Q3eR_K1L"       value="0.090322"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_BendAngle" value="0.0*rad"/>
+    <constant name="B2BeR_BendAngle" value="0.020*rad"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_5x41_He4.xml
+++ b/compact/fields/beamline_5x41_He4.xml
@@ -10,18 +10,17 @@
 
     <comment>
        Backwards Fields
-       Values taken from: https://indico.bnl.gov/event/10974/contributions/51260/
+       Values taken from: https://brookhavenlab.sharepoint.com/:f:/r/sites/eRHIC/bnl%26slac/Shared%20Documents/Version-6.3/
        Relevent values in the tables scale linearly with beam energy
     </comment>
 
-
     <!-- Beamline -->
-    <constant name="Q1eR_Gradient"  value="-0.739741*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="0.66821*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="0.21674*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*(-0.41401)*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*0.316408*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*0.111625*tesla/meter/GeV*ElectronBeamEnergy"/>
 
-    <constant name="B2AeR_B"        value="0.0106667*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"        value="0.0132222*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"        value="3.33564*0.0*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"        value="3.33564*0.00364*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/compact/fields/beamline_5x41_He4.xml
+++ b/compact/fields/beamline_5x41_He4.xml
@@ -18,14 +18,14 @@
     <constant name="Q1eR_K1L"       value="-0.41401"/>
     <constant name="Q2eR_K1L"       value="0.316408"/>
     <constant name="Q3eR_K1L"       value="0.090322"/>
-    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
-    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/meter/GeV*ElectronBeamEnergy"/>
+    <constant name="Q1eR_Gradient"  value="3.33564*Q1eR_K1L/Q1eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q2eR_Gradient"  value="3.33564*Q2eR_K1L/Q2eR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="Q3eR_Gradient"  value="3.33564*Q3eR_K1L/Q3eR_Length*tesla/GeV*ElectronBeamEnergy"/>
 
     <constant name="B2AeR_BendAngle" value="0.0*rad"/>
     <constant name="B2BeR_BendAngle" value="0.020*rad"/>
-    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*tesla/GeV*ElectronBeamEnergy"/>
-    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2AeR_B"         value="3.33564*B2AeR_BendAngle/B2AeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
+    <constant name="B2BeR_B"         value="3.33564*B2BeR_BendAngle/B2BeR_Length*meter*tesla/GeV*ElectronBeamEnergy"/>
 
     <!-- Luminosity System -->
     <constant name="LumiSweepMag_B" value="1/1.2*tesla"/> <!-- Currently left static before tuning of acceptance -->

--- a/src/BeamPipeChain_geo.cpp
+++ b/src/BeamPipeChain_geo.cpp
@@ -51,10 +51,10 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
     // Vectors momentarily filled with zeros for pipes in between magnets
     xCenters.push_back(getAttrOrDefault<double>(pipe, _Unicode(xcenter), 0));
     zCenters.push_back(getAttrOrDefault<double>(pipe, _Unicode(zcenter), 0));
-    lengths. push_back(getAttrOrDefault<double>(pipe, _Unicode(length),  0));
-    thetas.  push_back(getAttrOrDefault<double>(pipe, _Unicode(theta),   0));
-    rOuters1.push_back(getAttrOrDefault<double>(pipe, _Unicode(rout1),   0));
-    rOuters2.push_back(getAttrOrDefault<double>(pipe, _Unicode(rout2),   0));
+    lengths.push_back(getAttrOrDefault<double>(pipe, _Unicode(length), 0));
+    thetas.push_back(getAttrOrDefault<double>(pipe, _Unicode(theta), 0));
+    rOuters1.push_back(getAttrOrDefault<double>(pipe, _Unicode(rout1), 0));
+    rOuters2.push_back(getAttrOrDefault<double>(pipe, _Unicode(rout2), 0));
   }
 
   // Calculate parameters for connecting pipes in between magnets
@@ -70,17 +70,19 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
       continue;
     } // can't create pipe for an empty end slot
 
-    double previousPipeEndX = xCenters[pipeN - 1] - lengths[pipeN - 1] / 2. * sin(thetas[pipeN - 1]);
-    double previousPipeEndZ = zCenters[pipeN - 1] - lengths[pipeN - 1] / 2. * cos(thetas[pipeN - 1]);
-    double nextPipeStartX   = xCenters[pipeN + 1] + lengths[pipeN + 1] / 2. * sin(thetas[pipeN + 1]);
-    double nextPipeStartZ   = zCenters[pipeN + 1] + lengths[pipeN + 1] / 2. * cos(thetas[pipeN + 1]);
+    double previousPipeEndX =
+        xCenters[pipeN - 1] - lengths[pipeN - 1] / 2. * sin(thetas[pipeN - 1]);
+    double previousPipeEndZ =
+        zCenters[pipeN - 1] - lengths[pipeN - 1] / 2. * cos(thetas[pipeN - 1]);
+    double nextPipeStartX = xCenters[pipeN + 1] + lengths[pipeN + 1] / 2. * sin(thetas[pipeN + 1]);
+    double nextPipeStartZ = zCenters[pipeN + 1] + lengths[pipeN + 1] / 2. * cos(thetas[pipeN + 1]);
 
-    double x = (previousPipeEndX + nextPipeStartX) / 2.;
-    double z = (previousPipeEndZ + nextPipeStartZ) / 2.;
+    double x      = (previousPipeEndX + nextPipeStartX) / 2.;
+    double z      = (previousPipeEndZ + nextPipeStartZ) / 2.;
     double deltaX = previousPipeEndX - nextPipeStartX;
     double deltaZ = previousPipeEndZ - nextPipeStartZ;
-    double l     = sqrt(deltaX * deltaX + deltaZ * deltaZ);
-    double theta = atan2(deltaX,deltaZ);
+    double l      = sqrt(deltaX * deltaX + deltaZ * deltaZ);
+    double theta  = atan2(deltaX, deltaZ);
 
     xCenters[pipeN] = x;
     zCenters[pipeN] = z;
@@ -91,22 +93,17 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
   }
 
   // If there is an bend in the pipe, calculate the length reduction of the pipe and joint length
-  for (uint i = 1; i < thetas.size(); i++)
-  {
-    // Start at the join between the first two pipes ending at the join between the last two pipes N-1    
-    if(thetas[i-1] == thetas[i])
-    {
+  for (uint i = 1; i < thetas.size(); i++) {
+    // Start at the join between the first two pipes ending at the join between the last two pipes N-1
+    if (thetas[i - 1] == thetas[i]) {
       bendLengths.push_back(0);
-    }
-    else // Correct for tubes, not yet cones so imperfect
+    } else // Correct for tubes, not yet cones so imperfect
     {
-      double bendAngle  = thetas[i] - thetas[i-1];
-      double bendLength = abs(rOuters1[i] * tan(bendAngle/2));      
-      bendLengths.push_back(bendLength+bendRadius);
+      double bendAngle  = thetas[i] - thetas[i - 1];
+      double bendLength = abs(rOuters1[i] * tan(bendAngle / 2));
+      bendLengths.push_back(bendLength + bendRadius);
     }
-
   }
-  
 
   // Add all pipes to the assembly
   for (uint pipeN = 0; pipeN < xCenters.size(); pipeN++) {
@@ -119,78 +116,68 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
     double rOuter2 = rOuters2[pipeN];
 
     //Change straight pipe length to account for bend
-    if(pipeN!=0)
-    { 
-      length  -= bendLengths[pipeN-1];
-      xCenter -= bendLengths[pipeN-1]/2*sin(theta);
-      zCenter -= bendLengths[pipeN-1]/2*cos(theta);
+    if (pipeN != 0) {
+      length -= bendLengths[pipeN - 1];
+      xCenter -= bendLengths[pipeN - 1] / 2 * sin(theta);
+      zCenter -= bendLengths[pipeN - 1] / 2 * cos(theta);
     }
-    if(pipeN!=xCenters.size()-1)
-    {
-      length  -= bendLengths[pipeN];
-      xCenter += bendLengths[pipeN]/2*sin(theta);
-      zCenter += bendLengths[pipeN]/2*cos(theta);
+    if (pipeN != xCenters.size() - 1) {
+      length -= bendLengths[pipeN];
+      xCenter += bendLengths[pipeN] / 2 * sin(theta);
+      zCenter += bendLengths[pipeN] / 2 * cos(theta);
     }
 
-    ConeSegment s_tube(length / 2.0, rOuter2 - thickness, rOuter2,
-                       rOuter1 - thickness, rOuter1);
-    ConeSegment s_vacuum(length / 2.0, 0, rOuter2 - thickness, 0,
-                         rOuter1 - thickness);
+    ConeSegment s_tube(length / 2.0, rOuter2 - thickness, rOuter2, rOuter1 - thickness, rOuter1);
+    ConeSegment s_vacuum(length / 2.0, 0, rOuter2 - thickness, 0, rOuter1 - thickness);
 
     Volume v_tube("v_tube_" + names[pipeN], s_tube, m_Al);
     Volume v_vacuum("v_vacuum_" + names[pipeN], s_vacuum, m_Vacuum);
 
     v_tube.setVisAttributes(description.visAttributes(vis_name));
 
-    assembly.placeVolume(v_tube, Transform3D(RotationY(theta),
-                                             Position(xCenter, 0, zCenter)));
-    auto placed_vacuum =
-        assembly.placeVolume(v_vacuum, Transform3D(RotationY(theta),
-                                                   Position(xCenter, 0, zCenter)));
+    assembly.placeVolume(v_tube, Transform3D(RotationY(theta), Position(xCenter, 0, zCenter)));
+    auto placed_vacuum = assembly.placeVolume(
+        v_vacuum, Transform3D(RotationY(theta), Position(xCenter, 0, zCenter)));
 
     DetElement vacuum_element(sdet, names[pipeN] + "_vacuum", ids[pipeN]);
     vacuum_element.setPlacement(placed_vacuum);
 
     // // Add joining bend to next pipe
-    if(pipeN!=xCenters.size()-1 && bendLengths[pipeN]!=0){
+    if (pipeN != xCenters.size() - 1 && bendLengths[pipeN] != 0) {
 
       // double bendLength = bendLengths[pipeN];
-      double bendAngle  = thetas[pipeN+1] - thetas[pipeN];
+      double bendAngle = thetas[pipeN + 1] - thetas[pipeN];
 
       // Create a torus to join the two pipes
-      Torus s_bend_solid(rOuter2+bendRadius, rOuter2-thickness,rOuter2, 0.0,abs(bendAngle)); 
+      Torus s_bend_solid(rOuter2 + bendRadius, rOuter2 - thickness, rOuter2, 0.0, abs(bendAngle));
 
       //Create a vacuum torus to place inside the solid segment
-      Torus s_bend_vac(rOuter2+bendRadius, 0, rOuter2-thickness, 0, abs(bendAngle));
+      Torus s_bend_vac(rOuter2 + bendRadius, 0, rOuter2 - thickness, 0, abs(bendAngle));
 
       // //Create the volumes
       Volume v_bend_soild("v_bend_solid_" + names[pipeN], s_bend_solid, m_Al);
-      Volume v_bend_vac("v_bend_vac_" + names[pipeN], s_bend_vac,   m_Vacuum);
+      Volume v_bend_vac("v_bend_vac_" + names[pipeN], s_bend_vac, m_Vacuum);
 
       // Calculate the position and rotation to place bend at the joint
-      double bendCenterX = xCenter + rOuter2*cos(theta) - (length/2)*sin(theta);
-      double bendCenterZ = zCenter - rOuter2*sin(theta) - (length/2)*cos(theta);
-      double rotation = pi-theta;
-      if(bendAngle>0)
-      {
-        bendCenterX = xCenter - rOuter2*cos(theta) - (length/2)*sin(theta);
-        bendCenterZ = zCenter + rOuter2*sin(theta) - (length/2)*cos(theta);
-        rotation = -bendAngle-theta; 
+      double bendCenterX = xCenter + rOuter2 * cos(theta) - (length / 2) * sin(theta);
+      double bendCenterZ = zCenter - rOuter2 * sin(theta) - (length / 2) * cos(theta);
+      double rotation    = pi - theta;
+      if (bendAngle > 0) {
+        bendCenterX = xCenter - rOuter2 * cos(theta) - (length / 2) * sin(theta);
+        bendCenterZ = zCenter + rOuter2 * sin(theta) - (length / 2) * cos(theta);
+        rotation    = -bendAngle - theta;
       }
 
       // Place the bend in the assembly
-      assembly.placeVolume(v_bend_soild, Transform3D(RotationZYX(rotation,0,pi/2), Position(bendCenterX, 0, bendCenterZ)));
-      assembly.placeVolume(v_bend_vac,   Transform3D(RotationZYX(rotation,0,pi/2), Position(bendCenterX, 0, bendCenterZ)));
+      assembly.placeVolume(v_bend_soild, Transform3D(RotationZYX(rotation, 0, pi / 2),
+                                                     Position(bendCenterX, 0, bendCenterZ)));
+      assembly.placeVolume(v_bend_vac, Transform3D(RotationZYX(rotation, 0, pi / 2),
+                                                   Position(bendCenterX, 0, bendCenterZ)));
 
       // Set vis attributes
-      v_bend_soild.setVisAttributes(description.visAttributes(vis_name));  
-
+      v_bend_soild.setVisAttributes(description.visAttributes(vis_name));
     }
-
-
-
   }
-
 
   // Final placement
   auto pv_assembly =

--- a/src/BeamPipeChain_geo.cpp
+++ b/src/BeamPipeChain_geo.cpp
@@ -161,7 +161,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
       Torus s_bend_solid(rOuter2+bendRadius, rOuter2-thickness,rOuter2, 0.0,abs(bendAngle)); 
 
       //Create a vacuum torus to place inside the solid segment
-      Torus s_bend_vac(rOuter2+bendRadius, 0, rOuter2-thickness, 0, bendAngle);
+      Torus s_bend_vac(rOuter2+bendRadius, 0, rOuter2-thickness, 0, abs(bendAngle));
 
       // //Create the volumes
       Volume v_bend_soild("v_bend_solid_" + names[pipeN], s_bend_solid, m_Al);

--- a/src/BeamPipeChain_geo.cpp
+++ b/src/BeamPipeChain_geo.cpp
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-// Copyright (C) 2022 Dhevan Gangadharan
+// Copyright (C) 2022-25 Dhevan Gangadharan, Simon Gardner
 
 //==========================================================================
 //
 // Places a chain of beam pipe segments within and between the beamline magnets.
 //
 // Approximation used for beam pipes in between magnets.
-// Right-angled ends with a small air gap to avoid G4 overlap errors
 //
 //==========================================================================
 
@@ -29,6 +28,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
   Material m_Vacuum = description.material("Vacuum");
   string vis_name   = dd4hep::getAttrOrDefault<std::string>(x_det, _Unicode(vis), "BeamPipeVis");
   double thickness  = getAttrOrDefault<double>(x_det, _Unicode(wall_thickness), 0);
+  double bendRadius = 0.00001; //Small bend radius to allow the construction of toruses
 
   vector<string> names;
   vector<int> ids;
@@ -38,6 +38,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
   vector<double> thetas;
   vector<double> rOuters1;
   vector<double> rOuters2;
+  vector<double> bendLengths;
 
   // Grab info for beamline magnets
   for (xml_coll_t pipe_coll(x_det, _Unicode(pipe)); pipe_coll; pipe_coll++) { // pipes
@@ -50,10 +51,10 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
     // Vectors momentarily filled with zeros for pipes in between magnets
     xCenters.push_back(getAttrOrDefault<double>(pipe, _Unicode(xcenter), 0));
     zCenters.push_back(getAttrOrDefault<double>(pipe, _Unicode(zcenter), 0));
-    lengths.push_back(getAttrOrDefault<double>(pipe, _Unicode(length), 0));
-    thetas.push_back(getAttrOrDefault<double>(pipe, _Unicode(theta), 0));
-    rOuters1.push_back(getAttrOrDefault<double>(pipe, _Unicode(rout1), 0));
-    rOuters2.push_back(getAttrOrDefault<double>(pipe, _Unicode(rout2), 0));
+    lengths. push_back(getAttrOrDefault<double>(pipe, _Unicode(length),  0));
+    thetas.  push_back(getAttrOrDefault<double>(pipe, _Unicode(theta),   0));
+    rOuters1.push_back(getAttrOrDefault<double>(pipe, _Unicode(rout1),   0));
+    rOuters2.push_back(getAttrOrDefault<double>(pipe, _Unicode(rout2),   0));
   }
 
   // Calculate parameters for connecting pipes in between magnets
@@ -69,23 +70,17 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
       continue;
     } // can't create pipe for an empty end slot
 
-    double x = (xCenters[pipeN - 1] - lengths[pipeN - 1] / 2. * sin(thetas[pipeN - 1]) +
-                xCenters[pipeN + 1] + lengths[pipeN + 1] / 2. * sin(thetas[pipeN + 1])) /
-               2.;
-    double z = (zCenters[pipeN - 1] - lengths[pipeN - 1] / 2. * cos(thetas[pipeN - 1]) +
-                zCenters[pipeN + 1] + lengths[pipeN + 1] / 2. * cos(thetas[pipeN + 1])) /
-               2.;
-    double deltaX = (xCenters[pipeN - 1] - lengths[pipeN - 1] / 2. * sin(thetas[pipeN - 1])) -
-                    (xCenters[pipeN + 1] + lengths[pipeN + 1] / 2. * sin(thetas[pipeN + 1]));
-    double deltaZ = (zCenters[pipeN - 1] - lengths[pipeN - 1] / 2. * cos(thetas[pipeN - 1])) -
-                    (zCenters[pipeN + 1] + lengths[pipeN + 1] / 2. * cos(thetas[pipeN + 1]));
-    double l     = sqrt(pow(deltaX, 2) + pow(deltaZ, 2));
-    double theta = atan(deltaX / deltaZ);
+    double previousPipeEndX = xCenters[pipeN - 1] - lengths[pipeN - 1] / 2. * sin(thetas[pipeN - 1]);
+    double previousPipeEndZ = zCenters[pipeN - 1] - lengths[pipeN - 1] / 2. * cos(thetas[pipeN - 1]);
+    double nextPipeStartX   = xCenters[pipeN + 1] + lengths[pipeN + 1] / 2. * sin(thetas[pipeN + 1]);
+    double nextPipeStartZ   = zCenters[pipeN + 1] + lengths[pipeN + 1] / 2. * cos(thetas[pipeN + 1]);
 
-    // Small air gap between connecting and magnet beam pipes to avoid G4 overlap errors
-    if ((theta != thetas[pipeN - 1]) || (theta != thetas[pipeN + 1])) {
-      l -= 0.5;
-    }
+    double x = (previousPipeEndX + nextPipeStartX) / 2.;
+    double z = (previousPipeEndZ + nextPipeStartZ) / 2.;
+    double deltaX = previousPipeEndX - nextPipeStartX;
+    double deltaZ = previousPipeEndZ - nextPipeStartZ;
+    double l     = sqrt(deltaX * deltaX + deltaZ * deltaZ);
+    double theta = atan2(deltaX,deltaZ);
 
     xCenters[pipeN] = x;
     zCenters[pipeN] = z;
@@ -95,28 +90,107 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
     rOuters2[pipeN] = rOuters1[pipeN + 1];
   }
 
+  // If there is an bend in the pipe, calculate the length reduction of the pipe and joint length
+  for (uint i = 1; i < thetas.size(); i++)
+  {
+    // Start at the join between the first two pipes ending at the join between the last two pipes N-1    
+    if(thetas[i-1] == thetas[i])
+    {
+      bendLengths.push_back(0);
+    }
+    else // Correct for tubes, not yet cones so imperfect
+    {
+      double bendAngle  = thetas[i] - thetas[i-1];
+      double bendLength = abs(rOuters1[i] * tan(bendAngle/2));      
+      bendLengths.push_back(bendLength+bendRadius);
+    }
+
+  }
+  
+
   // Add all pipes to the assembly
   for (uint pipeN = 0; pipeN < xCenters.size(); pipeN++) {
 
-    ConeSegment s_tube(lengths[pipeN] / 2.0, rOuters2[pipeN] - thickness, rOuters2[pipeN],
-                       rOuters1[pipeN] - thickness, rOuters1[pipeN]);
-    ConeSegment s_vacuum(lengths[pipeN] / 2.0, 0, rOuters2[pipeN] - thickness, 0,
-                         rOuters1[pipeN] - thickness);
+    double length  = lengths[pipeN];
+    double theta   = thetas[pipeN];
+    double xCenter = xCenters[pipeN];
+    double zCenter = zCenters[pipeN];
+    double rOuter1 = rOuters1[pipeN];
+    double rOuter2 = rOuters2[pipeN];
+
+    //Change straight pipe length to account for bend
+    if(pipeN!=0)
+    { 
+      length  -= bendLengths[pipeN-1];
+      xCenter -= bendLengths[pipeN-1]/2*sin(theta);
+      zCenter -= bendLengths[pipeN-1]/2*cos(theta);
+    }
+    if(pipeN!=xCenters.size()-1)
+    {
+      length  -= bendLengths[pipeN];
+      xCenter += bendLengths[pipeN]/2*sin(theta);
+      zCenter += bendLengths[pipeN]/2*cos(theta);
+    }
+
+    ConeSegment s_tube(length / 2.0, rOuter2 - thickness, rOuter2,
+                       rOuter1 - thickness, rOuter1);
+    ConeSegment s_vacuum(length / 2.0, 0, rOuter2 - thickness, 0,
+                         rOuter1 - thickness);
 
     Volume v_tube("v_tube_" + names[pipeN], s_tube, m_Al);
     Volume v_vacuum("v_vacuum_" + names[pipeN], s_vacuum, m_Vacuum);
 
     v_tube.setVisAttributes(description.visAttributes(vis_name));
 
-    assembly.placeVolume(v_tube, Transform3D(RotationY(thetas[pipeN]),
-                                             Position(xCenters[pipeN], 0, zCenters[pipeN])));
+    assembly.placeVolume(v_tube, Transform3D(RotationY(theta),
+                                             Position(xCenter, 0, zCenter)));
     auto placed_vacuum =
-        assembly.placeVolume(v_vacuum, Transform3D(RotationY(thetas[pipeN]),
-                                                   Position(xCenters[pipeN], 0, zCenters[pipeN])));
+        assembly.placeVolume(v_vacuum, Transform3D(RotationY(theta),
+                                                   Position(xCenter, 0, zCenter)));
 
     DetElement vacuum_element(sdet, names[pipeN] + "_vacuum", ids[pipeN]);
     vacuum_element.setPlacement(placed_vacuum);
+
+    // // Add joining bend to next pipe
+    if(pipeN!=xCenters.size()-1 && bendLengths[pipeN]!=0){
+
+      // double bendLength = bendLengths[pipeN];
+      double bendAngle  = thetas[pipeN+1] - thetas[pipeN];
+
+      // Create a torus to join the two pipes
+      Torus s_bend_solid(rOuter2+bendRadius, rOuter2-thickness,rOuter2, 0.0,abs(bendAngle)); 
+
+      //Create a vacuum torus to place inside the solid segment
+      Torus s_bend_vac(rOuter2+bendRadius, 0, rOuter2-thickness, 0, bendAngle);
+
+      // //Create the volumes
+      Volume v_bend_soild("v_bend_solid_" + names[pipeN], s_bend_solid, m_Al);
+      Volume v_bend_vac("v_bend_vac_" + names[pipeN], s_bend_vac,   m_Vacuum);
+
+      // Calculate the position and rotation to place bend at the joint
+      double bendCenterX = xCenter + rOuter2*cos(theta) - (length/2)*sin(theta);
+      double bendCenterZ = zCenter - rOuter2*sin(theta) - (length/2)*cos(theta);
+      double rotation = pi-theta;
+      if(bendAngle>0)
+      {
+        bendCenterX = xCenter - rOuter2*cos(theta) - (length/2)*sin(theta);
+        bendCenterZ = zCenter + rOuter2*sin(theta) - (length/2)*cos(theta);
+        rotation = -bendAngle-theta; 
+      }
+
+      // Place the bend in the assembly
+      assembly.placeVolume(v_bend_soild, Transform3D(RotationZYX(rotation,0,pi/2), Position(bendCenterX, 0, bendCenterZ)));
+      assembly.placeVolume(v_bend_vac,   Transform3D(RotationZYX(rotation,0,pi/2), Position(bendCenterX, 0, bendCenterZ)));
+
+      // Set vis attributes
+      v_bend_soild.setVisAttributes(description.visAttributes(vis_name));  
+
+    }
+
+
+
   }
+
 
   // Final placement
   auto pv_assembly =

--- a/src/CylindricalMagnetChain_geo.cpp
+++ b/src/CylindricalMagnetChain_geo.cpp
@@ -33,6 +33,7 @@ static Ref_t create_magnet(Detector& description, xml_h e, SensitiveDetector /* 
     xml_comp_t magnet(magnet_coll);
 
     string name   = getAttrOrDefault<string>(magnet, _Unicode(name), "");
+    int id        = getAttrOrDefault<int>(magnet, _Unicode(id), 0);
     double x      = getAttrOrDefault<double>(magnet, _Unicode(x), 0);
     double y      = getAttrOrDefault<double>(magnet, _Unicode(y), 0);
     double z      = getAttrOrDefault<double>(magnet, _Unicode(z), 0);
@@ -45,9 +46,14 @@ static Ref_t create_magnet(Detector& description, xml_h e, SensitiveDetector /* 
     Tube yoke_tube(rin, rout, 0.5 * length);
     Volume v_yoke("v_yoke_" + name, yoke_tube, m_Iron);
 
-    v_yoke.setVisAttributes(description.visAttributes(vis_name));
+    v_yoke.setVisAttributes(x_det.visStr());
+    
+    auto yoke_pv = assembly.placeVolume(v_yoke, Transform3D(RotationY(theta), Position(x, y, z)));
 
-    assembly.placeVolume(v_yoke, Transform3D(RotationY(theta), Position(x, y, z)));
+    yoke_pv.addPhysVolID("element", id);
+    DetElement yoke_de(sdet, name, id);
+    yoke_de.setPlacement(yoke_pv);
+    yoke_de.setAttributes(description, v_yoke, x_det.regionStr(), x_det.limitsStr(), vis_name);
   }
 
   // Final placement

--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -44,9 +44,9 @@
       The ip6 (or other ip) defines should be included first.
       These files have only a define tags.
     </documentation>
-    <include ref="${DETECTOR_PATH}/compact/fields/beamline_{{ ebeam | default("18", true) }}x{{ pbeam | default("275", true) }}.xml" />
     <include ref="${DETECTOR_PATH}/compact/far_forward/definitions.xml" />
     <include ref="${DETECTOR_PATH}/compact/far_backward/definitions.xml" />
+    <include ref="${DETECTOR_PATH}/compact/fields/beamline_{{ ebeam | default("18", true) }}x{{ pbeam | default("275", true) }}.xml" />
     <include ref="${DETECTOR_PATH}/compact/definitions.xml" />
     <include ref="${DETECTOR_PATH}/compact/version.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Originally instigated by moving the B2eR magnet out of the cryostat, this geometry matches the most recent lattice of the accelerator in the far backward region.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
Changes the path of electrons in the far-backward region. This will break the Low-Q2 Tagger reconstruction, simple retraining of the network should be sufficient after this is eventually merged.