### PR TITLE
fix: include POST_BUILD in add_custom_command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ file(GLOB CONFIG_YMLS ${CMAKE_CURRENT_SOURCE_DIR}/configurations/*.yml)
 foreach(config_yml ${CONFIG_YMLS})
     get_filename_component(config ${config_yml} NAME_WE)
     add_custom_target(${config}.xml ALL)
-    add_custom_command(TARGET ${config}.xml
+    add_custom_command(TARGET ${config}.xml POST_BUILD
         COMMAND
             ${CMAKE_CURRENT_SOURCE_DIR}/bin/make_detector_configuration
                 --dir ${TEMPLATE_DIR}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR silences CMake warnings as of cmake-3.31 (e.g. https://github.com/eic/epic/actions/runs/17385066821/job/49350124044#step:8:167).

Refs:
- https://cmake.org/cmake/help/latest/command/add_custom_command.html
- https://cmake.org/cmake/help/latest/policy/CMP0175.html

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/epic/actions/runs/17385066821/job/49350124044#step:8:167)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.