### PR TITLE
feat: tighten up the world to a more minimal geometry

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -9,6 +9,7 @@
     <documentation>
       ## World volume
     </documentation>
+    <constant name="backward_x0" value="0.5*m"/>
     <constant name="backward_dx" value="2*m"/>
     <constant name="backward_dy" value="1*m"/>
     <constant name="backward_dz" value="35*m"/>

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -10,14 +10,14 @@
       ## World volume
     </documentation>
     <constant name="backward_dx" value="2*m"/>
-    <constant name="backward_dy" value="0.5*m"/>
-    <constant name="backward_dz" value="65*m"/>
+    <constant name="backward_dy" value="1*m"/>
+    <constant name="backward_dz" value="35*m"/>
     <constant name="exp_hall_dx" value="3.5*m"/>
     <constant name="exp_hall_dy" value="3.5*m"/>
     <constant name="exp_hall_dz" value="5.5*m"/>
-    <constant name="forward_dx" value="1*m"/>
+    <constant name="forward_dx" value="2*m"/>
     <constant name="forward_dy" value="1*m"/>
-    <constant name="forward_dz" value="65*m"/>
+    <constant name="forward_dz" value="25*m"/>
 
     <documentation>
       ## Detector IDs

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -12,7 +12,7 @@
     <constant name="backward_x0" value="0.5*m"/>
     <constant name="backward_dx" value="2*m"/>
     <constant name="backward_dy" value="1*m"/>
-    <constant name="backward_dz" value="35*m"/>
+    <constant name="backward_dz" value="40*m"/>
     <constant name="exp_hall_dx" value="3.5*m"/>
     <constant name="exp_hall_dy" value="3.5*m"/>
     <constant name="exp_hall_dz" value="5.5*m"/>

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -9,10 +9,15 @@
     <documentation>
       ## World volume
     </documentation>
-    <constant name="world_side" value="30*m"/>
-    <constant name="world_dx" value="world_side"/>
-    <constant name="world_dy" value="world_side"/>
-    <constant name="world_dz" value="100*m"/>
+    <constant name="backward_dx" value="2*m"/>
+    <constant name="backward_dy" value="0.5*m"/>
+    <constant name="backward_dz" value="65*m"/>
+    <constant name="exp_hall_dx" value="3.5*m"/>
+    <constant name="exp_hall_dy" value="3.5*m"/>
+    <constant name="exp_hall_dz" value="5.5*m"/>
+    <constant name="forward_dx" value="1*m"/>
+    <constant name="forward_dy" value="1*m"/>
+    <constant name="forward_dz" value="65*m"/>
 
     <documentation>
       ## Detector IDs

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -15,6 +15,7 @@
     <constant name="exp_hall_dx" value="3.5*m"/>
     <constant name="exp_hall_dy" value="3.5*m"/>
     <constant name="exp_hall_dz" value="5.5*m"/>
+    <constant name="forward_x0" value="-1*m"/>
     <constant name="forward_dx" value="2*m"/>
     <constant name="forward_dy" value="1*m"/>
     <constant name="forward_dz" value="25*m"/>

--- a/compact/far_forward/vacuum.xml
+++ b/compact/far_forward/vacuum.xml
@@ -59,6 +59,8 @@
                 <apperture x="B2PF_InnerRadius*2" y="B2PF_InnerRadius*2"  r="B2PF_InnerRadius" />
         </element>
 
+        <end_of_the_world z="exp_hall_dz + 2.0 * forward_dz"/>
+
       </detector>
   </detectors>
 

--- a/src/magnetVacuumFF.cpp
+++ b/src/magnetVacuumFF.cpp
@@ -99,6 +99,9 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
     z_elem_magnet.push_back(pos_z * dd4hep::cm);
   }
 
+  xml_comp_t x_end_of_the_world = x_det.child(_Unicode(end_of_the_world));
+  double end_of_the_world_z     = x_end_of_the_world.attr<double>(_Unicode(z));
+
   int numMagnets = radii_magnet.size(); //number of actual FF magnets between IP and FF detectors
   int numGaps =
       numMagnets -
@@ -265,7 +268,7 @@ static Ref_t create_detector(Detector& det, xml_h e, SensitiveDetector /* sens *
 
     int pieceIdx           = numMagnets - 1; // last B2PF magnet
     std::string piece_name = Form("GapVacuum%d", numGaps + numMagnets + 1);
-    double endGapLength    = (10000.0 - z_end[pieceIdx]) / cos(rotation_magnet[pieceIdx]);
+    double endGapLength = (end_of_the_world_z - z_end[pieceIdx]) / cos(rotation_magnet[pieceIdx]);
     endGapLength =
         endGapLength -
         4 * radii_magnet[pieceIdx] *

--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -93,7 +93,7 @@
   <documentation level="0">
     ## World Volume
 
-    The world is a simple box, but could be a union of multiple regions.
+    The world is a union of multiple regions.
   </documentation>
   <world material="Air">
     <shape type="BooleanShape" operation="Union">

--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -100,7 +100,7 @@
       <shape type="BooleanShape" operation="Union">
         <shape type="Box" dx="exp_hall_dx" dy="exp_hall_dy" dz="exp_hall_dz"/>
         <shape type="Box" dx="backward_dx" dy="backward_dy" dz="backward_dz"/>
-        <position x="0*cm" y="0*cm" z="- exp_hall_dz - backward_dz"/>
+        <position x="backward_x0" y="0*cm" z="- exp_hall_dz - backward_dz"/>
       </shape>
       <shape type="Box" dx="forward_dx" dy="forward_dy" dz="forward_dz"/>
       <position x="forward_x0" y="0*cm" z="+ exp_hall_dz + forward_dz"/>

--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -96,7 +96,15 @@
     The world is a simple box, but could be a union of multiple regions.
   </documentation>
   <world material="Air">
-    <shape type="Box" dx="world_dx" dy="world_dy" dz="world_dz"/>
+    <shape type="BooleanShape" operation="Union">
+      <shape type="BooleanShape" operation="Union">
+        <shape type="Box" dx="exp_hall_dx" dy="exp_hall_dy" dz="exp_hall_dz"/>
+        <shape type="Box" dx="backward_dx" dy="backward_dy" dz="backward_dz"/>
+        <position x="0*cm" y="0*cm" z="- exp_hall_dz - backward_dz"/>
+      </shape>
+      <shape type="Box" dx="forward_dx" dy="forward_dy" dz="forward_dz"/>
+      <position x="0*cm" y="0*cm" z="+ exp_hall_dz + forward_dz"/>
+    </shape>
     <!--regionref   name="world_region"/-->
     <!--limitsetref name="world_limits"/-->
   </world>

--- a/templates/epic.xml.jinja2
+++ b/templates/epic.xml.jinja2
@@ -103,7 +103,7 @@
         <position x="0*cm" y="0*cm" z="- exp_hall_dz - backward_dz"/>
       </shape>
       <shape type="Box" dx="forward_dx" dy="forward_dy" dz="forward_dz"/>
-      <position x="0*cm" y="0*cm" z="+ exp_hall_dz + forward_dz"/>
+      <position x="forward_x0" y="0*cm" z="+ exp_hall_dz + forward_dz"/>
     </shape>
     <!--regionref   name="world_region"/-->
     <!--limitsetref name="world_limits"/-->


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR shrinks the world volume from 60 m x 60 m x 200 m to something that is just sufficient to enclose the relevant volumes. This way we won't be tracking slow neutrons on their way to death in air.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: the world is too big)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators: @ajentsch @simonge this makes the forward and backwards regions quite narrow, chosen based on what's currently in the geometry

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.