### PR TITLE
Add support materials to FTOF

### DIFF
--- a/compact/tracking/tof_endcap.xml
+++ b/compact/tracking/tof_endcap.xml
@@ -121,12 +121,12 @@
     <constant name="EndcapTOF_HybridTrace_thickness"  value="0.002500*cm"/>
     <constant name="EndcapTOF_HybridPCB_thickness"    value="0.1*cm"/>
     <constant name="EndcapTOF_CFSkin_thickness"       value="2*0.0075*cm"/>
-    <constant name="EndcapTOF_CFSupp_thickness"        value="0.4*cm"/>
+    <constant name="EndcapTOF_CFSupp_thickness"       value="1*cm"/>
+    <constant name="EndcapTOF_ModuleBoard_thickness"  value="0.4*cm"/>
     <constant name="EndcapTOF_CFoam_thickness"        value="2*0.29*cm"/>
     <constant name="EndcapTOF_CHoneycomb_thickness"   value="2*0.29*cm"/>
     <constant name="EndcapTOF_CoolingTube_thickness"  value="0.08*cm"/>
     <constant name="EndcapTOF_Coolant_thickness"      value="0.08*cm"/>
-    <constant name="EndcapTOF_Module_thickness"       value="EndcapTOF_Sensor_thickness+2*EndcapTOF_Hybrid_thickness+2*EndcapTOF_CFSkin_thickness+EndcapTOF_CFoam_thickness+EndcapTOF_CoolingTube_thickness+EndcapTOF_Coolant_thickness"/>
 
     <constant name="EndcapTOF_zOffset"                 value="0*cm"/>
     <constant name="EndcapTOF_yOffset"                 value="0.5*cm"/>
@@ -209,6 +209,9 @@
       reflect="false">
       <type_flags type="DetType_TRACKER + DetType_ENDCAP"/>
       <position x="0*cm" y="0*cm" z="ForwardTOF_zmin" />
+      <module name="Support" vis="TOFEndcapModuleVis">
+	      <module_component name="Support" cylindrical="true" material="Carbon" rmin="ForwardTOFLayer_rmin" rmax="ForwardTOFLayer_rmax" thickness="EndcapTOF_CFSupp_thickness" vis="AnlGray"/>
+      </module>
       <module name="FrontRight" vis="TOFEndcapModuleVis">
         <module_component name="hybridkaptontop" material="Kapton" sensitive="false" width="EndcapTOF_Module_width" length="EndcapTOF_Module_length" thickness="EndcapTOF_Hybrid_thickness" vis="TOFHybridVis" >
           <position x="EndcapTOF_Service_position" y="0" z="0" />
@@ -234,7 +237,7 @@
         <module_component name="sensor4" material="Silicon" sensitive="true" width="EndcapTOF_Sensor_width" length="EndcapTOF_Sensor_length" thickness="EndcapTOF_Sensor_thickness" vis="TOFSensorVis" >
           <position x="EndcapTOF_Up_Sensor_position + EndcapTOF_Sensor_width + EndcapTOF_Sensor_gap " y="-0.5*(EndcapTOF_Sensor_length + EndcapTOF_Sensor_gap)" z="0" />
         </module_component>
-        <module_component name="carbonsupport" material="CarbonFiber" sensitive="false" width="EndcapTOF_Module_width" length="EndcapTOF_Module_length" thickness="EndcapTOF_CFSupp_thickness" vis="AnlGray" >
+        <module_component name="moduleBoard" material="Fr4" sensitive="false" width="EndcapTOF_Module_width" length="EndcapTOF_Module_length" thickness="EndcapTOF_ModuleBoard_thickness" vis="AnlGray" >
           <position x="EndcapTOF_Support_position" y="0" z="0" />
         </module_component>
       </module>
@@ -265,13 +268,13 @@
           <position x="EndcapTOF_Down_Sensor_position - EndcapTOF_Sensor_width - EndcapTOF_Sensor_gap " y="-0.5*(EndcapTOF_Sensor_length + EndcapTOF_Sensor_gap)" z="0" />
         </module_component>
 
-        <module_component name="carbonsupport" material="CarbonFiber" sensitive="false" width="EndcapTOF_Module_width" length="EndcapTOF_Module_length" thickness="EndcapTOF_CFSupp_thickness" vis="AnlGray" >
+        <module_component name="moduleBoard" material="Fr4" sensitive="false" width="EndcapTOF_Module_width" length="EndcapTOF_Module_length" thickness="EndcapTOF_ModuleBoard_thickness" vis="AnlGray" >
           <position x="EndcapTOF_Support_position" y="0" z="0" />
         </module_component>
       </module>
 
       <module name="BackRight" vis="TOFEndcapModuleVis">
