### PR TITLE
Bug fixed on incorrect ETOF readout offset

### DIFF
--- a/compact/tracking/tof_endcap.xml
+++ b/compact/tracking/tof_endcap.xml
@@ -658,7 +658,7 @@
 
   <readouts>
     <readout name="TOFEndcapHits">
-      <segmentation type="CartesianGridXY" grid_size_x="1*mm" grid_size_y="0.8*cm" />
+      <segmentation type="CartesianGridXY" grid_size_x="1*mm" grid_size_y="0.8*cm" offset_y="0.4*cm" offset_x="0.5*mm"/>
       <id>system:8,layer:4,module:2,idx:5,idy:5,ids:6,x:36:-12,y:-16</id>
     </readout>
   </readouts>


### PR DESCRIPTION
### Briefly, what does this PR introduce?

It was found that, due to incorrect offset on ETOF readout, the strips (i.e. cells) are not located at the right place inside a sensor. Here's how all strips within a sensor of ETOF looks like, with red rectangles representing the strips and light blue big squares representing each sensor unit. Height and width are reduced by 33% to show the gap between strips (otherwise each strip will connect seamlessly to form one giant rectangle),

![image](https://github.com/user-attachments/assets/9540403c-96a1-4e4e-9719-36f6788ed50b)

The red strips protrude out of the sensor because the center of that column is located exactly at the edge, causing half the bin to protrude outside.

Below is the strip locations after the bug fix,

![image](https://github.com/user-attachments/assets/461d1124-cc3c-463c-a187-10ef6d225aae)

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No, but potentially it could be related to https://github.com/eic/EICrecon/issues/1865. Cannot confirm for now. 

### Does this PR change default behavior?

No.