### PR TITLE
ci: Add reviewers to GitHub Actions Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    reviewers:
+      - "eic/epic-detector-geometry-review"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds @eic/epic-detector-geometry-review as reviewer to dependabot updates.