### PR TITLE
feat: add DIRC to Acts geometry for truth hits and projection surfaces

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -150,7 +150,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/check-tracking-geometry.yml
     with:
-      detector_configs: "['epic_craterlake', 'epic_ip6', 'epic_dirc_only']"
+      detector_configs: "['epic_craterlake', 'epic_ip6']"
 
   validate-material-map:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -150,7 +150,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/check-tracking-geometry.yml
     with:
-      detector_configs: "['epic_craterlake', 'epic_ip6']"
+      detector_configs: "['epic_craterlake', 'epic_ip6', 'epic_dirc_only']"
 
   validate-material-map:
     runs-on: ubuntu-latest

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -150,12 +150,15 @@ The unused IDs below are saved for future use.
     - DIRC subsystem       ID: 90
     - Barrel TRD subsystem ID: 91
     - Barrel TOF subsystem ID: 92
-    - Unused IDs: 93-99
+    - Barrel TOF subassembly ID: 93
+    - Barrel DIRC subassembly ID: 94
+    - Unused IDs: 95-99
     </documentation>
     <constant name="BarrelDIRC_ID" value="90"/>
     <constant name="BarrelTRD_ID"  value="91"/>
     <constant name="BarrelTOF_ID"  value="92"/>
     <constant name="TOFSubAssembly_ID" value="93"/>
+    <constant name="DIRCSubAssembly_ID" value="94"/>
 
     <documentation>
       #### (100-109) Electromagnetic Calorimeter

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -151,14 +151,12 @@ The unused IDs below are saved for future use.
     - Barrel TRD subsystem ID: 91
     - Barrel TOF subsystem ID: 92
     - Barrel TOF subassembly ID: 93
-    - Barrel DIRC subassembly ID: 94
-    - Unused IDs: 95-99
+    - Unused IDs: 94-99
     </documentation>
     <constant name="BarrelDIRC_ID" value="90"/>
     <constant name="BarrelTRD_ID"  value="91"/>
     <constant name="BarrelTOF_ID"  value="92"/>
     <constant name="TOFSubAssembly_ID" value="93"/>
-    <constant name="DIRCSubAssembly_ID" value="94"/>
 
     <documentation>
       #### (100-109) Electromagnetic Calorimeter

--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -151,12 +151,14 @@ The unused IDs below are saved for future use.
     - Barrel TRD subsystem ID: 91
     - Barrel TOF subsystem ID: 92
     - Barrel TOF subassembly ID: 93
-    - Unused IDs: 94-99
+    - Barrel DIRC subassembly ID: 94
+    - Unused IDs: 95-99
     </documentation>
     <constant name="BarrelDIRC_ID" value="90"/>
     <constant name="BarrelTRD_ID"  value="91"/>
     <constant name="BarrelTOF_ID"  value="92"/>
     <constant name="TOFSubAssembly_ID" value="93"/>
+    <constant name="DIRCSubAssembly_ID" value="94"/>
 
     <documentation>
       #### (100-109) Electromagnetic Calorimeter

--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -97,8 +97,15 @@
   </display>
 
   <detectors>
+    <detector id="DIRCSubAssembly_ID"
+      name="DIRCTrackerSubAssembly"
+      type="DD4hep_SubdetectorAssembly"
+      vis="TrackerSubAssemblyVis">
+      <composite name="cb_DIRC"/>
+    </detector>
+
     <detector id="BarrelDIRC_ID" name="cb_DIRC" type="epic_DIRC" readout="DIRCBarHits" vis="DIRCTube" region="DIRCRegion">
-      <type_flags type="DetType_CHERENKOV + DetType_BARREL"/>
+      <type_flags type="DetType_TRACKER + DetType_CHERENKOV + DetType_BARREL"/>
       <dimensions rmin="DIRCBar_center - DIRCBar_height/2" rmax="DIRCBar_center + DIRCBar_height/2" length="DIRC_length"/>
       <position x="0" y="0" z="DIRC_offset"/>
 
