### PR TITLE
fix: likely typo in PFRICH_geo.cpp

### DIFF
--- a/src/PFRICH_geo.cpp
+++ b/src/PFRICH_geo.cpp
@@ -423,7 +423,7 @@ static Ref_t createDetector(Detector& description, xml_h e, SensitiveDetector se
   PlacedVolume qdboxPV = hrppdVol_air.placeVolume(qdboxVol, Position(0.0, 0.0, accu + pdthick / 2));
 
   DetElement qdboxDE(sdet, "qdbox_de", 0);
-  pdboxDE.setPlacement(qdboxPV);
+  qdboxDE.setPlacement(qdboxPV);
 
   accu += certhick + 1 * mm;
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes a likely typo in the PFRICH geometry plugin. It is likely that the line `pdboxDE.setPlacement(pdboxPV)` was copied and only the argument changed, but not the object itself.

Previously:
```cpp
  DetElement pdboxDE(sdet, "pdbox_de", 0);
  pdboxDE.setPlacement(pdboxPV);
  // ...
  DetElement qdboxDE(sdet, "qdbox_de", 0);
  pdboxDE.setPlacement(qdboxPV);
```

New:
```cpp
  DetElement pdboxDE(sdet, "pdbox_de", 0);
  pdboxDE.setPlacement(pdboxPV);
  // ...
  DetElement qdboxDE(sdet, "qdbox_de", 0);
  qdboxDE.setPlacement(qdboxPV);
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue: `/world/RICHEndcapN/qdbox_de DetElement with INVALID PLACEMENT!`)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.