### PR TITLE
linux-eic-shell.yml: avoid building container for main branch

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -393,7 +393,7 @@ jobs:
 
   trigger-container:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: github.actor != 'dependabot[bot]' && github.ref != 'refs/heads/main'
     needs: [check-overlap-tgeo, check-overlap-geant4-fast]
     steps:
     - uses: eic/trigger-gitlab-ci@v3


### PR DESCRIPTION
There is no need to do this, every commit has to pass eicweb tests before merging anyway.