@@ -194,6 +201,13 @@
       <id>system:8,module:8,section:8,bar:8,x:32:-16,y:-16</id>
     </readout>
   </readouts>
+
+  <plugins>
+    <plugin name="DD4hep_ParametersPlugin">
+      <argument value="cb_DIRC"/>
+      <argument value="layer_pattern: str=cb_DIRC_layer\d"/>
+    </plugin>
+  </plugins>
 
   <fields>
   </fields>

--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -205,7 +205,7 @@
   <plugins>
     <plugin name="DD4hep_ParametersPlugin">
       <argument value="cb_DIRC"/>
-      <argument value="layer_pattern: str=envelope"/>
+      <argument value="layer_pattern: str=module\d"/>
     </plugin>
   </plugins>
 

--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -97,9 +97,25 @@
   </display>
 
   <detectors>
+    <detector id="DIRCSubAssembly_ID"
+      name="DIRCTrackerSubAssembly"
+      type="DD4hep_SubdetectorAssembly"
+      vis="TrackerSubAssemblyVis">
+      <composite name="cb_DIRC"/>
+    </detector>
+
     <detector id="BarrelDIRC_ID" name="cb_DIRC" type="epic_DIRC" readout="DIRCBarHits" vis="DIRCTube" region="DIRCRegion">
+      <type_flags type="DetType_TRACKER + DetType_CHERENKOV + DetType_BARREL"/>
       <dimensions rmin="DIRCBar_center - DIRCBar_height/2" rmax="DIRCBar_center + DIRCBar_height/2" length="DIRC_length"/>
       <position x="0" y="0" z="DIRC_offset"/>
+
+      <envelope vis="BarrelDIRC_envelope"
+        rmin="DIRC_rmin"
+        rmax="DIRC_rmax"
+        length="DIRC_length"
+        zstart="-DIRCBackward_zmax"
+      />
+
       <module name="DIRCBox" repeat="DIRCBox_count" width="DIRCPrism_width + 1*mm" height="DIRCPrism_height*2" length="DIRCBarAssm_length + 550*mm" vis="DIRCBox">
         <!-- Mirror (at the end of the module) -->
         <mirror
@@ -187,6 +203,10 @@
   </readouts>
 
   <plugins>
+    <plugin name="DD4hep_ParametersPlugin">
+      <argument value="cb_DIRC"/>
+      <argument value="layer_pattern: str=envelope"/>
+    </plugin>
   </plugins>
 
   <fields>

--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -202,13 +202,6 @@
     </readout>
   </readouts>
 
-  <plugins>
-    <plugin name="DD4hep_ParametersPlugin">
-      <argument value="cb_DIRC"/>
-      <argument value="layer_pattern: str=module\d"/>
-    </plugin>
-  </plugins>
-
   <fields>
   </fields>
 </lccdd>

--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -97,15 +97,8 @@
   </display>
 
   <detectors>
-    <detector id="DIRCSubAssembly_ID"
-      name="DIRCTrackerSubAssembly"
-      type="DD4hep_SubdetectorAssembly"
-      vis="TrackerSubAssemblyVis">
-      <composite name="cb_DIRC"/>
-    </detector>
-
     <detector id="BarrelDIRC_ID" name="cb_DIRC" type="epic_DIRC" readout="DIRCBarHits" vis="DIRCTube" region="DIRCRegion">
-      <type_flags type="DetType_TRACKER + DetType_CHERENKOV + DetType_BARREL"/>
+      <type_flags type="DetType_CHERENKOV + DetType_BARREL"/>
       <dimensions rmin="DIRCBar_center - DIRCBar_height/2" rmax="DIRCBar_center + DIRCBar_height/2" length="DIRC_length"/>
       <position x="0" y="0" z="DIRC_offset"/>
 

