### PR TITLE
linux-eic-shell: remove outdated capybara prerequisites install

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -571,7 +571,6 @@ jobs:
         platform-release: "eic_xl:nightly"
         setup: install/bin/thisepic.sh
         run: |
-          export PYTHONPATH=$HOME/.local/lib/python3.10/site-packages:$PYTHONPATH
           mkdir capybara-reports
           shopt -s nullglob
           capybara bara ref/sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root* sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
@@ -640,8 +639,6 @@ jobs:
         platform-release: "eic_xl:nightly"
         setup: install/bin/thisepic.sh
         run: |
-          pip install 'pygithub>=2' 'bokeh>=3'
-          export PYTHONPATH=$HOME/.local/lib/python3.10/site-packages:$PYTHONPATH
           mkdir capybara-reports
           shopt -s nullglob
           capybara bara ref/sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root* sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This prevents a recent CI failure: https://github.com/eic/epic/actions/runs/17475903445/job/49636424793?pr=935#step:9:103
The necessary dependencies are installed via spack in the container since a while ago.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No