### PR TITLE
Centralize IP6 Beampipe constant definitions

### DIFF
--- a/compact/central_beampipe.xml
+++ b/compact/central_beampipe.xml
@@ -2,12 +2,6 @@
 <!-- Copyright (C) 2022 Wouter Deconinck, Whitney Armstrong -->
 
 <lccdd>
-  <define>
-    <constant name="IPBeampipeUpstreamStraightLength" value="74.8 * cm"/>
-    <constant name="IPBeampipeDownstreamStraightLength" value="64.8 * cm"/>
-    <constant name="BeampipeOD" value="62 * mm"/>
-    <constant name="HadronConeOpenAngle" value="0.020 * rad + abs(CrossingAngle)"/>
-  </define>
 
   <display>
   </display>
@@ -33,18 +27,18 @@
                 place_vacuum="true">
         <outgoing_lepton wall_thickness="2.5 * mm"
                 coating_thickness="30 * um">
-          <zplane z="IPBeampipeUpstreamStraightLength" ID="IPBeampipeID"/>
-          <zplane z="454.449 * cm" ID="IPBeampipeID"/>
+          <zplane z="OutgoingLeptonBeamPipe_z0" ID="OutgoingLeptonBeamPipe_d0"/>
+          <zplane z="OutgoingLeptonBeamPipe_z1" ID="OutgoingLeptonBeamPipe_d1"/>
         </outgoing_lepton>
         <incoming_hadron wall_thickness="1.65 * mm"
                          coating_thickness="30 * um"
                          crossing_angle="CrossingAngle">
-          <zplane z="75.6 * cm" ID="2.527 * cm"/>
-          <zplane z="247.298 * cm" ID="2.527 * cm"/>
-          <zplane z="(247.298 + 2.54) * cm" ID="3.48 * cm"/>
-          <zplane z="(247.298 + 2.54 + 170.2) * cm" ID="3.48 * cm"/>
-          <zplane z="(247.298 + 2.54 + 170.2 + 1.27) * cm" ID="4.115 * cm"/>
-          <zplane z="(247.298 + 2.54 + 170.2 + 1.27 + 32.769) * cm" ID="4.115 * cm"/>
+          <zplane z="IncomingHadronBeamPipe_z0" ID="IncomingHadronBeamPipe_d0"/>
+          <zplane z="IncomingHadronBeamPipe_z1" ID="IncomingHadronBeamPipe_d1"/>
+          <zplane z="IncomingHadronBeamPipe_z2" ID="IncomingHadronBeamPipe_d2"/>
+          <zplane z="IncomingHadronBeamPipe_z3" ID="IncomingHadronBeamPipe_d3"/>
+          <zplane z="IncomingHadronBeamPipe_z4" ID="IncomingHadronBeamPipe_d4"/>
+          <zplane z="IncomingHadronBeamPipe_z5" ID="IncomingHadronBeamPipe_d5"/>
         </incoming_hadron>
       </upstream>
 

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -411,6 +411,50 @@ Examples:
     <constant name="SolenoidBarrel_length"     value="Solenoid_length"/>
 
     <documentation>
+      ## IP6 Beam Pipe Parameters - Note might need cleaning
+    </documentation>
+    <constant name="CrossingAngle" value="-0.025*rad "/>
+    <constant name="ionCrossingAngle" value="CrossingAngle"/>
+    <constant name="electronCrossingAngle" value="0.0"/>
+    <constant name="CrossingSlope" value="CrossingAngle"/>
+
+    <constant name="IPBeampipe_rmax" value="2.501*25.4*mm/2.0"/>
+    <constant name="Beampipe_rmax"   value="IPBeampipe_rmax"/>
+    <constant name="IPBeampipeID" desc="IP6 beam pipe inner diam w/o coating" value="62*mm"/>
+
+    <documentation>
+      ## Central Beam Pipe Parameters
+    </documentation>
+    <constant name="IPBeampipeUpstreamStraightLength" value="74.8 * cm"/>
+    <constant name="IPBeampipeDownstreamStraightLength" value="64.8 * cm"/>
+    <constant name="BeampipeOD" value="62 * mm"/>
+    <constant name="HadronConeOpenAngle" value="0.020 * rad + abs(CrossingAngle)"/>
+
+    <documentation>
+      ## Outgoing Lepton Beam Pipe Parameters
+    </documentation>
+    <constant name="OutgoingLeptonBeamPipe_z0" value="IPBeampipeUpstreamStraightLength"/>
+    <constant name="OutgoingLeptonBeamPipe_z1" value="454.449 * cm"/>
+    <constant name="OutgoingLeptonBeamPipe_d0" value="IPBeampipeID"/>
+    <constant name="OutgoingLeptonBeamPipe_d1" value="IPBeampipeID"/>
+
+    <documentation>
+      ## Incoming Hadron Beam Pipe Parameters
+    </documentation>
+    <constant name="IncomingHadronBeamPipe_z0" value="75.6*cm"/>
+    <constant name="IncomingHadronBeamPipe_z1" value="247.298*cm"/>
+    <constant name="IncomingHadronBeamPipe_z2" value="IncomingHadronBeamPipe_z1 + 2.54*cm"/>
+    <constant name="IncomingHadronBeamPipe_z3" value="IncomingHadronBeamPipe_z2 + 170.2*cm"/>
+    <constant name="IncomingHadronBeamPipe_z4" value="IncomingHadronBeamPipe_z3 + 1.27*cm"/>
+    <constant name="IncomingHadronBeamPipe_z5" value="IncomingHadronBeamPipe_z4 + 32.769*cm"/>
+    <constant name="IncomingHadronBeamPipe_d0" value="2.527*cm"/>
+    <constant name="IncomingHadronBeamPipe_d1" value="2.527*cm"/>
+    <constant name="IncomingHadronBeamPipe_d2" value="3.48*cm"/>
+    <constant name="IncomingHadronBeamPipe_d3" value="3.48*cm"/>
+    <constant name="IncomingHadronBeamPipe_d4" value="4.115*cm"/>
+    <constant name="IncomingHadronBeamPipe_d5" value="4.115*cm"/>
+
+    <documentation>
       ## Tracking Detector Parameters
     </documentation>
 

