### PR TITLE
Load Low-Q2_Steering_Reconstruction.onnx from xrootd server

### DIFF
--- a/compact/calibrations.xml
+++ b/compact/calibrations.xml
@@ -17,7 +17,7 @@
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_PATH:/opt/detector"/>
       <arg value="file:calibrations/onnx/Low-Q2_Steering_Reconstruction.onnx"/>
-      <arg value="url:https://github.com/eic/epic-data/raw/c9c83c1bcb65cf2fd9e97a0bf6499ef989df8d83/onnx/Low-Q2_Steering_Reconstruction.onnx"/>
+      <arg value="url:root://dtn-eic.jlab.org//volatile/eic/EPIC/xrdtest/CALIB/2025/5a202b05d865214e3c399883ee13859318044678f87d7b3d9fa8ff526b4909b6/Low-Q2_Steering_Reconstruction.onnx"/>
     </plugin>
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_PATH:/opt/detector"/>

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -22,7 +22,8 @@ using dd4hep::ERROR, dd4hep::WARNING, dd4hep::VERBOSE, dd4hep::INFO;
 using dd4hep::printout;
 
 namespace FileLoaderHelper {
-static constexpr const char* const kCurlCommand = "curl --retry 5 --location --fail {0} --output {1}";
+static constexpr const char* const kCurlCommand =
+    "curl --retry 5 --location --fail {0} --output {1}";
 static constexpr const char* const kXrootdCommand = "xrdcp --retry 5 {0} {1}";
 } // namespace FileLoaderHelper
 

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -22,7 +22,7 @@ using dd4hep::ERROR, dd4hep::WARNING, dd4hep::VERBOSE, dd4hep::INFO;
 using dd4hep::printout;
 
 namespace FileLoaderHelper {
-static constexpr const char* const kCommand = "curl --retry 5 --location --fail {0} --output {1}";
+static constexpr const char* const kCurlCommand = "curl --retry 5 --location --fail {0} --output {1}";
 static constexpr const char* const kXrootdCommand = "xrdcp --retry 5 {0} {1}";
 } // namespace FileLoaderHelper
 
@@ -137,7 +137,7 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
     if (url.find("root://") == 0) {
       cmd = fmt::format(FileLoaderHelper::kXrootdCommand, url, hash_path.c_str());
     } else {
-      cmd = fmt::format(FileLoaderHelper::kCommand, url, hash_path.c_str());
+      cmd = fmt::format(FileLoaderHelper::kCurlCommand, url, hash_path.c_str());
     }
     printout(INFO, "FileLoader", "downloading " + file + " as hash " + hash + " with " + cmd);
 

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -24,7 +24,7 @@ using dd4hep::printout;
 namespace FileLoaderHelper {
 static constexpr const char* const kCommand = "curl --retry 5 --location --fail {0} --output {1}";
 static constexpr const char* const kXrootdCommand = "xrdcp --retry 5 {0} {1}";
-}
+} // namespace FileLoaderHelper
 
 // Function to download files
 inline void EnsureFileFromURLExists(std::string url, std::string file, std::string cache_str = "") {
@@ -133,14 +133,14 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
   // if hash does not exist, we try to retrieve file from url
   if (!fs::exists(hash_path)) {
     std::string cmd;
-    
+
     if (url.find("root://") == 0) {
       cmd = fmt::format(FileLoaderHelper::kXrootdCommand, url, hash_path.c_str());
     } else {
       cmd = fmt::format(FileLoaderHelper::kCommand, url, hash_path.c_str());
     }
     printout(INFO, "FileLoader", "downloading " + file + " as hash " + hash + " with " + cmd);
-    
+
     // run cmd
     auto ret = std::system(cmd.c_str());
     if (!fs::exists(hash_path)) {

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -23,6 +23,7 @@ using dd4hep::printout;
 
 namespace FileLoaderHelper {
 static constexpr const char* const kCommand = "curl --retry 5 --location --fail {0} --output {1}";
+static constexpr const char* const kXrootdCommand = "xrdcp --retry 5 {0} {1}";
 }
 
 // Function to download files
@@ -131,9 +132,15 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
 
   // if hash does not exist, we try to retrieve file from url
   if (!fs::exists(hash_path)) {
-    std::string cmd =
-        fmt::format(FileLoaderHelper::kCommand, url, hash_path.c_str()); // TODO: Use c++20 std::fmt
+    std::string cmd;
+    
+    if (url.find("root://") == 0) {
+      cmd = fmt::format(FileLoaderHelper::kXrootdCommand, url, hash_path.c_str());
+    } else {
+      cmd = fmt::format(FileLoaderHelper::kCommand, url, hash_path.c_str());
+    }
     printout(INFO, "FileLoader", "downloading " + file + " as hash " + hash + " with " + cmd);
+    
     // run cmd
     auto ret = std::system(cmd.c_str());
     if (!fs::exists(hash_path)) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Allows the `epic_FileLoader` plugin to load files from `xrootd` servers. Using `Low-Q2_Steering_Reconstruction.onnx` as an example.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
Downloads Low-Q2_Steering_Reconstruction.onnx  from the jlab xrootd server rather than the epic-data github repository