### PR TITLE
feat: Update devcontainer image to eic_ci nightly version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
 {
   "name": "eic-shell",
-  "image": "ghcr.io/eic/eic_xl:nightly"
+  "image": "ghcr.io/eic/eic_ci:nightly"
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This pull request updates the development container configuration to use a different Docker image for the dev environment.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L3-R3): Changed the container image from `ghcr.io/eic/eic_xl:nightly` to `ghcr.io/eic/eic_ci:nightly` to use the CI image for development.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: eic_xl is too large and times out codespaces opening, or worse it runs out of disk space)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.