### PR TITLE
fix: avoid memory leaks in various geometry plugins

### DIFF
--- a/compact/central_beampipe.xml
+++ b/compact/central_beampipe.xml
@@ -14,7 +14,7 @@
 
   <detectors>
 
-    <detector id="BeamPipe_ID" name="BeamPipe" type="IP6BeamPipe" vis="BeamPipeVis">
+    <detector id="BeamPipe_ID" name="BeamPipe" type="IP6BeamPipe" vis_wall="AnlBlue" vis_coating="AnlRed" vis_IPwall="AnlGreen" vis_IPcoating="AnlOrange">
       <type_flags type="DetType_TRACKER + DetType_BEAMPIPE" />
       <beampipe/>
       <IP_pipe

--- a/src/EndcapFluxReturn_geo.cpp
+++ b/src/EndcapFluxReturn_geo.cpp
@@ -37,7 +37,7 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& description, xml_h e,
 
     dd4hep::Material l_mat = description.material(x_layer.materialStr());
 
-    dd4hep::DetElement disk_ele("disk_ele", layer_id);
+    dd4hep::DetElement disk_ele(sdet, Form("disk_ele_%d", layer_id), layer_id);
     dd4hep::Volume disk(x_layer.nameStr(),
                         dd4hep::Tube(layer_rmin, layer_rmax, layer_thickness / 2, 0.0, 2.0 * M_PI),
                         air);

--- a/src/ForwardRomanPot_geo.cpp
+++ b/src/ForwardRomanPot_geo.cpp
@@ -86,7 +86,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
     xml_comp_t x_ma = ma;
     string ma_name  = x_ma.nameStr();
     Assembly ma_vol(ma_name);
-    DetElement ma_de(ma_name, x_det.id());
+    DetElement ma_de(sdet, ma_name, x_det.id());
     module_assemblies[ma_name]         = ma_vol;
     module_assembly_delements[ma_name] = ma_de;
 
@@ -156,6 +156,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       auto comp_vol = module_assemblies[comp_assembly];
       auto comp_de =
           module_assembly_delements[comp_assembly].clone(comp_assembly + std::to_string(l_num));
+      sdet.add(comp_de);
       if (c_pos) {
         pv = l_vol.placeVolume(comp_vol, Position(c_pos.x(), c_pos.y(), c_pos.z()));
       } else {
@@ -168,6 +169,9 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
     pv = assembly.placeVolume(l_vol, l_pos);
     pv.addPhysVolID("layer", l_num);
   }
+
+  // delete unplaced volumes
+  module_assembly_delements.clear();
 
   Transform3D posAndRot(RotationZYX(rot.z(), rot.y(), rot.x()),
                         Position(pos.x(), pos.y(), pos.z()));

--- a/src/IP6BeamPipe.cpp
+++ b/src/IP6BeamPipe.cpp
@@ -52,7 +52,6 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   Material m_Vacuum  = det.material("Vacuum");
   Material m_Wall    = det.material("StainlessSteel");
   Material m_Coating = det.material("Copper");
-  string vis_name    = x_det.visStr();
 
   // IP Beampipe
   double IP_beampipe_ID                = IP_pipe_c.attr<double>(_Unicode(ID));
@@ -65,10 +64,10 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   double downstream_straight_length = IP_pipe_c.attr<double>(_Unicode(downstream_straight_length));
 
   // visualization
-  VisAttr wallVis("wall");
-  VisAttr coatingVis("coating");
-  VisAttr IPwallVis("IPwall");
-  VisAttr IPcoatingVis("IPcoating");
+  auto wallVis      = det.visAttributes(x_det.attr<std::string>(_Unicode(vis_wall)));
+  auto coatingVis   = det.visAttributes(x_det.attr<std::string>(_Unicode(vis_coating)));
+  auto IPwallVis    = det.visAttributes(x_det.attr<std::string>(_Unicode(vis_IPwall)));
+  auto IPcoatingVis = det.visAttributes(x_det.attr<std::string>(_Unicode(vis_IPcoating)));
 
   // colors: (r, g, b, alpha)
   wallVis.setColor(0.0, 0.0, 1.0, 1.0);      // blue
@@ -146,17 +145,15 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
                                IP_beampipe_coating_material);
   Volume v_upstream_IP_tube("v_upstream_IP_tube", upstream_IP_tube, IP_beampipe_wall_material);
 
-  // set vis colors
-  v_downstream_IP_tube.setVisAttributes(IPwallVis);
-  v_upstream_IP_tube.setVisAttributes(IPwallVis);
-  v_downstream_IP_coating.setVisAttributes(IPcoatingVis);
-  v_upstream_IP_coating.setVisAttributes(IPcoatingVis);
-
   // set names
-  sdet.setAttributes(det, v_upstream_IP_coating, x_det.regionStr(), x_det.limitsStr(), vis_name);
-  sdet.setAttributes(det, v_upstream_IP_tube, x_det.regionStr(), x_det.limitsStr(), vis_name);
-  sdet.setAttributes(det, v_downstream_IP_coating, x_det.regionStr(), x_det.limitsStr(), vis_name);
-  sdet.setAttributes(det, v_downstream_IP_tube, x_det.regionStr(), x_det.limitsStr(), vis_name);
+  sdet.setAttributes(det, v_upstream_IP_coating, x_det.regionStr(), x_det.limitsStr(),
+                     x_det.attr<std::string>(_Unicode(vis_IPcoating)));
+  sdet.setAttributes(det, v_upstream_IP_tube, x_det.regionStr(), x_det.limitsStr(),
+                     x_det.attr<std::string>(_Unicode(vis_IPwall)));
+  sdet.setAttributes(det, v_downstream_IP_coating, x_det.regionStr(), x_det.limitsStr(),
+                     x_det.attr<std::string>(_Unicode(vis_IPcoating)));
+  sdet.setAttributes(det, v_downstream_IP_tube, x_det.regionStr(), x_det.limitsStr(),
+                     x_det.attr<std::string>(_Unicode(vis_IPwall)));
 
   // place volumes
   assembly.placeVolume(v_upstream_IP_vacuum_fill, Position(0, 0, -upstream_straight_length / 2.0));

--- a/src/IP6BeamPipe.cpp
+++ b/src/IP6BeamPipe.cpp
@@ -755,6 +755,12 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   assembly.placeVolume(std::get<9>(volumes_downstream), tf_downstream);
   assembly.placeVolume(std::get<11>(volumes_downstream), tf_downstream);
 
+  // delete temporaries
+  wallVis.destroy();
+  coatingVis.destroy();
+  IPwallVis.destroy();
+  IPcoatingVis.destroy();
+
   // -----------------------------
   // final placement
   auto pv_assembly = det.pickMotherVolume(sdet).placeVolume(assembly);

--- a/src/IP6BeamPipe.cpp
+++ b/src/IP6BeamPipe.cpp
@@ -752,12 +752,6 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
   assembly.placeVolume(std::get<9>(volumes_downstream), tf_downstream);
   assembly.placeVolume(std::get<11>(volumes_downstream), tf_downstream);
 
-  // delete temporaries
-  wallVis.destroy();
-  coatingVis.destroy();
-  IPwallVis.destroy();
-  IPcoatingVis.destroy();
-
   // -----------------------------
   // final placement
   auto pv_assembly = det.pickMotherVolume(sdet).placeVolume(assembly);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes the recently introduced memory leak. VisAttributes are owned by the xml description. It also fixes a few other memory leaks, in particular due to interrupted DetElement trees, and forgotten `add` after `clone`.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.