### PR TITLE
fix: use correct git describe version tag match pattern

### DIFF
--- a/cmake/git_version.cmake
+++ b/cmake/git_version.cmake
@@ -7,7 +7,7 @@ macro(set_git_version VERSION)
   if(GIT_EXECUTABLE)
     # Generate a git-describe version string from Git repository tags
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --match "v*"
+      COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --match "*.*.*"
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
       OUTPUT_VARIABLE GIT_DESCRIBE_VERSION
       RESULT_VARIABLE GIT_DESCRIBE_ERROR_CODE


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Instead of  `v1.1.0-949-ge32c0d070-dirty` this should now give `25.08.0-0-g<hash>`.

### What kind of change does this PR introduce?
- [x] Bug fix (issue, ok not really a bug)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No. Hyrum's principle probably...

### Does this PR change default behavior?
No.