### PR TITLE
add 10x130 interpolated beamline to enable normal usage like other en…

### DIFF
--- a/compact/fields/beamline_10x130.xml
+++ b/compact/fields/beamline_10x130.xml
@@ -6,7 +6,7 @@
     <constant name="ElectronBeamEnergy" value="10*GeV"  />
     <constant name="IonBeamEnergy"      value="130*GeV" />
 
-    <constant name="FieldScaleFactor" value="130.0/275.0"  /> <!-- only use for light ion beams!!! ASK FF EXPERTS -->
+    <constant name="FieldScaleFactor" value="130.0/130.0"  /> <!-- only use for light ion beams!!! ASK FF EXPERTS -->
 
     <comment>
        Backwards Fields
@@ -35,9 +35,9 @@
 
     <constant name="B0PF_GradientMax"  value="-8.12238283*tesla/m"/>
     <constant name="B0APF_GradientMax" value="0.0*tesla/m"/>
-    <constant name="Q1APF_GradientMax" value="-72.608*tesla/m"/>
-    <constant name="Q1BPF_GradientMax" value="-63.24525402*tesla/m"/>
-    <constant name="Q2PF_GradientMax"  value="36.88301623*tesla/m"/>
+    <constant name="Q1APF_GradientMax" value="-48.9786*tesla/m"/>
+    <constant name="Q1BPF_GradientMax" value="-10.842*tesla/m"/>
+    <constant name="Q2PF_GradientMax"  value="16.909*tesla/m"/>
     <constant name="B1PF_GradientMax"  value="0.0*tesla/m"/>
     <constant name="B1APF_GradientMax" value="0.0*tesla/m"/>
     <constant name="B2PF_GradientMax"  value="0.0*tesla/m"/>
@@ -45,13 +45,13 @@
     <constant name="Q1EF_GradientMax"  value="5.85089*tesla/m"/>
 
     <constant name="B0PF_Bmax"  value="1.1840539*tesla"/>
-    <constant name="B0APF_Bmax" value="3.4314469*tesla"/>
+    <constant name="B0APF_Bmax" value="-0.371977*tesla"/>
     <constant name="Q1APF_Bmax" value="0.0*tesla"/>
     <constant name="Q1BPF_Bmax" value="0.0*tesla"/>
     <constant name="Q2PF_Bmax"  value="0.0*tesla"/>
-    <constant name="B1PF_Bmax"  value="3.447989*tesla"/>
-    <constant name="B1APF_Bmax" value="2.7*tesla"/>
-    <constant name="B2PF_Bmax" value="-4.7890142*tesla"/>
+    <constant name="B1PF_Bmax"  value="1.66058*tesla"/>
+    <constant name="B1APF_Bmax" value="1.27633*tesla"/>
+    <constant name="B2PF_Bmax" value="-2.26384*tesla"/>
     <constant name="Q0EF_BMax" value="0.0*tesla"/>
     <constant name="Q1EF_BMax"  value="0.0*tesla"/>
 


### PR DESCRIPTION
…ergies

### Briefly, what does this PR introduce?

This PR introduces a 10x130 lattice which has been calculated via interpolation between the three "core" beam energy settings, while still keeping the B0 constant.  This will be paired with a similar PR for the RP matrices in EICrecon.

This updated magnet setting file will allow for "normal" usage of the file, where the B0 and RP can be used simultaneously.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ x] Tests for the changes have been added
- [x] Documentation has been added / updated
- [x ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No, improves performance.

### Does this PR change default behavior?

Yes, it changes the default 10x130 magnet settings to something which can be properly used.
