### PR TITLE
fix: put BIC 1st layer in separate envelope for Acts conversion

### DIFF
--- a/.github/workflows/check-tracking-geometry.yml
+++ b/.github/workflows/check-tracking-geometry.yml
@@ -26,6 +26,7 @@ jobs:
         network_types: "none"
         setup: install/bin/thisepic.sh
         run: |
+          /usr/bin/time -v \
           root -b -q "scripts/test_ACTS.cxx+(\"${DETECTOR_PATH}/${{matrix.detector_config}}.xml\")" | tee check_tracking_geometry.out
           bin/acts_geo_check check_tracking_geometry.out
     - uses: actions/upload-artifact@v4

--- a/compact/ecal/bic/bic.xml
+++ b/compact/ecal/bic/bic.xml
@@ -410,7 +410,7 @@
   <plugins>
     <plugin name="DD4hep_ParametersPlugin">
       <argument value="EcalBarrelImaging"/>
-      <argument value="layer_pattern: str=envelope"/>
+      <argument value="layer_pattern: str=envelope1"/>
     </plugin>
   </plugins>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR moves the BIC 1st layer into a separate layer for Acts conversion purposes. With this modification, `/usr/bin/time -v root -b -q "scripts/test_ACTS.cxx+(\"${DETECTOR_PATH}/epic_craterlake.xml\")"` has a max RSS of 2.3 GB (down from 2.75 GB).

### What kind of change does this PR introduce?
- [x] Bug fix (issue #911)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.