### PR TITLE
Fixes for stuck particles

### DIFF
--- a/compact/far_backward/beamline_extension_hadron.xml
+++ b/compact/far_backward/beamline_extension_hadron.xml
@@ -58,8 +58,8 @@
     type="BeamPipeChain"
     wall_thickness="2*mm">
       <pipe id="0" name="Pipe_to_Q1APR"
-        xcenter="(Hadron_Beampipe_End*sin(CrossingAngle) + Q1APR_StartX)/2." zcenter="(Hadron_Beampipe_End + Q1APR_StartZ)/2."
-        length="(Hadron_Beampipe_End - Q1APR_StartZ)/cos(CrossingAngle)" theta="CrossingAngle"
+        xcenter="(Hadron_Beampipe_End*sin(CrossingAngle)+Q1APR_StartX)/2." zcenter="(Hadron_Beampipe_End*cos(CrossingAngle) + Q1APR_StartZ)/2."
+        length="sqrt((Hadron_Beampipe_End*sin(CrossingAngle) - Q1APR_StartX)^2 + (Hadron_Beampipe_End*cos(CrossingAngle) - Q1APR_StartZ)^2)" theta="CrossingAngle"
         rout1="Hadron_Beampipe_Rad" rout2="Hadron_Beampipe_Rad">
       </pipe>
       <pipe id="1" name="Pipe_in_Q1APR"

--- a/src/BeamPipeChain_geo.cpp
+++ b/src/BeamPipeChain_geo.cpp
@@ -97,9 +97,6 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
   for (uint i = 1; i < thetas.size(); i++) {
 
 
-    std::cout << "Pipe " << i<< ": " << names[i] << std::endl;
-    std::cout << "theta: " << thetas[i-1] << std::endl;
-    std::cout << "theta: " << thetas[i] << std::endl;
     // Start at the join between the first two pipes ending at the join between the last two pipes N-1
     double bendAngle  = thetas[i] - thetas[i - 1];
     if (std::abs(bendAngle) < 0.00001) {
@@ -108,8 +105,6 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
     {
       double bendLength = abs(rOuters1[i] * tan(bendAngle / 2));
       bendLengths.push_back(bendLength + bendRadius);
-      std::cout << "bendAngle: " << bendAngle << std::endl;
-      std::cout << "bendLength: " << bendLength << std::endl;
     }
   }
 

--- a/src/BeamPipeChain_geo.cpp
+++ b/src/BeamPipeChain_geo.cpp
@@ -84,6 +84,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
     double l      = sqrt(deltaX * deltaX + deltaZ * deltaZ);
     double theta  = atan2(deltaX, deltaZ);
 
+
     xCenters[pipeN] = x;
     zCenters[pipeN] = z;
     lengths[pipeN]  = l;
@@ -94,14 +95,21 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector /
 
   // If there is an bend in the pipe, calculate the length reduction of the pipe and joint length
   for (uint i = 1; i < thetas.size(); i++) {
+
+
+    std::cout << "Pipe " << i<< ": " << names[i] << std::endl;
+    std::cout << "theta: " << thetas[i-1] << std::endl;
+    std::cout << "theta: " << thetas[i] << std::endl;
     // Start at the join between the first two pipes ending at the join between the last two pipes N-1
-    if (thetas[i - 1] == thetas[i]) {
+    double bendAngle  = thetas[i] - thetas[i - 1];
+    if (std::abs(bendAngle) < 0.00001) {
       bendLengths.push_back(0);
     } else // Correct for tubes, not yet cones so imperfect
     {
-      double bendAngle  = thetas[i] - thetas[i - 1];
       double bendLength = abs(rOuters1[i] * tan(bendAngle / 2));
       bendLengths.push_back(bendLength + bendRadius);
+      std::cout << "bendAngle: " << bendAngle << std::endl;
+      std::cout << "bendLength: " << bendLength << std::endl;
     }
   }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Appears to fix #902.

Tiny torus segments were being created where the alignment of one tube didn't match the next due to floating point rounding errors. Below a limit of 0.01 mrad difference now is rounded down to 0.

Length of `Pipe_to_Q1APR` has also been fixed so it correctly joins with the central beampipe.

Most of this may be reworked again after #893 and #838

### What kind of change does this PR introduce?
- [x] Bug fix (issue #902 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