-        <module_component name="carbonsupport" material="CarbonFiber" sensitive="false" width="EndcapTOF_Module_width" length="EndcapTOF_Module_length" thickness="EndcapTOF_CFSupp_thickness" vis="AnlGray" >
+        <module_component name="moduleBoard" material="Fr4" sensitive="false" width="EndcapTOF_Module_width" length="EndcapTOF_Module_length" thickness="EndcapTOF_ModuleBoard_thickness" vis="AnlGray" >
           <position x="EndcapTOF_Support_position" y="0" z="0" />
         </module_component>
         <module_component name="sensor1" material="Silicon" sensitive="true" width="EndcapTOF_Sensor_width" length="EndcapTOF_Sensor_length" thickness="EndcapTOF_Sensor_thickness" vis="TOFSensorVis"  keep_layer="true">
@@ -301,7 +304,7 @@
       </module>
 
       <module name="BackLeft" vis="TOFEndcapModuleVis">
-        <module_component name="carbonsupport" material="CarbonFiber" sensitive="false" width="EndcapTOF_Module_width" length="EndcapTOF_Module_length" thickness="EndcapTOF_CFSupp_thickness" vis="AnlGray" >
+        <module_component name="moduleBoard" material="Fr4" sensitive="false" width="EndcapTOF_Module_width" length="EndcapTOF_Module_length" thickness="EndcapTOF_ModuleBoard_thickness" vis="AnlGray" >
           <position x="EndcapTOF_Support_position" y="0" z="0" />
         </module_component>
         <module_component name="sensor1" material="Silicon" sensitive="true" width="EndcapTOF_Sensor_width" length="EndcapTOF_Sensor_length" thickness="EndcapTOF_Sensor_thickness" vis="TOFSensorVis"  keep_layer="true">
@@ -335,7 +338,7 @@
       <envelope vis="TOF_envelope"
         rmin="ForwardTOFLayer_rmin"
         rmax="ForwardTOFLayer_rmax"
-        zstart="ForwardTOF_zmin - EndcapTOF_CFSupp_thickness"
+        zstart="ForwardTOF_zmin"
         xoffset="-EndcapTOF_Board_spacing/2"
       />
 
@@ -485,11 +488,28 @@
         </layout>
       </layer>
 
+      <layer id="3" front="true" name="Support">
+
+      <envelope vis="TOF_envelope"
+        rmin="ForwardTOFLayer_rmin"
+        rmax="ForwardTOFLayer_rmax"
+	zstack="true"
+        xoffset="0"
+      />
+        <layout left="true" module="Support">
+		<row deadspace="ForwardTOFLayer_rmax - EndcapTOF_Module_width/2"/>
+		<row x_offset="(-EndcapTOF_Module_length)/2" nsensors="1">
+                  <board nsensors="1"/>
+                </row>
+	</layout>
+      </layer>
+
+
       <layer id="2" front="false" name="Back">
       <envelope vis="TOF_envelope"
         rmin="ForwardTOFLayer_rmin"
         rmax="ForwardTOFLayer_rmax"
-        zstart="ForwardTOF_zmin + EndcapTOF_CFSupp_thickness"
+	zstack="true"
         xoffset="-EndcapTOF_Board_spacing/2"
       />
 

--- a/compact/tracking/tof_endcap.xml
+++ b/compact/tracking/tof_endcap.xml
@@ -210,7 +210,7 @@
       <type_flags type="DetType_TRACKER + DetType_ENDCAP"/>
       <position x="0*cm" y="0*cm" z="ForwardTOF_zmin" />
       <module name="Support" vis="TOFEndcapModuleVis">
-	      <module_component name="Support" cylindrical="true" material="CarbonFoam" rmin="ForwardTOFLayer_rmin" rmax="ForwardTOFLayer_rmax" thickness="EndcapTOF_CFSupp_thickness" vis="AnlGray"/>
+              <module_component name="Support" cylindrical="true" material="CarbonFoam" rmin="ForwardTOFLayer_rmin" rmax="ForwardTOFLayer_rmax" thickness="EndcapTOF_CFSupp_thickness" vis="AnlGray"/>
       </module>
       <module name="FrontRight" vis="TOFEndcapModuleVis">
         <module_component name="hybridkaptontop" material="Kapton" sensitive="false" width="EndcapTOF_Module_width" length="EndcapTOF_Module_length" thickness="EndcapTOF_Hybrid_thickness" vis="TOFHybridVis" >
