### PR TITLE
add Au197 5x41 GeV magnet configuration (scaled from top energy)

### DIFF
--- a/compact/fields/beamline_5x41_Au197.xml
+++ b/compact/fields/beamline_5x41_Au197.xml
@@ -3,7 +3,7 @@
 
   <define>
 
-    <constant name="ElectronBeamEnergy" value="10*GeV"  />
+    <constant name="ElectronBeamEnergy" value="5*GeV"  />
     <constant name="IonBeamEnergy"      value="41*GeV" /> <!-- per nucleon beam energy -->
 
     <constant name="FieldScaleFactor" value="102.24/275.0"  /> <!-- only use for light ion beams!!! ASK FF EXPERTS -->


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Add 5x41 GeV Au-197 magnetic field configuration as an option (using a scaled field from the top energy config).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No, just adds new configuration.

### Does this PR change default behavior?

No.