--- a/compact/far_backward/beamline_extension_hadron.xml
+++ b/compact/far_backward/beamline_extension_hadron.xml
@@ -60,12 +60,12 @@
       <pipe id="0" name="Pipe_to_Q1APR"
         xcenter="(Hadron_Beampipe_End*sin(CrossingAngle) + Q1APR_StartX)/2." zcenter="(Hadron_Beampipe_End + Q1APR_StartZ)/2."
         length="(Hadron_Beampipe_End - Q1APR_StartZ)/cos(CrossingAngle)" theta="CrossingAngle"
-        rout1="Hadron_Beampipe_Rad/2." rout2="Hadron_Beampipe_Rad/2.">
+        rout1="Hadron_Beampipe_Rad" rout2="Hadron_Beampipe_Rad">
       </pipe>
       <pipe id="1" name="Pipe_in_Q1APR"
         xcenter="(Q1APR_StartX + Q1APR_EndX)/2." zcenter="(Q1APR_StartZ + Q1APR_EndZ)/2."
         length="Q1APR_Length" theta="Q1APR_Theta"
-        rout1="Q1APR_InnerRadius/2." rout2="Q1APR_InnerRadius">
+        rout1="Q1APR_InnerRadius" rout2="Q1APR_InnerRadius">
       </pipe>
       <pipe id="2" name="Pipe_Q1APR_to_Q1BPR"/>
       <pipe id="3" name="Pipe_in_Q1BPR"

--- a/compact/far_backward/definitions.xml
+++ b/compact/far_backward/definitions.xml
@@ -5,11 +5,11 @@
 
     <comment> Connection to central beam pipe </comment>
 
-    <constant name="Center_Beampipe_End"  value="-4560.17*mm"/>
-    <constant name="Center_Beampipe_Rad"  value="47.60*mm"/>
+    <constant name="Center_Beampipe_End"  value="-OutgoingLeptonBeamPipe_z1"/>
+    <constant name="Center_Beampipe_Rad"  value="OutgoingLeptonBeamPipe_d1/2"/>
 
-    <constant name="Hadron_Beampipe_End"        value="-4490.35*mm"/>
-    <constant name="Hadron_Beampipe_Rad"        value="50*mm"/>
+    <constant name="Hadron_Beampipe_End"        value="-IncomingHadronBeamPipe_z5"/>
+    <constant name="Hadron_Beampipe_Rad"        value="IncomingHadronBeamPipe_d5/2"/>
     <constant name="Hadron_Beampipe_Thickness"  value="1.64*mm"/>
 
     <comment> Electron magnet dimensions and positions </comment>

--- a/compact/far_forward/definitions.xml
+++ b/compact/far_forward/definitions.xml
@@ -2,15 +2,6 @@
 <!-- Copyright (C) 2022 Alex Jentsch, Whitney Armstrong, Chao Peng -->
 
   <define>
-    <constant name="CrossingAngle" value="-0.025*rad "/>
-    <constant name="ionCrossingAngle" value="CrossingAngle"/>
-    <constant name="electronCrossingAngle" value="0.0"/>
-    <constant name="CrossingSlope" value="CrossingAngle"/>
-
-    <constant name="IPBeampipe_rmax" value="2.501*25.4*mm/2.0"/>
-    <constant name="Beampipe_rmax"   value="IPBeampipe_rmax"/>
-    <constant name="IPBeampipeID" desc="IP6 beam pipe inner diam w/o coating" value="62*mm"/>
-
 
     <comment>
                                     Hadron Magnets -- PRE BIG FLIP COORDINATES

--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -45,9 +45,9 @@
       These files have only a define tags.
     </documentation>
     <include ref="${DETECTOR_PATH}/compact/fields/beamline_{{ ebeam | default("18", true) }}x{{ pbeam | default("275", true) }}.xml" />
+    <include ref="${DETECTOR_PATH}/compact/definitions.xml" />
     <include ref="${DETECTOR_PATH}/compact/far_forward/definitions.xml" />
     <include ref="${DETECTOR_PATH}/compact/far_backward/definitions.xml" />
-    <include ref="${DETECTOR_PATH}/compact/definitions.xml" />
     <include ref="${DETECTOR_PATH}/compact/version.xml"/>
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
   </define>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fixes an airgap in the Far-Backward beamline by centralizing the definitions for the beampipe ends.

TaggerTrackerTracks have gone missing from the EICRecon output since the IP6 beampipe update. A visual inspection shows an air gap between the central beampipe and the current far-backward electron beamline (and an overlap with the incoming hadron extension). The air is _hopefully_ responsible for breaking the electron track reconstruction...

![image](https://github.com/user-attachments/assets/ab40317b-7c43-4964-b7fb-ac77065f8e61)

Centralizing the variables used to define the positions of the ends should fix this and stop something like this happening in the future. The small gap in the incoming hadron beamline is much less important.

![image](https://github.com/user-attachments/assets/20dd30b3-2244-478a-8845-28f345747c55)

A more detailed revision of the far-backward beamline is in progress but this is required sooner.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
Hopefully recovers a full vacuum