@@ -493,15 +493,15 @@
       <envelope vis="TOF_envelope"
         rmin="ForwardTOFLayer_rmin"
         rmax="ForwardTOFLayer_rmax"
-	zstack="true"
+        zstack="true"
         xoffset="0"
       />
         <layout left="true" module="Support">
-		<row deadspace="ForwardTOFLayer_rmax - EndcapTOF_Module_width/2"/>
-		<row x_offset="(-EndcapTOF_Module_length)/2" nsensors="1">
+                <row deadspace="ForwardTOFLayer_rmax - EndcapTOF_Module_width/2"/>
+                <row x_offset="(-EndcapTOF_Module_length)/2" nsensors="1">
                   <board nsensors="1"/>
                 </row>
-	</layout>
+        </layout>
       </layer>
 
 
@@ -509,7 +509,7 @@
       <envelope vis="TOF_envelope"
         rmin="ForwardTOFLayer_rmin"
         rmax="ForwardTOFLayer_rmax"
-	zstack="true"
+        zstack="true"
         xoffset="-EndcapTOF_Board_spacing/2"
       />
 

--- a/compact/tracking/tof_endcap.xml
+++ b/compact/tracking/tof_endcap.xml
@@ -210,7 +210,7 @@
       <type_flags type="DetType_TRACKER + DetType_ENDCAP"/>
       <position x="0*cm" y="0*cm" z="ForwardTOF_zmin" />
       <module name="Support" vis="TOFEndcapModuleVis">
-	      <module_component name="Support" cylindrical="true" material="Carbon" rmin="ForwardTOFLayer_rmin" rmax="ForwardTOFLayer_rmax" thickness="EndcapTOF_CFSupp_thickness" vis="AnlGray"/>
+	      <module_component name="Support" cylindrical="true" material="CarbonFoam" rmin="ForwardTOFLayer_rmin" rmax="ForwardTOFLayer_rmax" thickness="EndcapTOF_CFSupp_thickness" vis="AnlGray"/>
       </module>
       <module name="FrontRight" vis="TOFEndcapModuleVis">
         <module_component name="hybridkaptontop" material="Kapton" sensitive="false" width="EndcapTOF_Module_width" length="EndcapTOF_Module_length" thickness="EndcapTOF_Hybrid_thickness" vis="TOFHybridVis" >

--- a/src/EndcapTOF_geo.cpp
+++ b/src/EndcapTOF_geo.cpp
@@ -93,9 +93,9 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       bool cylindrical   = getAttrOrDefault<bool>(x_comp, _Unicode(cylindrical), false);
 
       Volume c_vol;
