### PR TITLE
Fix new low q2 onnx blob to raw

### DIFF
--- a/compact/calibrations.xml
+++ b/compact/calibrations.xml
@@ -17,7 +17,7 @@
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_PATH:/opt/detector"/>
       <arg value="file:calibrations/onnx/Low-Q2_Steering_Reconstruction.onnx"/>
-      <arg value="url:https://github.com/eic/epic-data/blob/c9c83c1bcb65cf2fd9e97a0bf6499ef989df8d83/onnx/Low-Q2_Steering_Reconstruction.onnx"/>
+      <arg value="url:https://github.com/eic/epic-data/raw/c9c83c1bcb65cf2fd9e97a0bf6499ef989df8d83/onnx/Low-Q2_Steering_Reconstruction.onnx"/>
     </plugin>
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_PATH:/opt/detector"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The link to epic-data for the new low-q2 onnx file linked to the html site rather than the raw file

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
Downloads the raw onnx rather than html site...