### PR TITLE
linux-eic-shell.yml: fix download step in build-artifacts-page

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -779,7 +779,8 @@ jobs:
     - name: Download GitHub Pages staging artifact
       uses: actions/download-artifact@v4
       with:
-        path: artifacts/
+        name: github-pages-staging
+        path: publishing_docs/
     - name: Build jekyll page
       uses: actions/jekyll-build-pages@v1
     - name: Make PR summary page


### PR DESCRIPTION
This should help with issues like https://github.com/eic/epic/actions/runs/14817178151/job/41749142343#step:7:7

Doesn't look like `artifacts/` were supposed to be used https://github.com/eic/EICrecon/blob/734cd480d8637ac50837db0d70da0ac48a1498d5/.github/workflows/linux-eic-shell.yml#L1161C11-L1162

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
