### PR TITLE
feat: convert FieldMapB to using covfie

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -62,7 +62,7 @@ jobs:
           # Used for material map generation
           - CC: gcc
             CXX: g++
-            release: 25.07.0-stable
+            release: 25.09.0-stable
     env:
       PREFIX: ${{ github.workspace }}/install
     steps:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -556,7 +556,7 @@ jobs:
         platform-release: "eic_xl:nightly"
         setup: install/bin/thisepic.sh
         run: |
-          npsim --compactFile ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -G --random.seed 1 --gun.particle "${{ matrix.particle }}-" --gun.momentumMin "1*GeV" --gun.momentumMax "20*GeV" --gun.distribution "uniform" -N 100 --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -v WARNING
+          npsim --compactFile ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -G --random.seed 1 --random.enableEventSeed --gun.particle "${{ matrix.particle }}-" --gun.momentumMin "1*GeV" --gun.momentumMax "20*GeV" --gun.distribution "uniform" -N 100 --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -v WARNING
     - uses: actions/upload-artifact@v7
       with:
         name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
@@ -616,7 +616,7 @@ jobs:
         run: |
           url=root://dtn-eic.jlab.org//volatile/eic/EPIC/EVGEN/DIS/NC/${{matrix.beam}}/minQ2=${{matrix.minq2}}/pythia8NCDIS_${{matrix.beam}}_minQ2=${{matrix.minq2}}_beamEffects_xAngle=-0.025_hiDiv_1.hepmc3.tree.root
           gprofng collect app -o sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.er \
-          npsim --compactFile ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -N 100 --inputFiles ${url} --random.seed 1 --outputFile sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -v WARNING
+          npsim --compactFile ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -N 100 --inputFiles ${url} --random.seed 1 --random.enableEventSeed --outputFile sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root -v WARNING
           gprofng display text -ctree sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.er > sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.ctree.txt
     - name: Upload ROOT output
       uses: actions/upload-artifact@v7

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -62,7 +62,7 @@ jobs:
           # Used for material map generation
           - CC: gcc
             CXX: g++
-            release: 25.09.0-stable
+            release: 26.01.0-stable
     env:
       PREFIX: ${{ github.workspace }}/install
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ include(GNUInstallDirs)
 find_package(DD4hep 1.27 REQUIRED COMPONENTS DDCore DDRec)
 find_package(fmt REQUIRED)
 find_package(covfie REQUIRED)
+find_package(Boost COMPONENTS program_options)
 find_package(IRT2 2.1.1)
 
 #-----------------------------------------------------------------------------------
@@ -72,6 +73,16 @@ endif()
 if(IRT2_FOUND)
     target_compile_definitions(${a_lib_name} PRIVATE WITH_IRT2_SUPPORT)
     target_link_libraries(${a_lib_name} PRIVATE IRT2)
