### PR TITLE
feat: make FieldMapB rotation and translation optional

### DIFF
--- a/compact/far_backward/lumi/lumi_magnets.xml
+++ b/compact/far_backward/lumi/lumi_magnets.xml
@@ -107,7 +107,6 @@ Construct the sweeper and analyzer dipole magnets for the luminosity subsystem.
         <Y step="2.0*cm" min="-34*cm" max="34*cm" />
         <Z step="2.0*cm" min="-80*cm" max="80*cm" />
         <translationCoord x="LumiSweepMag_X" y="LumiSweepMag_Y" z="LumiSweepMag_Z" />
-        <rotationField x="0" y="0" z="0" />
       </dimensions>
     </field>
 
@@ -121,7 +120,6 @@ Construct the sweeper and analyzer dipole magnets for the luminosity subsystem.
         <Y step="2.0*cm" min="-34*cm" max="34*cm" />
         <Z step="2.0*cm" min="-80*cm" max="80*cm" />
         <translationCoord x="LumiAnalyzerMag_X" y="LumiAnalyzerMag_Y" z="LumiAnalyzerMag_Z" />
-        <rotationField x="0" y="0" z="0" />
       </dimensions>
     </field>
 

--- a/compact/fields/marco.xml
+++ b/compact/fields/marco.xml
@@ -11,8 +11,6 @@
       <dimensions>
         <R step="2.0*cm" min="0*cm" max="998*cm" />
         <Z step="2.0*cm" min="-800*cm" max="798*cm" />
-        <translationCoord x="0.0*cm" y="0.0*cm" z="0.0*cm" />
-        <rotationField x="0" y="0" z="0" />
       </dimensions>
     </field>
   </fields>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR makes the specification of rotation and translation for FieldMapB entities optional, and does not do any trivial rotation and translation when they are not set. VTune profiling indicated that there was a 1% speed-up opportunity in avoiding the ROOT::Math::XYZPoint transformations (as well as the delayed phi determination). It is a bit of a micro-optimization, though, but `fieldComponents` is still the highest nail that is entirely under our control in simulations (because poorly defined geometry doesn't show up that way...).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: avoid defining trivial objects)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.