--- a/src/DIRC_geo.cpp
+++ b/src/DIRC_geo.cpp
@@ -94,14 +94,10 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens) {
       DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(det);
   if (xml_det.hasChild(_Unicode(envelope))) {
     xml_comp_t x_envelope = xml_det.child(_Unicode(envelope));
-    envelope_params.set<double>("envelope_r_min",
-                                getAttrOrDefault(x_envelope, _U(rmin), 0.));
-    envelope_params.set<double>("envelope_r_max",
-                                getAttrOrDefault(x_envelope, _U(rmax), 0.));
-    envelope_params.set<double>("envelope_z_min",
-                                getAttrOrDefault(x_envelope, _U(zmin), 0.));
-    envelope_params.set<double>("envelope_z_max",
-                                getAttrOrDefault(x_envelope, _U(zmax), 0.));
+    envelope_params.set<double>("envelope_r_min", getAttrOrDefault(x_envelope, _U(rmin), 0.));
+    envelope_params.set<double>("envelope_r_max", getAttrOrDefault(x_envelope, _U(rmax), 0.));
+    envelope_params.set<double>("envelope_z_min", getAttrOrDefault(x_envelope, _U(zmin), 0.));
+    envelope_params.set<double>("envelope_z_max", getAttrOrDefault(x_envelope, _U(zmax), 0.));
   }
   // Add the volume boundary material if configured
   for (xml_coll_t boundary_material(xml_det, _Unicode(boundary_material)); boundary_material;

--- a/src/DIRC_geo.cpp
+++ b/src/DIRC_geo.cpp
@@ -96,8 +96,16 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens) {
     xml_comp_t x_envelope = xml_det.child(_Unicode(envelope));
     envelope_params.set<double>("envelope_r_min", getAttrOrDefault(x_envelope, _U(rmin), 0.));
     envelope_params.set<double>("envelope_r_max", getAttrOrDefault(x_envelope, _U(rmax), 0.));
-    envelope_params.set<double>("envelope_z_min", getAttrOrDefault(x_envelope, _U(zmin), 0.));
-    envelope_params.set<double>("envelope_z_max", getAttrOrDefault(x_envelope, _U(zmax), 0.));
+    // Handle zstart+length format (convert to zmin/zmax)
+    if (x_envelope.hasAttr(_U(zstart)) && x_envelope.hasAttr(_U(length))) {
+      double zstart = x_envelope.attr<double>(_U(zstart));
+      double length = x_envelope.attr<double>(_U(length));
+      envelope_params.set<double>("envelope_z_min", zstart);
+      envelope_params.set<double>("envelope_z_max", zstart + length);
+    } else {
+      envelope_params.set<double>("envelope_z_min", getAttrOrDefault(x_envelope, _U(zmin), 0.));
+      envelope_params.set<double>("envelope_z_max", getAttrOrDefault(x_envelope, _U(zmax), 0.));
+    }
   }
   // Add the volume boundary material if configured
   for (xml_coll_t boundary_material(xml_det, _Unicode(boundary_material)); boundary_material;

--- a/src/DIRC_geo.cpp
+++ b/src/DIRC_geo.cpp
@@ -16,6 +16,7 @@
 
 using namespace std;
 using namespace dd4hep;
+using namespace dd4hep::rec;
 
 static dd4hep::Trap MakeTrap(const std::string& pName, double pZ, double pY, double pX,
                              double pLTX);

--- a/src/DIRC_geo.cpp
+++ b/src/DIRC_geo.cpp
@@ -189,6 +189,19 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens) {
   Box Envelope_box("Envelope_box", envbox_xsize, envbox_ysize, envbox_zsize);
   Volume Envelope_box_vol("Envelope_box_vol", Envelope_box, desc.material("AirOptical"));
   dirc_module.placeVolume(Envelope_box_vol, Position(0, 0, 0.5 * mirror_thickness));
+
+  //---- Define Acts measurement surface for entire bar assembly (one plane per module)
+  // This provides a continuous projection surface without gaps between bars
+  // Surface normal points radially outward (local x), u along bar length (z), v along bar width (y)
+  Vector3D u(0., 0., 1.);                // along bar length (z-axis)
+  Vector3D v(0., 1., 0.);                // along bar width (y-axis)
+  Vector3D n(1., 0., 0.);                // radially outward (x-axis)
+  double inner_thickness = envbox_xsize; // full depth of envelope
+  double outer_thickness = envbox_xsize;
+  SurfaceType type(
+      SurfaceType::Helper); // Helper surface for projection, not sensitive for tracking
+  VolPlane module_surf(Envelope_box_vol, type, inner_thickness, outer_thickness, u, v, n);
+
   printout(DEBUG, "DIRC_geo", "envbox_xsize    = %12.4f ", envbox_xsize);
   printout(DEBUG, "DIRC_geo", "envbox_ysize    = %12.4f ", envbox_ysize);
   printout(DEBUG, "DIRC_geo", "envbox_zsize    = %12.4f ", envbox_zsize);
@@ -373,7 +386,13 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens) {
     double x   = det_ravg * cos(phi);
     double y   = det_ravg * sin(phi);
     Transform3D tr(RotationZ(phi), Position(x, y, 0));
-    det_volume.placeVolume(dirc_module, tr).addPhysVolID("module", i);
+    PlacedVolume module_pv = det_volume.placeVolume(dirc_module, tr).addPhysVolID("module", i);
+
+    // Create DetElement for this module and attach single measurement surface
+    DetElement module_det(det, Form("module%d", i), i);
+    module_det.setPlacement(module_pv);
+    // Attach Acts measurement surface (one continuous plane per module, not per bar)
+    volSurfaceList(module_det)->push_back(module_surf);
   }
 
   //---- Construct Assembly dirc_support

--- a/src/DIRC_geo.cpp
+++ b/src/DIRC_geo.cpp
@@ -388,17 +388,37 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens) {
   Envelope_trap_vol.placeVolume(mcp_vol, Transform3D(mcp_rotation, mcp_position));
 
   //---- Place modules -----------------------------------------------
+  // Create a cylindrical layer volume (TGeoTubeSeg) wrapping all modules.
+  // Acts requires a Tube-shaped layer envelope for cylindrical layers.
+  // All 12 modules are placed inside this layer, which is then placed in det_volume.
   const int module_repeat = xml_module.repeat();
   const double dphi       = 2. * M_PI / module_repeat;
+
+  double layer_zsize = envbox_zsize + 0.5 * mirror_thickness; // half-length covering all bars
+  double layer_rmin  = det_rmin;
+  double layer_rmax  = det_rmax;
+  string layer_name  = det_name + "_layer0";
+  Tube layer_tube(layer_rmin, layer_rmax, layer_zsize);
+  Volume layer_vol(layer_name, layer_tube, desc.material("Air"));
+  layer_vol.setVisAttributes(desc.invisible());
+
+  // Place the cylindrical layer in the detector assembly and create its DetElement
+  // (must be done before module loop so module DetElements can be children of layer_det)
+  PlacedVolume layer_pv = det_volume.placeVolume(layer_vol);
+  layer_pv.addPhysVolID("layer", 0);
+  DetElement layer_det(det, layer_name, 0);
+  layer_det.setPlacement(layer_pv);
+  DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(layer_det);
+
   for (int i = 0; i < module_repeat; i++) {
     double phi = dphi * i;
     double x   = det_ravg * cos(phi);
     double y   = det_ravg * sin(phi);
     Transform3D tr(RotationZ(phi), Position(x, y, 0));
-    PlacedVolume module_pv = det_volume.placeVolume(dirc_module, tr).addPhysVolID("module", i);
+    PlacedVolume module_pv = layer_vol.placeVolume(dirc_module, tr).addPhysVolID("module", i);
 
-    // Create DetElement for this module and attach single measurement surface
-    DetElement module_det(det, Form("module%d", i), i);
+    // Create DetElement for this module (child of layer_det) and attach surface
+    DetElement module_det(layer_det, Form("module%d", i), i);
     module_det.setPlacement(module_pv);
     // Ensure VariantParameters extension exists for this module
     DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(module_det);

--- a/src/DIRC_geo.cpp
+++ b/src/DIRC_geo.cpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 - 2026 Wouter Deconinck, Dmitry Romanov, Bill Llope
 
+#include "DD4hepDetectorHelper.h"
 #include "DD4hep/DetFactoryHelper.h"
 #include "DD4hep/OpticalSurfaces.h"
 #include "DD4hep/Printout.h"
 #include "DDRec/DetectorData.h"
 #include "DDRec/Surface.h"
 #include <XML/Helper.h>
+#include <XML/Utilities.h>
 
 //////////////////////////////////
 // Central Barrel DIRC
@@ -77,6 +79,9 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens) {
   //---- Detector type
   sens.setType("tracker");
 
+  // Set detector type flag
+  dd4hep::xml::setDetectorTypeFlag(xml_det, det);
+
   //---- Entire DIRC assembly
   Assembly det_volume("DIRC");
   det_volume.setAttributes(desc, xml_det.regionStr(), xml_det.limitsStr(), xml_det.visStr());
@@ -84,8 +89,37 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens) {
   det.setPlacement(
       desc.pickMotherVolume(det).placeVolume(det_volume, det_tr).addPhysVolID("system", det_id));
 
+  // ACTS support
+  auto& envelope_params =
+      DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(det);
+  if (xml_det.hasChild(_Unicode(envelope))) {
+    xml_comp_t x_envelope = xml_det.child(_Unicode(envelope));
+    envelope_params.set<double>("envelope_r_min",
+                                getAttrOrDefault(x_envelope, _U(rmin), 0.));
+    envelope_params.set<double>("envelope_r_max",
+                                getAttrOrDefault(x_envelope, _U(rmax), 0.));
+    envelope_params.set<double>("envelope_z_min",
+                                getAttrOrDefault(x_envelope, _U(zmin), 0.));
+    envelope_params.set<double>("envelope_z_max",
+                                getAttrOrDefault(x_envelope, _U(zmax), 0.));
+  }
+  // Add the volume boundary material if configured
+  for (xml_coll_t boundary_material(xml_det, _Unicode(boundary_material)); boundary_material;
+       ++boundary_material) {
+    xml_comp_t x_boundary_material = boundary_material;
+    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(x_boundary_material, envelope_params,
+                                                    "boundary_material");
+  }
+  // Add the volume layer material if configured
+  for (xml_coll_t layer_material(xml_det, _Unicode(layer_material)); layer_material;
+       ++layer_material) {
+    xml_comp_t x_layer_material = layer_material;
+    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(x_layer_material, envelope_params,
+                                                    "layer_material");
+  }
+
   //---- Assembly dirc_module holds all the hpDIRC
-  //
+  // Construct module
   xml_comp_t xml_module = xml_det.child(_U(module));
   Assembly dirc_module("DIRCModule");
   dirc_module.setVisAttributes(desc.visAttributes(xml_module.visStr()));

--- a/src/DIRC_geo.cpp
+++ b/src/DIRC_geo.cpp
@@ -400,6 +400,8 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens) {
     // Create DetElement for this module and attach single measurement surface
     DetElement module_det(det, Form("module%d", i), i);
     module_det.setPlacement(module_pv);
+    // Ensure VariantParameters extension exists for this module
+    DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(module_det);
     // Attach Acts measurement surface (one continuous plane per module, not per bar)
     volSurfaceList(module_det)->push_back(module_surf);
   }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The DIRC group needs track projections to the DIRC, a way to assess the quality of these track projections, and truth information to generate lookup tables.

This PR adds Acts support to the DIRC. This will ensure consistency between truth and reconstruction surfaces, and the material budgets around the DIRC (inner/outer). The sim hits on the DIRC will be generated for non-optical photons only, and will not be used in the track reconstruction (naturally).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: DIRC needs the track position at the quartz bars)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.