### PR TITLE
Add another low-q2 reconstruction onnx to calibrations

### DIFF
--- a/compact/calibrations.xml
+++ b/compact/calibrations.xml
@@ -16,6 +16,11 @@
     </plugin>
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_PATH:/opt/detector"/>
+      <arg value="file:calibrations/onnx/Low-Q2_Steering_Reconstruction.onnx"/>
+      <arg value="url:https://github.com/eic/epic-data/blob/c9c83c1bcb65cf2fd9e97a0bf6499ef989df8d83/onnx/Low-Q2_Steering_Reconstruction.onnx"/>
+    </plugin>
+    <plugin name="epic_FileLoader">
+      <arg value="cache:$DETECTOR_PATH:/opt/detector"/>
       <arg value="file:calibrations/onnx/identity_gemm_w1x1_b1.onnx"/>
       <arg value="url:https://github.com/eic/epic-data/raw/27ef75b2b6108b5e72d3ab891f32aeeb3770c7bd/onnx/identity_gemm_w1x1_b1.onnx"/>
     </plugin>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Adds a third neural network to the calibrations which behaves the same as the previous onnx implementation but internalizes the projection of the vector onto a plane (dimension reduction). This has been trained using the benchmark script but needs to be added before the benchmark workflow can be properly implemented as a chicken and egg situation.

The other two implementations will be removed once this becomes the primary method used in reconstructing the lowQ2 electrons for ReconstructedParticles.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
Will download an additional file from epic-data when the geometry is loaded/