+endif()
+
+#-----------------------------------------------------------------------------------
+# Field map converter tool (requires boost::program_options)
+if(Boost_program_options_FOUND)
+  add_executable(convert_fieldmap_to_covfie scripts/convert_fieldmap_to_covfie.cpp)
+  target_link_libraries(convert_fieldmap_to_covfie
+    PRIVATE covfie::core Boost::program_options
+    )
+  install(TARGETS convert_fieldmap_to_covfie DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 #-----------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ include(GNUInstallDirs)
 # Dependencies
 find_package(DD4hep 1.27 REQUIRED COMPONENTS DDCore DDRec)
 find_package(fmt REQUIRED)
+find_package(covfie REQUIRED)
 find_package(IRT2 2.1.1)
 
 #-----------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ dd4hep_add_plugin(${a_lib_name}
   )
 target_link_libraries(${a_lib_name}
   PUBLIC DD4hep::DDCore DD4hep::DDRec fmt::fmt
+  PRIVATE covfie::core
   )
 set(WITH_IRT1_SUPPORT TRUE CACHE STRING "Enable constant definitions used by EICrecon integration in IRT1")
 if(WITH_IRT1_SUPPORT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ include(GNUInstallDirs)
 # Dependencies
 find_package(DD4hep 1.27 REQUIRED COMPONENTS DDCore DDRec)
 find_package(fmt REQUIRED)
-find_package(covfie REQUIRED)
+find_package(covfie 0.15 REQUIRED)
 find_package(Boost COMPONENTS program_options)
 find_package(IRT2 2.1.1)
 

--- a/compact/far_backward/lumi/lumi_magnets.xml
+++ b/compact/far_backward/lumi/lumi_magnets.xml
@@ -98,27 +98,21 @@ Construct the sweeper and analyzer dipole magnets for the luminosity subsystem.
 
     <comment> Calculated fields </comment>
     <field type="epic_FieldMapB" name="LumiSweeperField" field_type="magnetic" coord_type="BxByBz"
-           field_map="fieldmaps/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.txt"
-           url="https://github.com/eic/epic-data/raw/5a6bc4cd583fb3330bce475cf25b599661b902ee/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.txt"
+           field_map="fieldmaps/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
+           url="https://github.com/eic/epic-data/raw/5a853e4e19f2072db725f1c96a97b2f7198c6a4b/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
            cache="$DETECTOR_PATH:/opt/detector"
            scale="1.0">
       <dimensions>
-        <X step="0.5*cm" min="-7.5*cm" max="7.5*cm" />
-        <Y step="2.0*cm" min="-34*cm" max="34*cm" />
-        <Z step="2.0*cm" min="-80*cm" max="80*cm" />
         <translationCoord x="LumiSweepMag_X" y="LumiSweepMag_Y" z="LumiSweepMag_Z" />
       </dimensions>
     </field>
 
     <field type="epic_FieldMapB" name="LumiAnalyzerField" field_type="magnetic" coord_type="BxByBz"
-           field_map="fieldmaps/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.txt"
-           url="https://github.com/eic/epic-data/raw/5a6bc4cd583fb3330bce475cf25b599661b902ee/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.txt"
+           field_map="fieldmaps/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
+           url="https://github.com/eic/epic-data/raw/054b191ca5de53b103d89ef20f770d0b7d5946d4/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
            cache="$DETECTOR_PATH:/opt/detector"
            scale="1.0">
       <dimensions>
-        <X step="0.5*cm" min="-7.5*cm" max="7.5*cm" />
-        <Y step="2.0*cm" min="-34*cm" max="34*cm" />
-        <Z step="2.0*cm" min="-80*cm" max="80*cm" />
         <translationCoord x="LumiAnalyzerMag_X" y="LumiAnalyzerMag_Y" z="LumiAnalyzerMag_Z" />
       </dimensions>
     </field>

--- a/compact/far_backward/lumi/lumi_magnets.xml
+++ b/compact/far_backward/lumi/lumi_magnets.xml
@@ -99,7 +99,7 @@ Construct the sweeper and analyzer dipole magnets for the luminosity subsystem.
     <comment> Calculated fields </comment>
     <field type="epic_FieldMapB" name="LumiSweeperField" field_type="magnetic" coord_type="BxByBz"
            field_map="fieldmaps/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
-           url="https://github.com/eic/epic-data/raw/5a853e4e19f2072db725f1c96a97b2f7198c6a4b/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
+           url="https://github.com/eic/epic-data/raw/4d6becf98579fbcee8812407e3198d337ea241f2/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
            cache="$DETECTOR_CACHE:/opt/detector"
            scale="1.0">
       <dimensions>
@@ -109,7 +109,7 @@ Construct the sweeper and analyzer dipole magnets for the luminosity subsystem.
 
     <field type="epic_FieldMapB" name="LumiAnalyzerField" field_type="magnetic" coord_type="BxByBz"
            field_map="fieldmaps/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
-           url="https://github.com/eic/epic-data/raw/054b191ca5de53b103d89ef20f770d0b7d5946d4/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
+           url="https://github.com/eic/epic-data/raw/4d6becf98579fbcee8812407e3198d337ea241f2/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
            cache="$DETECTOR_CACHE:/opt/detector"
            scale="1.0">
       <dimensions>

--- a/compact/far_backward/lumi/lumi_magnets.xml
+++ b/compact/far_backward/lumi/lumi_magnets.xml
@@ -98,27 +98,21 @@ Construct the sweeper and analyzer dipole magnets for the luminosity subsystem.
 
     <comment> Calculated fields </comment>
     <field type="epic_FieldMapB" name="LumiSweeperField" field_type="magnetic" coord_type="BxByBz"
-           field_map="fieldmaps/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.txt"
-           url="https://github.com/eic/epic-data/raw/5a6bc4cd583fb3330bce475cf25b599661b902ee/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.txt"
+           field_map="fieldmaps/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
+           url="https://github.com/eic/epic-data/raw/5a853e4e19f2072db725f1c96a97b2f7198c6a4b/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
            cache="$DETECTOR_CACHE:/opt/detector"
            scale="1.0">
       <dimensions>
-        <X step="0.5*cm" min="-7.5*cm" max="7.5*cm" />
-        <Y step="2.0*cm" min="-34*cm" max="34*cm" />
-        <Z step="2.0*cm" min="-80*cm" max="80*cm" />
         <translationCoord x="LumiSweepMag_X" y="LumiSweepMag_Y" z="LumiSweepMag_Z" />
       </dimensions>
     </field>
 
     <field type="epic_FieldMapB" name="LumiAnalyzerField" field_type="magnetic" coord_type="BxByBz"
-           field_map="fieldmaps/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.txt"
-           url="https://github.com/eic/epic-data/raw/5a6bc4cd583fb3330bce475cf25b599661b902ee/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.txt"
+           field_map="fieldmaps/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
+           url="https://github.com/eic/epic-data/raw/054b191ca5de53b103d89ef20f770d0b7d5946d4/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
            cache="$DETECTOR_CACHE:/opt/detector"
            scale="1.0">
       <dimensions>
-        <X step="0.5*cm" min="-7.5*cm" max="7.5*cm" />
-        <Y step="2.0*cm" min="-34*cm" max="34*cm" />
-        <Z step="2.0*cm" min="-80*cm" max="80*cm" />
         <translationCoord x="LumiAnalyzerMag_X" y="LumiAnalyzerMag_Y" z="LumiAnalyzerMag_Z" />
       </dimensions>
     </field>

--- a/compact/far_backward/lumi/lumi_magnets.xml
+++ b/compact/far_backward/lumi/lumi_magnets.xml
@@ -99,7 +99,7 @@ Construct the sweeper and analyzer dipole magnets for the luminosity subsystem.
     <comment> Calculated fields </comment>
     <field type="epic_FieldMapB" name="LumiSweeperField" field_type="magnetic" coord_type="BxByBz"
            field_map="fieldmaps/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
-           url="https://github.com/eic/epic-data/raw/5a853e4e19f2072db725f1c96a97b2f7198c6a4b/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
+           url="https://github.com/eic/epic-data/raw/4d6becf98579fbcee8812407e3198d337ea241f2/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
            cache="$DETECTOR_PATH:/opt/detector"
            scale="1.0">
       <dimensions>
@@ -109,7 +109,7 @@ Construct the sweeper and analyzer dipole magnets for the luminosity subsystem.
 
     <field type="epic_FieldMapB" name="LumiAnalyzerField" field_type="magnetic" coord_type="BxByBz"
            field_map="fieldmaps/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
-           url="https://github.com/eic/epic-data/raw/054b191ca5de53b103d89ef20f770d0b7d5946d4/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
+           url="https://github.com/eic/epic-data/raw/4d6becf98579fbcee8812407e3198d337ea241f2/LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie"
            cache="$DETECTOR_PATH:/opt/detector"
            scale="1.0">
       <dimensions>

--- a/compact/fields/marco.xml
+++ b/compact/fields/marco.xml
@@ -4,14 +4,10 @@
 <lccdd>
   <fields>
     <field type="epic_FieldMapB" name="GlobalSolenoid" field_type="magnetic" coord_type="BrBz"
-           field_map="fieldmaps/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.txt"
-           url="https://github.com/eic/epic-data/raw/81182bfe32e62db3e3e2014e27decbb1f47f7a6a/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.txt"
+           field_map="fieldmaps/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.covfie"
+           url="https://github.com/eic/epic-data/raw/5a853e4e19f2072db725f1c96a97b2f7198c6a4b/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.covfie"
            cache="$DETECTOR_PATH:/opt/detector"
            scale="1.0">
-      <dimensions>
-        <R step="2.0*cm" min="0*cm" max="998*cm" />
-        <Z step="2.0*cm" min="-800*cm" max="798*cm" />
-      </dimensions>
     </field>
   </fields>
 </lccdd>

--- a/compact/fields/marco.xml
+++ b/compact/fields/marco.xml
@@ -5,7 +5,7 @@
   <fields>
     <field type="epic_FieldMapB" name="GlobalSolenoid" field_type="magnetic" coord_type="BrBz"
            field_map="fieldmaps/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.covfie"
-           url="https://github.com/eic/epic-data/raw/5a853e4e19f2072db725f1c96a97b2f7198c6a4b/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.covfie"
+           url="https://github.com/eic/epic-data/raw/4d6becf98579fbcee8812407e3198d337ea241f2/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.covfie"
            cache="$DETECTOR_CACHE:/opt/detector"
            scale="1.0">
     </field>

--- a/compact/fields/marco.xml
+++ b/compact/fields/marco.xml
@@ -4,14 +4,10 @@
 <lccdd>
   <fields>
     <field type="epic_FieldMapB" name="GlobalSolenoid" field_type="magnetic" coord_type="BrBz"
-           field_map="fieldmaps/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.txt"
-           url="https://github.com/eic/epic-data/raw/81182bfe32e62db3e3e2014e27decbb1f47f7a6a/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.txt"
+           field_map="fieldmaps/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.covfie"
+           url="https://github.com/eic/epic-data/raw/5a853e4e19f2072db725f1c96a97b2f7198c6a4b/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.covfie"
            cache="$DETECTOR_CACHE:/opt/detector"
            scale="1.0">
-      <dimensions>
-        <R step="2.0*cm" min="0*cm" max="998*cm" />
-        <Z step="2.0*cm" min="-800*cm" max="798*cm" />
-      </dimensions>
     </field>
   </fields>
 </lccdd>

--- a/compact/fields/marco.xml
+++ b/compact/fields/marco.xml
@@ -5,7 +5,7 @@
   <fields>
     <field type="epic_FieldMapB" name="GlobalSolenoid" field_type="magnetic" coord_type="BrBz"
            field_map="fieldmaps/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.covfie"
-           url="https://github.com/eic/epic-data/raw/5a853e4e19f2072db725f1c96a97b2f7198c6a4b/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.covfie"
+           url="https://github.com/eic/epic-data/raw/4d6becf98579fbcee8812407e3198d337ea241f2/MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.covfie"
            cache="$DETECTOR_PATH:/opt/detector"
            scale="1.0">
     </field>

--- a/scripts/convert_fieldmap_to_covfie.cpp
+++ b/scripts/convert_fieldmap_to_covfie.cpp
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2025 the ePIC collaboration
+
+// Convert a text field map to covfie binary format for use with FieldMapB.
+//
+// The output field is stored with coordinates in DD4hep length units (cm, since
+// dd4hep::cm == 1.0) so that FieldMapB can call view.at() directly with the
+// values it already has. Text field map coordinates are assumed to be in cm.
+// Field values are stored in Tesla; FieldMapB multiplies by dd4hep::tesla.
+//
+// Usage examples:
+//   BrBz (solenoid):
+//     convert_fieldmap_to_covfie --coord-type BrBz
+//       --r-min 0 --r-max 998 --r-step 2
+//       --z-min -800 --z-max 798 --z-step 2
+//       -i field.txt -o field.covfie
+//
+//   BxByBz (dipole):
+//     convert_fieldmap_to_covfie --coord-type BxByBz
+//       --x-min -7.5 --x-max 7.5 --x-step 0.5
+//       --y-min -34  --y-max 34  --y-step 2
+//       --z-min -80  --z-max 80  --z-step 2
+//       -i field.txt -o field.covfie
+
+#include <covfie/core/algebra/affine.hpp>
+#include <covfie/core/backend/primitive/array.hpp>
+#include <covfie/core/backend/transformer/affine.hpp>
+#include <covfie/core/backend/transformer/nearest_neighbour.hpp>
+#include <covfie/core/backend/transformer/strided.hpp>
+#include <covfie/core/field.hpp>
+#include <covfie/core/parameter_pack.hpp>
+
+#include <boost/program_options.hpp>
+
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace po = boost::program_options;
+
+// Field types matching FieldMapB.cpp (linear ≡ nearest_neighbour on disk)
+using fieldBrBz_t = covfie::field<
+    covfie::backend::affine<covfie::backend::nearest_neighbour<covfie::backend::strided<
+        covfie::vector::size2, covfie::backend::array<covfie::vector::float2>>>>>;
+
+using fieldBxByBz_t = covfie::field<
+    covfie::backend::affine<covfie::backend::nearest_neighbour<covfie::backend::strided<
+        covfie::vector::size3, covfie::backend::array<covfie::vector::float3>>>>>;
+
+// Coordinates in the text field maps are in cm.
+// DD4hep's internal length unit is cm (dd4hep::cm == 1.0), so the affine
+// transform must map cm → grid index to match what FieldMapB::fieldComponents
+// receives in pos[].
+// Field values in the text maps are in Tesla. FieldMapB::fieldComponents
+// converts to DD4hep internal field units (dd4hep::tesla = 1e-13) before
+// accumulating into field[]. The converter therefore stores raw Tesla values.
+
+void convert_BrBz(const std::string& input_file, const std::string& output_file, float r_min,
+                  float r_max, float r_step, float z_min, float z_max, float z_step, float scale) {
+  const std::size_t nr = static_cast<std::size_t>(std::lround((r_max - r_min) / r_step)) + 1;
+  const std::size_t nz = static_cast<std::size_t>(std::lround((z_max - z_min) / z_step)) + 1;
+  std::cout << "Grid: " << nr << " x " << nz << " (BrBz)" << std::endl;
+
+  // Affine: map cm coordinates → grid indices
+  covfie::algebra::affine<2> translation = covfie::algebra::affine<2>::translation(-r_min, -z_min);
+  covfie::algebra::affine<2> scaling     = covfie::algebra::affine<2>::scaling(
+      static_cast<float>(nr - 1) / (r_max - r_min), static_cast<float>(nz - 1) / (z_max - z_min));
+
+  fieldBrBz_t field(covfie::make_parameter_pack(
+      fieldBrBz_t::backend_t::configuration_t(scaling * translation),
+      fieldBrBz_t::backend_t::backend_t::configuration_t{},
+      fieldBrBz_t::backend_t::backend_t::backend_t::configuration_t{nr, nz}));
+  fieldBrBz_t::view_t fv(field);
+
+  std::ifstream f(input_file);
+  if (!f.good()) {
+    std::cerr << "Failed to open input file: " << input_file << std::endl;
+    std::exit(1);
+  }
+
+  std::size_t count = 0;
+  float r, z, Br, Bz;
+  while (f >> r >> z >> Br >> Bz) {
+    fieldBrBz_t::view_t::output_t& p = fv.at(r, z); // r, z already in cm
+    p[0]                             = Br * scale;
+    p[1]                             = Bz * scale;
+    ++count;
+  }
+  std::cout << "Read " << count << " field values." << std::endl;
+
+  std::ofstream fs(output_file, std::ofstream::binary);
+  if (!fs.good()) {
+    std::cerr << "Failed to open output file: " << output_file << std::endl;
+    std::exit(1);
+  }
+  field.dump(fs);
+  std::cout << "Wrote " << output_file << std::endl;
+}
+
+void convert_BxByBz(const std::string& input_file, const std::string& output_file, float x_min,
+                    float x_max, float x_step, float y_min, float y_max, float y_step, float z_min,
+                    float z_max, float z_step, float scale) {
+  const std::size_t nx = static_cast<std::size_t>(std::lround((x_max - x_min) / x_step)) + 1;
+  const std::size_t ny = static_cast<std::size_t>(std::lround((y_max - y_min) / y_step)) + 1;
+  const std::size_t nz = static_cast<std::size_t>(std::lround((z_max - z_min) / z_step)) + 1;
+  std::cout << "Grid: " << nx << " x " << ny << " x " << nz << " (BxByBz)" << std::endl;
+
+  // Affine: map cm coordinates → grid indices
+  covfie::algebra::affine<3> translation =
+      covfie::algebra::affine<3>::translation(-x_min, -y_min, -z_min);
+  covfie::algebra::affine<3> scaling = covfie::algebra::affine<3>::scaling(
+      static_cast<float>(nx - 1) / (x_max - x_min), static_cast<float>(ny - 1) / (y_max - y_min),
+      static_cast<float>(nz - 1) / (z_max - z_min));
+
+  fieldBxByBz_t field(covfie::make_parameter_pack(
+      fieldBxByBz_t::backend_t::configuration_t(scaling * translation),
+      fieldBxByBz_t::backend_t::backend_t::configuration_t{},
+      fieldBxByBz_t::backend_t::backend_t::backend_t::configuration_t{nx, ny, nz}));
+  fieldBxByBz_t::view_t fv(field);
+
+  std::ifstream f(input_file);
+  if (!f.good()) {
+    std::cerr << "Failed to open input file: " << input_file << std::endl;
+    std::exit(1);
+  }
+
+  std::size_t count = 0;
+  float x, y, z, Bx, By, Bz;
+  while (f >> x >> y >> z >> Bx >> By >> Bz) {
+    fieldBxByBz_t::view_t::output_t& p = fv.at(x, y, z); // x, y, z already in cm
+    p[0]                               = Bx * scale;
+    p[1]                               = By * scale;
+    p[2]                               = Bz * scale;
+    ++count;
+  }
+  std::cout << "Read " << count << " field values." << std::endl;
+
+  std::ofstream fs(output_file, std::ofstream::binary);
+  if (!fs.good()) {
+    std::cerr << "Failed to open output file: " << output_file << std::endl;
+    std::exit(1);
+  }
+  field.dump(fs);
+  std::cout << "Wrote " << output_file << std::endl;
+}
+
+int main(int argc, char** argv) {
+  po::options_description opts("convert_fieldmap_to_covfie options");
+  // clang-format off
+  opts.add_options()
+    ("help,h", "produce help message")
+    ("input,i",       po::value<std::string>()->required(), "input text field map file")
+    ("output,o",      po::value<std::string>()->required(), "output covfie binary file")
+    ("coord-type,t",  po::value<std::string>()->required(), "coordinate type: BrBz or BxByBz")
+    ("scale,s",       po::value<float>()->default_value(1.0f), "scale factor applied to field values")
+    ("r-min",  po::value<float>(), "R minimum [cm] (BrBz)")
+    ("r-max",  po::value<float>(), "R maximum [cm] (BrBz)")
+    ("r-step", po::value<float>(), "R step size [cm] (BrBz)")
+    ("x-min",  po::value<float>(), "X minimum [cm] (BxByBz)")
+    ("x-max",  po::value<float>(), "X maximum [cm] (BxByBz)")
+    ("x-step", po::value<float>(), "X step size [cm] (BxByBz)")
+    ("y-min",  po::value<float>(), "Y minimum [cm] (BxByBz)")
+    ("y-max",  po::value<float>(), "Y maximum [cm] (BxByBz)")
+    ("y-step", po::value<float>(), "Y step size [cm] (BxByBz)")
+    ("z-min",  po::value<float>(), "Z minimum [cm]")
+    ("z-max",  po::value<float>(), "Z maximum [cm]")
+    ("z-step", po::value<float>(), "Z step size [cm]");
+  // clang-format on
+
+  po::variables_map vm;
+  try {
+    po::store(po::parse_command_line(argc, argv, opts), vm);
+    if (vm.count("help")) {
+      std::cout << opts << std::endl;
+      return 0;
+    }
+    po::notify(vm);
+  } catch (const po::error& e) {
+    std::cerr << "Error: " << e.what() << "\n" << opts << std::endl;
+    return 1;
+  }
+
+  const auto input      = vm["input"].as<std::string>();
+  const auto output     = vm["output"].as<std::string>();
+  const auto coord_type = vm["coord-type"].as<std::string>();
+  const float scale     = vm["scale"].as<float>();
+
+  if (coord_type == "BrBz") {
+    for (const char* p : {"r-min", "r-max", "r-step", "z-min", "z-max", "z-step"}) {
+      if (!vm.count(p)) {
+        std::cerr << "Error: --" << p << " is required for BrBz" << std::endl;
+        return 1;
+      }
+    }
+    convert_BrBz(input, output, vm["r-min"].as<float>(), vm["r-max"].as<float>(),
+                 vm["r-step"].as<float>(), vm["z-min"].as<float>(), vm["z-max"].as<float>(),
+                 vm["z-step"].as<float>(), scale);
+  } else if (coord_type == "BxByBz") {
+    for (const char* p :
+         {"x-min", "x-max", "x-step", "y-min", "y-max", "y-step", "z-min", "z-max", "z-step"}) {
+      if (!vm.count(p)) {
+        std::cerr << "Error: --" << p << " is required for BxByBz" << std::endl;
+        return 1;
+      }
+    }
+    convert_BxByBz(input, output, vm["x-min"].as<float>(), vm["x-max"].as<float>(),
+                   vm["x-step"].as<float>(), vm["y-min"].as<float>(), vm["y-max"].as<float>(),
+                   vm["y-step"].as<float>(), vm["z-min"].as<float>(), vm["z-max"].as<float>(),
+                   vm["z-step"].as<float>(), scale);
+  } else {
+    std::cerr << "Error: --coord-type must be BrBz or BxByBz" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/scripts/convert_fieldmap_to_covfie.cpp
+++ b/scripts/convert_fieldmap_to_covfie.cpp
@@ -25,6 +25,7 @@
 #include <covfie/core/algebra/affine.hpp>
 #include <covfie/core/backend/primitive/array.hpp>
 #include <covfie/core/backend/transformer/affine.hpp>
+#include <covfie/core/backend/transformer/clamp.hpp>
 #include <covfie/core/backend/transformer/nearest_neighbour.hpp>
 #include <covfie/core/backend/transformer/strided.hpp>
 #include <covfie/core/field.hpp>
@@ -40,14 +41,17 @@
 
 namespace po = boost::program_options;
 
-// Field types matching FieldMapB.cpp (linear ≡ nearest_neighbour on disk)
-using fieldBrBz_t = covfie::field<
-    covfie::backend::affine<covfie::backend::nearest_neighbour<covfie::backend::strided<
-        covfie::vector::size2, covfie::backend::array<covfie::vector::float2>>>>>;
+// Field types for writing. Both nearest_neighbour and linear are transparent on
+// disk (write_binary delegates directly, no header written). The writer uses
+// nearest_neighbour so that affine gets a float input type; the reader in
+// FieldMapB.cpp uses linear for interpolation. Binary format is affine<clamp<strided>>.
+using fieldBrBz_t = covfie::field<covfie::backend::affine<
+    covfie::backend::nearest_neighbour<covfie::backend::clamp<covfie::backend::strided<
+        covfie::vector::size2, covfie::backend::array<covfie::vector::float2>>>>>>;
 
-using fieldBxByBz_t = covfie::field<
-    covfie::backend::affine<covfie::backend::nearest_neighbour<covfie::backend::strided<
-        covfie::vector::size3, covfie::backend::array<covfie::vector::float3>>>>>;
+using fieldBxByBz_t = covfie::field<covfie::backend::affine<
+    covfie::backend::nearest_neighbour<covfie::backend::clamp<covfie::backend::strided<
+        covfie::vector::size3, covfie::backend::array<covfie::vector::float3>>>>>>;
 
 // Coordinates in the text field maps are in cm.
 // DD4hep's internal length unit is cm (dd4hep::cm == 1.0), so the affine
@@ -71,7 +75,8 @@ void convert_BrBz(const std::string& input_file, const std::string& output_file,
   fieldBrBz_t field(covfie::make_parameter_pack(
       fieldBrBz_t::backend_t::configuration_t(scaling * translation),
       fieldBrBz_t::backend_t::backend_t::configuration_t{},
-      fieldBrBz_t::backend_t::backend_t::backend_t::configuration_t{nr, nz}));
+      fieldBrBz_t::backend_t::backend_t::backend_t::configuration_t{{0UL, 0UL}, {nr - 1, nz - 1}},
+      fieldBrBz_t::backend_t::backend_t::backend_t::backend_t::configuration_t{nr, nz}));
   fieldBrBz_t::view_t fv(field);
 
   std::ifstream f(input_file);
@@ -117,7 +122,9 @@ void convert_BxByBz(const std::string& input_file, const std::string& output_fil
   fieldBxByBz_t field(covfie::make_parameter_pack(
       fieldBxByBz_t::backend_t::configuration_t(scaling * translation),
       fieldBxByBz_t::backend_t::backend_t::configuration_t{},
-      fieldBxByBz_t::backend_t::backend_t::backend_t::configuration_t{nx, ny, nz}));
+      fieldBxByBz_t::backend_t::backend_t::backend_t::configuration_t{{0UL, 0UL, 0UL},
+                                                                      {nx - 1, ny - 1, nz - 1}},
+      fieldBxByBz_t::backend_t::backend_t::backend_t::backend_t::configuration_t{nx, ny, nz}));
   fieldBxByBz_t::view_t fv(field);
 
   std::ifstream f(input_file);

--- a/scripts/convert_fieldmap_to_covfie.sh
+++ b/scripts/convert_fieldmap_to_covfie.sh
@@ -1,0 +1,3 @@
+convert_fieldmap_to_covfie -i MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.txt -o MARCO_v.7.6.2.2.11_1.7T_Magnetic_Field_Map_2024_05_02_rad_coords_cm_T.BMap.covfie --coord-type BrBz --r-min 0 --r-max 998 --r-step 2 --z-min -800 --z-max 798 --z-step 2
+
+convert_fieldmap_to_covfie -i LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.txt -o LumiDipoleMapping_2023_09_15_XYZ_coords_cm_T.covfie --coord-type BxByBz --x-min -7.5 --x-max 7.5 --x-step 0.5 --y-min -34 --y-max 34 --y-step 2 --z-min -80 --z-max 80 --z-step 2

--- a/src/FieldMapB.cpp
+++ b/src/FieldMapB.cpp
@@ -231,9 +231,8 @@ void FieldMapB::fieldComponents(const double* pos, double* field) {
 
   if (fieldCoord == FieldCoord::BrBz) {
     // coordinates conversion
-    const float r   = sqrt(p.x() * p.x() + p.y() * p.y());
-    const float z   = p.z();
-    const float phi = atan2(p.y(), p.x());
+    const float r = sqrt(p.x() * p.x() + p.y() * p.y());
+    const float z = p.z();
 
     // Return 0 field outside map extent
     if (r < bmin[0] || r > bmax[0] || z < bmin[1] || z > bmax[1])
@@ -246,9 +245,11 @@ void FieldMapB::fieldComponents(const double* pos, double* field) {
             typename T::view_t view(f);
             typename T::output_t b = view.at(r, z);
             const float Br = b[0], Bz = b[1];
-            auto B = fieldRot.has_value()
-                         ? fieldRot.value() * ROOT::Math::XYZPoint(Br * cos(phi), Br * sin(phi), Bz)
-                         : ROOT::Math::XYZPoint(Br * cos(phi), Br * sin(phi), Bz);
+            const float inv_r = (r > 0.f) ? 1.f / r : 0.f;
+            const float Bx    = Br * p.x() * inv_r;
+            const float By    = Br * p.y() * inv_r;
+            auto B = fieldRot.has_value() ? fieldRot.value() * ROOT::Math::XYZPoint(Bx, By, Bz)
+                                          : ROOT::Math::XYZPoint(Bx, By, Bz);
             field[0] += B.x() * dd4hep::tesla * fieldScale;
             field[1] += B.y() * dd4hep::tesla * fieldScale;
             field[2] += B.z() * dd4hep::tesla * fieldScale;

--- a/src/FieldMapB.cpp
+++ b/src/FieldMapB.cpp
@@ -5,6 +5,14 @@
 #include <DD4hep/FieldTypes.h>
 #include <DD4hep/Printout.h>
 #include <XML/Utilities.h>
+#include <covfie/core/algebra/affine.hpp>
+#include <covfie/core/backend/primitive/array.hpp>
+#include <covfie/core/backend/transformer/affine.hpp>
+#include <covfie/core/backend/transformer/linear.hpp>
+#include <covfie/core/backend/transformer/strided.hpp>
+#include <covfie/core/field.hpp>
+#include <covfie/core/field_view.hpp>
+#include <covfie/core/parameter_pack.hpp>
 
 #include <cstdlib>
 #include <filesystem>
@@ -18,6 +26,14 @@
 namespace fs = std::filesystem;
 
 #include "FileLoaderHelper.h"
+
+using fieldBrBz_t =
+    covfie::field<covfie::backend::affine<covfie::backend::linear<covfie::backend::strided<
+        covfie::vector::size2, covfie::backend::array<covfie::vector::float2>>>>>;
+
+using fieldBxByBz_t =
+    covfie::field<covfie::backend::affine<covfie::backend::linear<covfie::backend::strided<
+        covfie::vector::size3, covfie::backend::array<covfie::vector::float3>>>>>;
 
 using namespace dd4hep;
 
@@ -40,11 +56,9 @@ class FieldMapB : public dd4hep::CartesianField::Object {
 public:
   FieldMapB(const std::string& field_type_str = "magnetic",
             const std::string& coord_type_str = "BrBz");
-  void Configure(std::vector<xml_comp_t> dimensions);
+
   void LoadMap(const std::string& map_file, float scale);
-  bool GetIndices(float R, float Z, int* idxR, int* idxZ, float* deltaR, float* deltaZ);
-  bool GetIndices(float X, float Y, float Z, int* idxX, int* idxY, int* idxZ, float* deltaX,
-                  float* deltaY, float* deltaZ);
+
   void SetCoordTranslation(const Transform3D& tr) {
     coordTranslate     = tr;
     coordTranslate_inv = tr.Inverse();
@@ -62,12 +76,10 @@ private:
   std::optional<Transform3D> coordTranslate_inv{std::nullopt};
   std::optional<Transform3D> fieldRot{std::nullopt}; // field rotation
   std::optional<Transform3D> fieldRot_inv{std::nullopt};
-  std::vector<float> steps, mins, maxs;                    // B map cell info
-  int ir, ix, iy, iz;                                      // lookup indices
-  float dr, dx, dy, dz;                                    // deltas for interpolation
-  std::vector<std::vector<std::array<float, 2>>> Bvals_RZ; // B map values:  {R}, {Z}, {Br,Bz}
-  std::vector<std::vector<std::vector<std::array<float, 3>>>>
-      Bvals_XYZ; // B map values: {X}, {Y}, {Z}, {Bx,By,Bz}
+  std::vector<float> steps, mins, maxs; // B map cell info
+
+  std::shared_ptr<fieldBrBz_t> fieldBrBz;
+  std::shared_ptr<fieldBxByBz_t> fieldBxByBz;
 };
 
 // constructor
@@ -94,120 +106,21 @@ FieldMapB::FieldMapB(const std::string& field_type_str, const std::string& coord
   }
 }
 
-// fill field vector
-void FieldMapB::Configure(std::vector<xml_comp_t> dimensions) {
-  // Fill vectors with step size, min, max for each dimension
-  for (auto el : dimensions) {
-    steps.push_back(el.step());
-    mins.push_back(getAttrOrDefault<float>(el, _Unicode(min), 0));
-    maxs.push_back(getAttrOrDefault<float>(el, _Unicode(max), 0));
-  }
-
-  if (fieldCoord == FieldCoord::BrBz) {
-    // N bins increased by 1 beyond grid size to account for edge cases at upper limits
-    int nr = std::roundf((maxs[0] - mins[0]) / steps[0]) + 2;
-    int nz = std::roundf((maxs[1] - mins[1]) / steps[1]) + 2;
-
-    Bvals_RZ.resize(nr);
-    for (auto& B2 : Bvals_RZ) {
-      B2.resize(nz);
-    }
-  } else {
-    // N bins increased by 1 beyond grid size to account for edge cases at upper limits
-    int nx = std::roundf((maxs[0] - mins[0]) / steps[0]) + 2;
-    int ny = std::roundf((maxs[1] - mins[1]) / steps[1]) + 2;
-    int nz = std::roundf((maxs[2] - mins[2]) / steps[2]) + 2;
-
-    Bvals_XYZ.resize(nx);
-    for (auto& B3 : Bvals_XYZ) {
-      B3.resize(ny);
-      for (auto& B2 : B3) {
-        B2.resize(nz);
-      }
-    }
-  }
-}
-
-// get RZ cell indices corresponding to point of interest
-bool FieldMapB::GetIndices(float R, float Z, int* idxR, int* idxZ, float* deltaR, float* deltaZ) {
-  // boundary check
-  if (R > maxs[0] || R < mins[0] || Z > maxs[1] || Z < mins[1]) {
-    return false;
-  }
-
-  // get indices
-  float idx_1_f, idx_2_f;
-  *deltaR = std::modf((R - mins[0]) / steps[0], &idx_1_f);
-  *deltaZ = std::modf((Z - mins[1]) / steps[1], &idx_2_f);
-  *idxR   = static_cast<int>(idx_1_f);
-  *idxZ   = static_cast<int>(idx_2_f);
-
-  return true;
-}
-
-// get XYZ cell indices corresponding to point of interest
-bool FieldMapB::GetIndices(float X, float Y, float Z, int* idxX, int* idxY, int* idxZ,
-                           float* deltaX, float* deltaY, float* deltaZ) {
-  // boundary check
-  if (X > maxs[0] || X < mins[0] || Y > maxs[1] || Y < mins[1] || Z > maxs[2] || Z < mins[2]) {
-    return false;
-  }
-
-  // get indices
-  float idx_1_f, idx_2_f, idx_3_f;
-  *deltaX = std::modf((X - mins[0]) / steps[0], &idx_1_f);
-  *deltaY = std::modf((Y - mins[1]) / steps[1], &idx_2_f);
-  *deltaZ = std::modf((Z - mins[2]) / steps[2], &idx_3_f);
-  *idxX   = static_cast<int>(idx_1_f);
-  *idxY   = static_cast<int>(idx_2_f);
-  *idxZ   = static_cast<int>(idx_3_f);
-
-  return true;
-}
-
 // load data
-void FieldMapB::LoadMap(const std::string& map_file, float scale) {
+void FieldMapB::LoadMap(const std::string& map_file, float) {
   std::string line;
   std::ifstream input(map_file);
   if (!input) {
     printout(ERROR, "FieldMapB", "FieldMapB Error: file " + map_file + " cannot be read.");
   }
 
-  std::vector<float> coord = {};
-  std::vector<float> Bcomp = {};
-
-  while (std::getline(input, line).good()) {
-    std::istringstream iss(line);
-
-    coord.clear();
-    Bcomp.clear();
-
-    if (fieldCoord == FieldCoord::BrBz) {
-      coord.resize(2);
-      Bcomp.resize(2);
-      iss >> coord[0] >> coord[1] >> Bcomp[0] >> Bcomp[1];
-
-      if (!GetIndices(coord[0], coord[1], &ir, &iz, &dr, &dz)) {
-        printout(WARNING, "FieldMapB", "coordinates out of range, skipped it.");
-      } else { // scale field
-        Bvals_RZ[ir][iz] = {Bcomp[0] * scale * float(tesla), Bcomp[1] * scale * float(tesla)};
-      }
-    } else {
-      coord.resize(3);
-      Bcomp.resize(3);
-      iss >> coord[0] >> coord[1] >> coord[2] >> Bcomp[0] >> Bcomp[1] >> Bcomp[2];
-
-      if (!GetIndices(coord[0], coord[1], coord[2], &ix, &iy, &iz, &dx, &dy, &dz)) {
-        printout(WARNING, "FieldMap", "coordinates out of range, skipped it.");
-      } else { // scale and rotate B field vector
-        auto B = ROOT::Math::XYZPoint(Bcomp[0], Bcomp[1], Bcomp[2]);
-        B *= scale * float(tesla);
-        if (fieldRot.has_value()) {
-          B = fieldRot.value() * B;
-        }
-        Bvals_XYZ[ix][iy][iz] = {float(B.x()), float(B.y()), float(B.z())};
-      }
-    }
+  switch (fieldCoord) {
+  case FieldCoord::BrBz:
+    fieldBrBz = std::make_shared<fieldBrBz_t>(input);
+    break;
+  case FieldCoord::BxByBz:
+    fieldBxByBz = std::make_shared<fieldBxByBz_t>(input);
+    break;
   }
 }
 
@@ -223,65 +136,31 @@ void FieldMapB::fieldComponents(const double* pos, double* field) {
     const float r = sqrt(p.x() * p.x() + p.y() * p.y());
     const float z = p.z();
 
-    if (!GetIndices(r, z, &ir, &iz, &dr, &dz)) {
-      // out of range
-      return;
-    }
-
-    // p1    p3
-    //    p
-    // p0    p2
-    auto& p0 = Bvals_RZ[ir][iz];
-    auto& p1 = Bvals_RZ[ir][iz + 1];
-    auto& p2 = Bvals_RZ[ir + 1][iz];
-    auto& p3 = Bvals_RZ[ir + 1][iz + 1];
-
-    // Bilinear interpolation
-    float Br = p0[0] * (1 - dr) * (1 - dz) + p1[0] * (1 - dr) * dz + p2[0] * dr * (1 - dz) +
-               p3[0] * dr * dz;
-
-    float Bz = p0[1] * (1 - dr) * (1 - dz) + p1[1] * (1 - dr) * dz + p2[1] * dr * (1 - dz) +
-               p3[1] * dr * dz;
+    fieldBrBz_t::view_t view(*fieldBrBz);
+    fieldBrBz_t::output_t b = view.at(r, z);
+    float Br                = b[0];
+    float Bz                = b[1];
 
     // convert Br Bz to Bx By Bz and rotate field
     const float phi = atan2(p.y(), p.x());
-    auto B = fieldRot.has_value()
-                 ? fieldRot.value() * ROOT::Math::XYZPoint(Br * cos(phi), Br * sin(phi), Bz)
-                 : ROOT::Math::XYZPoint(Br * cos(phi), Br * sin(phi), Bz);
+    auto B          = fieldRot.has_value()
+                          ? fieldRot.value() * ROOT::Math::XYZPoint(Br * cos(phi), Br * sin(phi), Bz)
+                          : ROOT::Math::XYZPoint(Br * cos(phi), Br * sin(phi), Bz);
+
     field[0] += B.x();
     field[1] += B.y();
     field[2] += B.z();
+
   } else { // BxByBz
 
-    if (!GetIndices(p.x(), p.y(), p.z(), &ix, &iy, &iz, &dx, &dy, &dz)) {
-      return; // out of range
-    }
-
-    float b[3] = {0};
-    for (int comp = 0; comp < 3; comp++) { // field component loop
-      // Trilinear interpolation
-      // First along X, along 4 lines
-      float b00 = Bvals_XYZ[ix][iy][iz][comp] * (1 - dx) + Bvals_XYZ[ix + 1][iy][iz][comp] * dx;
-      float b01 =
-          Bvals_XYZ[ix][iy][iz + 1][comp] * (1 - dx) + Bvals_XYZ[ix + 1][iy][iz + 1][comp] * dx;
-      float b10 =
-          Bvals_XYZ[ix][iy + 1][iz][comp] * (1 - dx) + Bvals_XYZ[ix + 1][iy + 1][iz][comp] * dx;
-      float b11 = Bvals_XYZ[ix][iy + 1][iz + 1][comp] * (1 - dx) +
-                  Bvals_XYZ[ix + 1][iy + 1][iz + 1][comp] * dx;
-      // Next along Y, along 2 lines
-      float b0 = b00 * (1 - dy) + b10 * dy;
-      float b1 = b01 * (1 - dy) + b11 * dy;
-      // Finally along Z
-      b[comp] = b0 * (1 - dz) + b1 * dz;
-    }
+    fieldBxByBz_t::view_t view(*fieldBxByBz);
+    fieldBxByBz_t::output_t b = view.at(p.x(), p.y(), p.z());
 
     // field rotation done in LoadMap()
     field[0] += b[0];
     field[1] += b[1];
     field[2] += b[2];
   }
-
-  return;
 }
 
 // assign the field map to CartesianField
@@ -331,7 +210,6 @@ static Ref_t create_field_map_b(Detector& /*lcdd*/, xml::Handle_t handle) {
   }
 
   auto map = new FieldMapB(field_type, coord_type);
-  map->Configure(dimensions);
 
   // translation
   if (x_dim.hasChild(_Unicode(rotationField))) {

--- a/src/FieldMapB.cpp
+++ b/src/FieldMapB.cpp
@@ -4,11 +4,13 @@
 #include <DD4hep/DetFactoryHelper.h>
 #include <DD4hep/FieldTypes.h>
 #include <DD4hep/Printout.h>
+#include <DD4hep/DD4hepUnits.h>
 #include <XML/Utilities.h>
 #include <covfie/core/algebra/affine.hpp>
 #include <covfie/core/backend/primitive/array.hpp>
 #include <covfie/core/backend/transformer/affine.hpp>
 #include <covfie/core/backend/transformer/linear.hpp>
+#include <covfie/core/backend/transformer/morton.hpp>
 #include <covfie/core/backend/transformer/strided.hpp>
 #include <covfie/core/field.hpp>
 #include <covfie/core/field_view.hpp>
@@ -23,17 +25,30 @@
 #include <stdexcept>
 #include <string>
 #include <tuple>
+#include <variant>
 namespace fs = std::filesystem;
 
 #include "FileLoaderHelper.h"
 
-using fieldBrBz_t =
+// Strided (default, matches on-disk file format)
+using fieldBrBz_strided_t =
     covfie::field<covfie::backend::affine<covfie::backend::linear<covfie::backend::strided<
         covfie::vector::size2, covfie::backend::array<covfie::vector::float2>>>>>;
-
-using fieldBxByBz_t =
+using fieldBxByBz_strided_t =
     covfie::field<covfie::backend::affine<covfie::backend::linear<covfie::backend::strided<
         covfie::vector::size3, covfie::backend::array<covfie::vector::float3>>>>>;
+
+// Morton (space-filling curve layout for improved cache locality)
+using fieldBrBz_morton_t =
+    covfie::field<covfie::backend::affine<covfie::backend::linear<covfie::backend::morton<
+        covfie::vector::size2, covfie::backend::array<covfie::vector::float2>>>>>;
+using fieldBxByBz_morton_t =
+    covfie::field<covfie::backend::affine<covfie::backend::linear<covfie::backend::morton<
+        covfie::vector::size3, covfie::backend::array<covfie::vector::float3>>>>>;
+
+// Variant types (monostate = not yet loaded)
+using fieldBrBz_t   = std::variant<std::monostate, fieldBrBz_strided_t, fieldBrBz_morton_t>;
+using fieldBxByBz_t = std::variant<std::monostate, fieldBxByBz_strided_t, fieldBxByBz_morton_t>;
 
 using namespace dd4hep;
 
@@ -52,10 +67,12 @@ using namespace dd4hep;
 class FieldMapB : public dd4hep::CartesianField::Object {
 
   enum FieldCoord { BrBz, BxByBz };
+  enum class BackendType { strided, morton };
 
 public:
-  FieldMapB(const std::string& field_type_str = "magnetic",
-            const std::string& coord_type_str = "BrBz");
+  FieldMapB(const std::string& field_type_str   = "magnetic",
+            const std::string& coord_type_str   = "BrBz",
+            const std::string& backend_type_str = "strided");
 
   void LoadMap(const std::string& map_file, float scale);
 
@@ -63,27 +80,30 @@ public:
     coordTranslate     = tr;
     coordTranslate_inv = tr.Inverse();
   }
-  void SetFieldRotation(const Transform3D& tr) {
-    fieldRot     = tr;
-    fieldRot_inv = tr.Inverse();
-  }
+  void SetFieldRotation(const Transform3D& tr) { fieldRot = tr; }
 
   virtual void fieldComponents(const double* pos, double* field);
 
 private:
   FieldCoord fieldCoord;                                   // field coordinate type
+  BackendType backendType{BackendType::strided};           // memory layout backend
   std::optional<Transform3D> coordTranslate{std::nullopt}; // coord translation
   std::optional<Transform3D> coordTranslate_inv{std::nullopt};
   std::optional<Transform3D> fieldRot{std::nullopt}; // field rotation
-  std::optional<Transform3D> fieldRot_inv{std::nullopt};
-  std::vector<float> steps, mins, maxs; // B map cell info
 
-  std::shared_ptr<fieldBrBz_t> fieldBrBz;
-  std::shared_ptr<fieldBxByBz_t> fieldBxByBz;
+  fieldBrBz_t fieldBrBz;
+  fieldBxByBz_t fieldBxByBz;
+
+  // Coordinate bounds extracted from the field map after loading.
+  // For BrBz: bmin[0]=r_min, bmin[1]=z_min, bmax[0]=r_max, bmax[1]=z_max
+  // For BxByBz: bmin[0..2]=x/y/z_min, bmax[0..2]=x/y/z_max
+  std::array<float, 3> bmin{}, bmax{};
+  float fieldScale{1.0f}; // scale factor applied to field values in fieldComponents
 };
 
 // constructor
-FieldMapB::FieldMapB(const std::string& field_type_str, const std::string& coord_type_str) {
+FieldMapB::FieldMapB(const std::string& field_type_str, const std::string& coord_type_str,
+                     const std::string& backend_type_str) {
   std::string ftype = field_type_str;
   for (auto& c : ftype) {
     c = tolower(c);
@@ -104,23 +124,101 @@ FieldMapB::FieldMapB(const std::string& field_type_str, const std::string& coord
   } else { // BxByBz
     fieldCoord = FieldCoord::BxByBz;
   }
+
+  if (backend_type_str == "morton") {
+    backendType = BackendType::morton;
+  } else {
+    backendType = BackendType::strided;
+  }
 }
 
 // load data
-void FieldMapB::LoadMap(const std::string& map_file, float) {
-  std::string line;
+void FieldMapB::LoadMap(const std::string& map_file, float scale) {
   std::ifstream input(map_file);
   if (!input) {
     printout(ERROR, "FieldMapB", "FieldMapB Error: file " + map_file + " cannot be read.");
+    std::_Exit(EXIT_FAILURE);
   }
 
   switch (fieldCoord) {
-  case FieldCoord::BrBz:
-    fieldBrBz = std::make_shared<fieldBrBz_t>(input);
+  case FieldCoord::BrBz: {
+    fieldBrBz_strided_t strided(input);
+    switch (backendType) {
+    case BackendType::morton:
+      fieldBrBz = fieldBrBz_morton_t(strided);
+      break;
+    default:
+      fieldBrBz = std::move(strided);
+      break;
+    }
     break;
-  case FieldCoord::BxByBz:
-    fieldBxByBz = std::make_shared<fieldBxByBz_t>(input);
+  }
+  case FieldCoord::BxByBz: {
+    fieldBxByBz_strided_t strided(input);
+    switch (backendType) {
+    case BackendType::morton:
+      fieldBxByBz = fieldBxByBz_morton_t(strided);
+      break;
+    default:
+      fieldBxByBz = std::move(strided);
+      break;
+    }
     break;
+  }
+  }
+
+  // Store scale factor for application in fieldComponents.
+  fieldScale = scale;
+
+  // Extract coordinate bounds from the affine matrix and array sizes so that
+  // fieldComponents can return 0 for out-of-bounds queries.
+  auto extract_bounds = [&](auto& f) {
+    using T = std::decay_t<decltype(f)>;
+    if constexpr (!std::is_same_v<T, std::monostate>) {
+      const auto& mat         = f.backend().get_configuration();
+      const auto& sizes       = f.backend().get_backend().get_backend().get_configuration();
+      constexpr std::size_t N = std::decay_t<decltype(sizes)>::dimensions;
+      for (std::size_t i = 0; i < N; ++i) {
+        bmin[i] = -mat(i, N) / mat(i, i);
+        bmax[i] = bmin[i] + static_cast<float>(sizes[i] - 1) / mat(i, i);
+      }
+    }
+  };
+  if (fieldCoord == FieldCoord::BrBz)
+    std::visit(extract_bounds, fieldBrBz);
+  else
+    std::visit(extract_bounds, fieldBxByBz);
+
+  // Print extent and central field value via fieldComponents to verify units.
+  if (fieldCoord == FieldCoord::BrBz) {
+    const float z_c = 0.5f * (bmin[1] + bmax[1]);
+    // Query at r=0 (on-axis), mid-z, in world coords (undo translation).
+    auto origin   = coordTranslate.has_value()
+                        ? coordTranslate.value() * ROOT::Math::XYZPoint(0, 0, z_c)
+                        : ROOT::Math::XYZPoint(0, 0, z_c);
+    double pos[3] = {origin.x(), origin.y(), origin.z()};
+    double B[3]   = {0, 0, 0};
+    fieldComponents(pos, B);
+    // Convert back from DD4hep units to Tesla for display.
+    printout(INFO, "FieldMapB",
+             "Loaded BrBz map: r=[%.1f,%.1f] cm, z=[%.1f,%.1f] cm; "
+             "B(r=0,z=%.1f) = (Bz=%.4f) T",
+             bmin[0], bmax[0], bmin[1], bmax[1], z_c, B[2] / dd4hep::tesla);
+  } else {
+    const float x_c = 0.5f * (bmin[0] + bmax[0]);
+    const float y_c = 0.5f * (bmin[1] + bmax[1]);
+    const float z_c = 0.5f * (bmin[2] + bmax[2]);
+    auto origin     = coordTranslate.has_value()
+                          ? coordTranslate.value() * ROOT::Math::XYZPoint(x_c, y_c, z_c)
+                          : ROOT::Math::XYZPoint(x_c, y_c, z_c);
+    double pos[3]   = {origin.x(), origin.y(), origin.z()};
+    double B[3]     = {0, 0, 0};
+    fieldComponents(pos, B);
+    printout(INFO, "FieldMapB",
+             "Loaded BxByBz map: x=[%.1f,%.1f] cm, y=[%.1f,%.1f] cm, z=[%.1f,%.1f] cm; "
+             "B(x=%.1f,y=%.1f,z=%.1f) = (Bx=%.4f, By=%.4f, Bz=%.4f) T",
+             bmin[0], bmax[0], bmin[1], bmax[1], bmin[2], bmax[2], x_c, y_c, z_c,
+             B[0] / dd4hep::tesla, B[1] / dd4hep::tesla, B[2] / dd4hep::tesla);
   }
 }
 
@@ -133,33 +231,53 @@ void FieldMapB::fieldComponents(const double* pos, double* field) {
 
   if (fieldCoord == FieldCoord::BrBz) {
     // coordinates conversion
-    const float r = sqrt(p.x() * p.x() + p.y() * p.y());
-    const float z = p.z();
-
-    fieldBrBz_t::view_t view(*fieldBrBz);
-    fieldBrBz_t::output_t b = view.at(r, z);
-    float Br                = b[0];
-    float Bz                = b[1];
-
-    // convert Br Bz to Bx By Bz and rotate field
+    const float r   = sqrt(p.x() * p.x() + p.y() * p.y());
+    const float z   = p.z();
     const float phi = atan2(p.y(), p.x());
-    auto B          = fieldRot.has_value()
-                          ? fieldRot.value() * ROOT::Math::XYZPoint(Br * cos(phi), Br * sin(phi), Bz)
-                          : ROOT::Math::XYZPoint(Br * cos(phi), Br * sin(phi), Bz);
 
-    field[0] += B.x();
-    field[1] += B.y();
-    field[2] += B.z();
+    // Return 0 field outside map extent
+    if (r < bmin[0] || r > bmax[0] || z < bmin[1] || z > bmax[1])
+      return;
+
+    std::visit(
+        [&](auto& f) {
+          using T = std::decay_t<decltype(f)>;
+          if constexpr (!std::is_same_v<T, std::monostate>) {
+            typename T::view_t view(f);
+            typename T::output_t b = view.at(r, z);
+            const float Br = b[0], Bz = b[1];
+            auto B = fieldRot.has_value()
+                         ? fieldRot.value() * ROOT::Math::XYZPoint(Br * cos(phi), Br * sin(phi), Bz)
+                         : ROOT::Math::XYZPoint(Br * cos(phi), Br * sin(phi), Bz);
+            field[0] += B.x() * dd4hep::tesla * fieldScale;
+            field[1] += B.y() * dd4hep::tesla * fieldScale;
+            field[2] += B.z() * dd4hep::tesla * fieldScale;
+          }
+        },
+        fieldBrBz);
 
   } else { // BxByBz
 
-    fieldBxByBz_t::view_t view(*fieldBxByBz);
-    fieldBxByBz_t::output_t b = view.at(p.x(), p.y(), p.z());
+    // Return 0 field outside map extent
+    if (p.x() < bmin[0] || p.x() > bmax[0] || p.y() < bmin[1] || p.y() > bmax[1] ||
+        p.z() < bmin[2] || p.z() > bmax[2])
+      return;
 
-    // field rotation done in LoadMap()
-    field[0] += b[0];
-    field[1] += b[1];
-    field[2] += b[2];
+    std::visit(
+        [&](auto& f) {
+          using T = std::decay_t<decltype(f)>;
+          if constexpr (!std::is_same_v<T, std::monostate>) {
+            typename T::view_t view(f);
+            typename T::output_t b = view.at(p.x(), p.y(), p.z());
+            auto B                 = fieldRot.has_value()
+                                         ? fieldRot.value() * ROOT::Math::XYZPoint(b[0], b[1], b[2])
+                                         : ROOT::Math::XYZPoint(b[0], b[1], b[2]);
+            field[0] += B.x() * dd4hep::tesla * fieldScale;
+            field[1] += B.y() * dd4hep::tesla * fieldScale;
+            field[2] += B.z() * dd4hep::tesla * fieldScale;
+          }
+        },
+        fieldBxByBz);
   }
 }
 
@@ -177,20 +295,7 @@ static Ref_t create_field_map_b(Detector& /*lcdd*/, xml::Handle_t handle) {
 
   std::string coord_type = x_par.attr<std::string>(_Unicode(coord_type));
 
-  // dimensions
-  xml_comp_t x_dim = x_par.dimensions();
-
-  // vector of dimension parameters: step, min, max
-  std::vector<xml_comp_t> dimensions;
-
-  if (coord_type.compare("BrBz") == 0) {
-    dimensions.push_back(x_dim.child(_Unicode(R)));
-    dimensions.push_back(x_dim.child(_Unicode(Z)));
-  } else if (coord_type.compare("BxByBz") == 0) {
-    dimensions.push_back(x_dim.child(_Unicode(X)));
-    dimensions.push_back(x_dim.child(_Unicode(Y)));
-    dimensions.push_back(x_dim.child(_Unicode(Z)));
-  } else {
+  if (coord_type.compare("BrBz") != 0 && coord_type.compare("BxByBz") != 0) {
     printout(ERROR, "FieldMapB", "Coordinate type: " + coord_type + ", is not BrBz nor BxByBz");
     std::_Exit(EXIT_FAILURE);
   }
@@ -209,20 +314,25 @@ static Ref_t create_field_map_b(Detector& /*lcdd*/, xml::Handle_t handle) {
     std::_Exit(EXIT_FAILURE);
   }
 
-  auto map = new FieldMapB(field_type, coord_type);
+  auto map = new FieldMapB(field_type, coord_type,
+                           getAttrOrDefault<std::string>(x_par, _Unicode(backend_type), "strided"));
 
-  // translation
-  if (x_dim.hasChild(_Unicode(rotationField))) {
-    static float deg2r = ROOT::Math::Pi() / 180.;
-    xml_comp_t rot_dim = x_dim.child(_Unicode(rotationField));
-    RotationZYX rot(rot_dim.z() * deg2r, rot_dim.y() * deg2r, rot_dim.x() * deg2r);
-    map->SetFieldRotation(Transform3D(rot));
-  }
-  // rotation
-  if (x_dim.hasChild(_Unicode(translationCoord))) {
-    xml_comp_t trans_dim = x_dim.child(_Unicode(translationCoord));
-    Translation3D trans(trans_dim.x(), trans_dim.y(), trans_dim.z());
-    map->SetCoordTranslation(Transform3D(trans));
+  // Optional field rotation and coordinate translation
+  if (x_par.hasChild(_Unicode(dimensions))) {
+    xml_comp_t x_dim = x_par.dimensions();
+
+    if (x_dim.hasChild(_Unicode(rotationField))) {
+      static float deg2r = ROOT::Math::Pi() / 180.;
+      xml_comp_t rot_dim = x_dim.child(_Unicode(rotationField));
+      RotationZYX rot(rot_dim.z() * deg2r, rot_dim.y() * deg2r, rot_dim.x() * deg2r);
+      map->SetFieldRotation(Transform3D(rot));
+    }
+
+    if (x_dim.hasChild(_Unicode(translationCoord))) {
+      xml_comp_t trans_dim = x_dim.child(_Unicode(translationCoord));
+      Translation3D trans(trans_dim.x(), trans_dim.y(), trans_dim.z());
+      map->SetCoordTranslation(Transform3D(trans));
+    }
   }
 
   map->LoadMap(field_map_file, field_map_scale);

--- a/src/FieldMapB.cpp
+++ b/src/FieldMapB.cpp
@@ -9,6 +9,7 @@
 #include <covfie/core/algebra/affine.hpp>
 #include <covfie/core/backend/primitive/array.hpp>
 #include <covfie/core/backend/transformer/affine.hpp>
+#include <covfie/core/backend/transformer/clamp.hpp>
 #include <covfie/core/backend/transformer/linear.hpp>
 #include <covfie/core/backend/transformer/morton.hpp>
 #include <covfie/core/backend/transformer/strided.hpp>
@@ -31,20 +32,20 @@ namespace fs = std::filesystem;
 #include "FileLoaderHelper.h"
 
 // Strided (default, matches on-disk file format)
-using fieldBrBz_strided_t =
-    covfie::field<covfie::backend::affine<covfie::backend::linear<covfie::backend::strided<
-        covfie::vector::size2, covfie::backend::array<covfie::vector::float2>>>>>;
-using fieldBxByBz_strided_t =
-    covfie::field<covfie::backend::affine<covfie::backend::linear<covfie::backend::strided<
-        covfie::vector::size3, covfie::backend::array<covfie::vector::float3>>>>>;
+using fieldBrBz_strided_t = covfie::field<
+    covfie::backend::affine<covfie::backend::linear<covfie::backend::clamp<covfie::backend::strided<
+        covfie::vector::size2, covfie::backend::array<covfie::vector::float2>>>>>>;
+using fieldBxByBz_strided_t = covfie::field<
+    covfie::backend::affine<covfie::backend::linear<covfie::backend::clamp<covfie::backend::strided<
+        covfie::vector::size3, covfie::backend::array<covfie::vector::float3>>>>>>;
 
 // Morton (space-filling curve layout for improved cache locality)
-using fieldBrBz_morton_t =
-    covfie::field<covfie::backend::affine<covfie::backend::linear<covfie::backend::morton<
-        covfie::vector::size2, covfie::backend::array<covfie::vector::float2>>>>>;
-using fieldBxByBz_morton_t =
-    covfie::field<covfie::backend::affine<covfie::backend::linear<covfie::backend::morton<
-        covfie::vector::size3, covfie::backend::array<covfie::vector::float3>>>>>;
+using fieldBrBz_morton_t = covfie::field<
+    covfie::backend::affine<covfie::backend::linear<covfie::backend::clamp<covfie::backend::morton<
+        covfie::vector::size2, covfie::backend::array<covfie::vector::float2>>>>>>;
+using fieldBxByBz_morton_t = covfie::field<
+    covfie::backend::affine<covfie::backend::linear<covfie::backend::clamp<covfie::backend::morton<
+        covfie::vector::size3, covfie::backend::array<covfie::vector::float3>>>>>>;
 
 // Variant types (monostate = not yet loaded)
 using fieldBrBz_t   = std::variant<std::monostate, fieldBrBz_strided_t, fieldBrBz_morton_t>;
@@ -175,8 +176,8 @@ void FieldMapB::LoadMap(const std::string& map_file, float scale) {
   auto extract_bounds = [&](auto& f) {
     using T = std::decay_t<decltype(f)>;
     if constexpr (!std::is_same_v<T, std::monostate>) {
-      const auto& mat         = f.backend().get_configuration();
-      const auto& sizes       = f.backend().get_backend().get_backend().get_configuration();
+      const auto& mat   = f.backend().get_configuration();
+      const auto& sizes = f.backend().get_backend().get_backend().get_backend().get_configuration();
       constexpr std::size_t N = std::decay_t<decltype(sizes)>::dimensions;
       for (std::size_t i = 0; i < N; ++i) {
         bmin[i] = -mat(i, N) / mat(i, i);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Needs:
- [ ] https://github.com/eic/epic-data/pull/30
- [x] https://github.com/eic/eic-spack/pull/849

This PR converts the FieldMapB handling to using [covfie](https://github.com/acts-project/covfie) for all interpolation etc. This will allow us to pass-through covfie to ACTS and others(*), while continuing to use the DD4hep field accessors where necessary.

(*) No demo of this. Not sure all necessary parts are there. You'd need to access the bare cvf file.

After profiling with this change, the cost of fieldComponent calls went from 12% to 7% (and due to the way covfie works with templated code, all calls could be inlined so there is no remaining branching).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.