### PR TITLE
fix: handle dead symlinks in FileLoaderHelper

### DIFF
--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -188,7 +188,7 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
                  "but a file already exists there and we will not remove it automatically");
     printout(ERROR, "FileLoader", "hint: backup the file, remove it manually, and retry");
     std::_Exit(EXIT_FAILURE);
-  }    
+  }
   // file_path now does not exist
 
   // symlink file_path to hash_path

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -180,14 +180,16 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
       }
     }
   } else {
-    // failure mode: file exists but not symlink, and we won't remove files
-    printout(ERROR, "FileLoader",
-             "file " + file_path.string() + " already exists but is not a symlink");
-    printout(ERROR, "FileLoader",
-             "we tried to create a symlink " + file_path.string() + " to the actual resource, " +
-                 "but a file already exists there and we will not remove it automatically");
-    printout(ERROR, "FileLoader", "hint: backup the file, remove it manually, and retry");
-    std::_Exit(EXIT_FAILURE);
+    if (fs::exists(file_path)) {
+      // failure mode: file exists but not symlink, and we won't remove files
+      printout(ERROR, "FileLoader",
+               "file " + file_path.string() + " already exists but is not a symlink");
+      printout(ERROR, "FileLoader",
+               "we tried to create a symlink " + file_path.string() + " to the actual resource, " +
+                   "but a file already exists there and we will not remove it automatically");
+      printout(ERROR, "FileLoader", "hint: backup the file, remove it manually, and retry");
+      std::_Exit(EXIT_FAILURE);
+    }
   }
   // file_path now does not exist
 

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -180,6 +180,15 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
       printout(ERROR, "FileLoader", "hint: backup the file, remove it manually, and retry");
       std::_Exit(EXIT_FAILURE);
     }
+  } else {
+    // file does not exists
+    if (fs::is_symlink(file_path)) {
+      // file is (dead) symllink
+      if (fs::remove(file_path) == false) {
+        printout(ERROR, "FileLoader", "unable to remove symlink " + file_path.string());
+        std::_Exit(EXIT_FAILURE);
+      }
+    }
   }
   // file_path now does not exist
 

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -146,18 +146,19 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
     }
   }
 
-  // check if file already exists
-  if (fs::exists(file_path)) {
-    // file already exists
-    if (fs::is_symlink(file_path)) {
-      // file is symlink
+  // check if file is symlink
+  if (fs::is_symlink(file_path)) {
+    // file is symlink, i.e. valid symlink
+    if (fs::exists(file_path)) {
+      // file already exists
       fs::path symlink_target = fs::read_symlink(file_path);
       if (fs::exists(symlink_target) && fs::equivalent(hash_path, symlink_target)) {
         // link points to correct path
         return;
       } else {
-        // link points to incorrect path
+        // link points to incorrect path -> remove symlink
         if (fs::remove(file_path) == false) {
+          // failure mode: cannot remove incorrect symlink
           printout(ERROR, "FileLoader", "unable to remove symlink " + file_path.string());
           printout(ERROR, "FileLoader",
                    "we tried to create a symlink " + file_path.string() +
@@ -171,25 +172,23 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
         }
       }
     } else {
-      // file exists but not symlink
-      printout(ERROR, "FileLoader",
-               "file " + file_path.string() + " already exists but is not a symlink");
-      printout(ERROR, "FileLoader",
-               "we tried to create a symlink " + file_path.string() + " to the actual resource, " +
-                   "but a file already exists there and we will not remove it automatically");
-      printout(ERROR, "FileLoader", "hint: backup the file, remove it manually, and retry");
-      std::_Exit(EXIT_FAILURE);
-    }
-  } else {
-    // file does not exists
-    if (fs::is_symlink(file_path)) {
-      // file is (dead) symllink
+      // file does not exists, i.e. dead symllink -> remove symlink
       if (fs::remove(file_path) == false) {
+        // failure mode; cannot remove dead symlink
         printout(ERROR, "FileLoader", "unable to remove symlink " + file_path.string());
         std::_Exit(EXIT_FAILURE);
       }
     }
-  }
+  } else {
+    // failure mode: file exists but not symlink, and we won't remove files
+    printout(ERROR, "FileLoader",
+             "file " + file_path.string() + " already exists but is not a symlink");
+    printout(ERROR, "FileLoader",
+             "we tried to create a symlink " + file_path.string() + " to the actual resource, " +
+                 "but a file already exists there and we will not remove it automatically");
+    printout(ERROR, "FileLoader", "hint: backup the file, remove it manually, and retry");
+    std::_Exit(EXIT_FAILURE);
+  }    
   // file_path now does not exist
 
   // symlink file_path to hash_path


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes an infrequent recurring issue in the handling of calibrations and fieldmaps. It occurs when a file handle symlink is pointing to a hash symlink that is itself pointing to a non-existent location (the following is the situation after the error occurs):
```
jug_dev> wdconinc@menelaos:~/git/epic$ ls -al calibrations/
total 152616
drwxr-xr-x  6 wdconinc wdconinc     4096 May 12 13:16 .
drwxrwxr-x 32 wdconinc wdconinc     4096 May 12 13:16 ..
lrwxrwxrwx  1 wdconinc wdconinc      109 May 12 13:16 0820c1b054653fef -> /opt/detector/epic-git.63e5b941500f64c35449c29850b0bd60717adb2c_main/share/epic/calibrations/0820c1b054653fef
-rwxrwxrwx  1 wdconinc wdconinc      178 Apr 27 11:14 5a54959cc63eeb5b -> /opt/software/linux-debian12-x86_64_v2/gcc-12.2.0/epic-git.4f29e576c85b7342bf0b3b3f0329e4f4583b3f5f_main-
lrwxrwxrwx  1 wdconinc wdconinc       16 Apr 27 11:14 materials-map.cbor -> 5a54959cc63eeb5b
```
Above, the link `0820c1b054653fef` to the new `materials-map.cbor` in `/opt` has already been created, but `materials-map.cbor` cannot be relinked to point to `0820c1b054653fef`. The file handle symlink `materials-map.cbor` is indicated to not exist even if the symlink exists but the file it points to does not. Since it does not exist, the code tries to create the symlink, but fails because it already exists.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: headaches when updating calibrations files)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.