-      if(cylindrical) {
-        Tube c_tub(x_comp.rmin(), x_comp.rmax(), x_comp.thickness() / 2.0, 0, 2*M_PI);
-        c_vol = Volume(c_nam, c_tub, description.material(x_comp.materialStr())); 
+      if (cylindrical) {
+        Tube c_tub(x_comp.rmin(), x_comp.rmax(), x_comp.thickness() / 2.0, 0, 2 * M_PI);
+        c_vol = Volume(c_nam, c_tub, description.material(x_comp.materialStr()));
       } else {
         Box c_box(x_comp.width() / 2, x_comp.length() / 2, x_comp.thickness() / 2);
         c_vol = Volume(c_nam, c_box, description.material(x_comp.materialStr()));
@@ -156,7 +156,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
     modules[m_nam] = m_vol;
   }
 
-  int module = 0;
+  int module       = 0;
   double current_z = std::numeric_limits<double>::lowest();
   for (xml_coll_t li(x_det, _U(layer)); li; ++li) {
     xml_comp_t x_layer = li;
@@ -181,17 +181,20 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       envelope_length     = std::max(envelope_length, mod_thickness[m_nam]);
     }
 
-    double zstart = 0;  
-    if(zstack) {
-      if(current_z == std::numeric_limits<double>::lowest()) 
-        throw std::runtime_error("You cannot enable stack on the first layer. You need to place the first layer with 'zstart', then you can stack the next layer.");
+    double zstart = 0;
+    if (zstack) {
+      if (current_z == std::numeric_limits<double>::lowest())
+        throw std::runtime_error(
+            "You cannot enable stack on the first layer. You need to place the first layer with "
+            "'zstart', then you can stack the next layer.");
       else
         zstart = current_z;
-    } else zstart = envelope.zstart();
+    } else
+      zstart = envelope.zstart();
 
     Tube lay_tub(envelope.rmin(), envelope.rmax(), envelope_length / 2.0, phimin, phimax);
     Volume lay_vol(lay_nam, lay_tub, air); // Create the layer envelope volume.
-    Position lay_pos(xoffset, 0, zstart + 0.5*envelope_length);
+    Position lay_pos(xoffset, 0, zstart + 0.5 * envelope_length);
     current_z = zstart + envelope_length;
     lay_vol.setVisAttributes(description.visAttributes(x_layer.visStr()));
 

--- a/src/EndcapTOF_geo.cpp
+++ b/src/EndcapTOF_geo.cpp
@@ -90,9 +90,16 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       xml_comp_t x_pos   = x_comp.position(false);
       xml_comp_t x_rot   = x_comp.rotation(false);
       const string c_nam = x_comp.nameStr();
+      bool cylindrical   = getAttrOrDefault<bool>(x_comp, _Unicode(cylindrical), false);
 
-      Box c_box(x_comp.width() / 2, x_comp.length() / 2, x_comp.thickness() / 2);
-      Volume c_vol(c_nam, c_box, description.material(x_comp.materialStr()));
+      Volume c_vol;
+      if(cylindrical) {
+        Tube c_tub(x_comp.rmin(), x_comp.rmax(), x_comp.thickness() / 2.0, 0, 2*M_PI);
+        c_vol = Volume(c_nam, c_tub, description.material(x_comp.materialStr())); 
+      } else {
+        Box c_box(x_comp.width() / 2, x_comp.length() / 2, x_comp.thickness() / 2);
+        c_vol = Volume(c_nam, c_box, description.material(x_comp.materialStr()));
+      }
       // Utility variable for the relative z-offset based off the previous components
       const double zoff = thickness_so_far + x_comp.thickness() / 2.0;
       if (x_pos && x_rot) {
@@ -150,6 +157,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   }
 
   int module = 0;
+  double current_z = std::numeric_limits<double>::lowest();
   for (xml_coll_t li(x_det, _U(layer)); li; ++li) {
     xml_comp_t x_layer = li;
     bool front         = x_layer.attr<bool>(_Unicode(front));
@@ -163,6 +171,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
     double phimin       = dd4hep::getAttrOrDefault<double>(envelope, _Unicode(phimin), 0.);
     double phimax       = dd4hep::getAttrOrDefault<double>(envelope, _Unicode(phimax), 2 * M_PI);
     double xoffset      = getAttrOrDefault<double>(envelope, _Unicode(xoffset), 0);
+    bool zstack         = getAttrOrDefault<bool>(envelope, _Unicode(zstack), false);
 
     // envelope thickness is the max layer thickness to accomodate all layers
     double envelope_length = 0;
@@ -172,10 +181,18 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       envelope_length     = std::max(envelope_length, mod_thickness[m_nam]);
     }
 
+    double zstart = 0;  
+    if(zstack) {
+      if(current_z == std::numeric_limits<double>::lowest()) 
+        throw std::runtime_error("You cannot enable stack on the first layer. You need to place the first layer with 'zstart', then you can stack the next layer.");
+      else
+        zstart = current_z;
+    } else zstart = envelope.zstart();
+
     Tube lay_tub(envelope.rmin(), envelope.rmax(), envelope_length / 2.0, phimin, phimax);
     Volume lay_vol(lay_nam, lay_tub, air); // Create the layer envelope volume.
-    Position lay_pos(xoffset, 0,
-                     envelope.zstart() + (front ? -0.5 * envelope_length : 0.5 * envelope_length));
+    Position lay_pos(xoffset, 0, zstart + 0.5*envelope_length);
+    current_z = zstart + envelope_length;
     lay_vol.setVisAttributes(description.visAttributes(x_layer.visStr()));
 
     DetElement lay_elt(sdet, lay_nam, lay_id);


### PR DESCRIPTION
### Briefly, what does this PR introduce?

There is currently nothing between the front and back layers of FTOF. However, dRICH group wants to study the effect of FTOF material and having the right material is important for their study. 

A uniform slab of carbon foam of width 1 cm is now sandwiched between the two layers. Details such as cooling tubes will be added later. The width of the support structure is given by slide 6 of https://indico.bnl.gov/event/24949/attachments/57520/98759/ePICTOF_WP2_FTOFLayout_09272024v2.pdf

The thickness of the module board and PCB are not final and will be changed in the future. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No

### Does this PR change default behavior?

No