### PR TITLE
fix: resolve material map scripts for Acts 39 (v2)

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -166,6 +166,7 @@ jobs:
         path: |
           scripts/material_map/*.json
           scripts/material_map/material-map.cbor
+          scripts/material_map/plots/
           scripts/material_map/Surfaces/
           scripts/material_map/Validation/
         if-no-files-found: error

--- a/compact/tracking/silicon_disks.xml
+++ b/compact/tracking/silicon_disks.xml
@@ -30,6 +30,10 @@
     <constant name="SiTrackerEndcapMod_angle"       value="360.0*degree / SiTrackerEndcapMod_count * (1 + SiTrackerEndcapMod_overlap)" />
     <constant name="SiTrackerEndcapLayer_thickness" value="SiTrackerEndcapMod_thickness + 2 * SiTrackerEndcapMod_dz + 1*um" />
 
+    <comment> Acts envelope buffer distances </comment>
+    <constant name="SiTrackerEndcap_envelope_rmin_delta" value="1*mm"/>
+    <constant name="SiTrackerEndcap_envelope_rmax_delta" value="1*mm"/>
+    <constant name="SiTrackerEndcap_envelope_length_delta" value="2*mm"/>
   </define>
 
   <comment>
@@ -73,10 +77,10 @@
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
-          rmin="InnerTrackerEndcapPLayer1_rmin - 1*mm"
-          rmax="InnerTrackerEndcapPLayer1_rmax + 1*mm"
-          length="SiTrackerEndcapLayer_thickness + 2*mm"
-          zstart="InnerTrackerEndcapPLayer1_zmin - 1*mm"/>
+          rmin="InnerTrackerEndcapPLayer1_rmin - SiTrackerEndcap_envelope_rmin_delta"
+          rmax="InnerTrackerEndcapPLayer1_rmax + SiTrackerEndcap_envelope_rmax_delta"
+          length="SiTrackerEndcapLayer_thickness + SiTrackerEndcap_envelope_length_delta"
+          zstart="InnerTrackerEndcapPLayer1_zmin - SiTrackerEndcap_envelope_length_delta/2"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <ring
@@ -103,10 +107,10 @@
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
-          rmin="InnerTrackerEndcapNLayer1_rmin - 1*mm"
-          rmax="InnerTrackerEndcapNLayer1_rmax + 1*mm"
-          length="SiTrackerEndcapLayer_thickness + 2*mm"
-          zstart="InnerTrackerEndcapNLayer1_zmin - 1*mm"/>
+          rmin="InnerTrackerEndcapNLayer1_rmin - SiTrackerEndcap_envelope_rmin_delta"
+          rmax="InnerTrackerEndcapNLayer1_rmax + SiTrackerEndcap_envelope_rmax_delta"
+          length="SiTrackerEndcapLayer_thickness + SiTrackerEndcap_envelope_length_delta"
+          zstart="InnerTrackerEndcapNLayer1_zmin - SiTrackerEndcap_envelope_length_delta/2"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <ring
@@ -217,10 +221,10 @@
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapPLayer1_rmin - 1*mm"
-          rmax="TrackerEndcapPLayer1_rmax + 1*mm"
-          length="SiTrackerEndcapLayer_thickness + 2*mm"
-          zstart="TrackerEndcapPLayer1_zmin - 1*mm"/>
+          rmin="TrackerEndcapPLayer1_rmin - SiTrackerEndcap_envelope_rmin_delta"
+          rmax="TrackerEndcapPLayer1_rmax + SiTrackerEndcap_envelope_rmax_delta"
+          length="SiTrackerEndcapLayer_thickness + SiTrackerEndcap_envelope_length_delta"
+          zstart="TrackerEndcapPLayer1_zmin - SiTrackerEndcap_envelope_length_delta/2"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <ring
@@ -247,10 +251,10 @@
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapNLayer1_rmin - 1*mm"
-          rmax="TrackerEndcapNLayer1_rmax + 1*mm"
-          length="SiTrackerEndcapLayer_thickness + 2*mm"
-          zstart="TrackerEndcapNLayer1_zmin - 1*mm"/>
+          rmin="TrackerEndcapNLayer1_rmin - SiTrackerEndcap_envelope_rmin_delta"
+          rmax="TrackerEndcapNLayer1_rmax + SiTrackerEndcap_envelope_rmax_delta"
+          length="SiTrackerEndcapLayer_thickness + SiTrackerEndcap_envelope_length_delta"
+          zstart="TrackerEndcapNLayer1_zmin - SiTrackerEndcap_envelope_length_delta/2"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <ring
@@ -289,10 +293,10 @@
       </module>
       <layer id="2">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapPLayer2_rmin - 1*mm"
-          rmax="TrackerEndcapPLayer2_rmax + 1*mm"
-          length="SiTrackerEndcapLayer_thickness + 2*mm"
-          zstart="TrackerEndcapPLayer2_zmin - 1*mm"/>
+          rmin="TrackerEndcapPLayer2_rmin - SiTrackerEndcap_envelope_rmin_delta"
+          rmax="TrackerEndcapPLayer2_rmax + SiTrackerEndcap_envelope_rmax_delta"
+          length="SiTrackerEndcapLayer_thickness + SiTrackerEndcap_envelope_length_delta"
+          zstart="TrackerEndcapPLayer2_zmin - SiTrackerEndcap_envelope_length_delta/2"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="20"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="20"/>
         <ring
@@ -304,10 +308,10 @@
       </layer>
       <layer id="3">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapPLayer3_rmin - 1*mm"
-          rmax="TrackerEndcapPLayer3_rmax + 1*mm"
-          length="SiTrackerEndcapLayer_thickness + 2*mm"
-          zstart="TrackerEndcapPLayer3_zmin - 1*mm"/>
+          rmin="TrackerEndcapPLayer3_rmin - SiTrackerEndcap_envelope_rmin_delta"
+          rmax="TrackerEndcapPLayer3_rmax + SiTrackerEndcap_envelope_rmax_delta"
+          length="SiTrackerEndcapLayer_thickness + SiTrackerEndcap_envelope_length_delta"
+          zstart="TrackerEndcapPLayer3_zmin - SiTrackerEndcap_envelope_length_delta/2"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="20"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="20"/>
         <ring
@@ -319,10 +323,10 @@
       </layer>
       <layer id="4">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapPLayer4_rmin - 1*mm"
-          rmax="TrackerEndcapPLayer4_rmax + 1*mm"
-          length="SiTrackerEndcapLayer_thickness + 2*mm"
-          zstart="TrackerEndcapPLayer4_zmin - 1*mm"/>
+          rmin="TrackerEndcapPLayer4_rmin - SiTrackerEndcap_envelope_rmin_delta"
+          rmax="TrackerEndcapPLayer4_rmax + SiTrackerEndcap_envelope_rmax_delta"
+          length="SiTrackerEndcapLayer_thickness + SiTrackerEndcap_envelope_length_delta"
+          zstart="TrackerEndcapPLayer4_zmin - SiTrackerEndcap_envelope_length_delta/2"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="10"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="10"/>
         <ring
@@ -361,10 +365,10 @@
       </module>
       <layer id="2">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapNLayer2_rmin - 1*mm"
-          rmax="TrackerEndcapNLayer2_rmax + 1*mm"
-          length="SiTrackerEndcapLayer_thickness + 2*mm"
-          zstart="TrackerEndcapNLayer2_zmin - 1*mm"/>
+          rmin="TrackerEndcapNLayer2_rmin - SiTrackerEndcap_envelope_rmin_delta"
+          rmax="TrackerEndcapNLayer2_rmax + SiTrackerEndcap_envelope_rmax_delta"
+          length="SiTrackerEndcapLayer_thickness + SiTrackerEndcap_envelope_length_delta"
+          zstart="TrackerEndcapNLayer2_zmin - SiTrackerEndcap_envelope_length_delta/2"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="20"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="20"/>
         <ring
@@ -376,10 +380,10 @@
       </layer>
       <layer id="3">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapNLayer3_rmin - 1*mm"
-          rmax="TrackerEndcapNLayer3_rmax + 1*mm"
-          length="SiTrackerEndcapLayer_thickness + 2*mm"
-          zstart="TrackerEndcapNLayer3_zmin - 1*mm"/>
+          rmin="TrackerEndcapNLayer3_rmin - SiTrackerEndcap_envelope_rmin_delta"
+          rmax="TrackerEndcapNLayer3_rmax + SiTrackerEndcap_envelope_rmax_delta"
+          length="SiTrackerEndcapLayer_thickness + SiTrackerEndcap_envelope_length_delta"
+          zstart="TrackerEndcapNLayer3_zmin - SiTrackerEndcap_envelope_length_delta/2"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="20"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="20"/>
         <ring
@@ -391,10 +395,10 @@
       </layer>
       <layer id="4">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapNLayer4_rmin - 1*mm"
-          rmax="TrackerEndcapNLayer4_rmax + 1*mm"
-          length="SiTrackerEndcapLayer_thickness + 2*mm"
-          zstart="TrackerEndcapNLayer4_zmin - 1*mm"/>
+          rmin="TrackerEndcapNLayer4_rmin - SiTrackerEndcap_envelope_rmin_delta"
+          rmax="TrackerEndcapNLayer4_rmax + SiTrackerEndcap_envelope_rmax_delta"
+          length="SiTrackerEndcapLayer_thickness + SiTrackerEndcap_envelope_length_delta"
+          zstart="TrackerEndcapNLayer4_zmin - SiTrackerEndcap_envelope_length_delta/2"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="10"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="10"/>
         <ring

--- a/compact/tracking/silicon_disks.xml
+++ b/compact/tracking/silicon_disks.xml
@@ -73,10 +73,10 @@
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
-          rmin="InnerTrackerEndcapPLayer1_rmin"
-          rmax="InnerTrackerEndcapPLayer1_rmax"
-          length="SiTrackerEndcapLayer_thickness"
-          zstart="InnerTrackerEndcapPLayer1_zmin" />
+          rmin="InnerTrackerEndcapPLayer1_rmin - 1*mm"
+          rmax="InnerTrackerEndcapPLayer1_rmax + 1*mm"
+          length="SiTrackerEndcapLayer_thickness + 2*mm"
+          zstart="InnerTrackerEndcapPLayer1_zmin - 1*mm"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <ring
@@ -103,10 +103,10 @@
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
-          rmin="InnerTrackerEndcapNLayer1_rmin"
-          rmax="InnerTrackerEndcapNLayer1_rmax"
-          length="SiTrackerEndcapLayer_thickness"
-          zstart="InnerTrackerEndcapNLayer1_zmin" />
+          rmin="InnerTrackerEndcapNLayer1_rmin - 1*mm"
+          rmax="InnerTrackerEndcapNLayer1_rmax + 1*mm"
+          length="SiTrackerEndcapLayer_thickness + 2*mm"
+          zstart="InnerTrackerEndcapNLayer1_zmin - 1*mm"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <ring
@@ -217,10 +217,10 @@
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapPLayer1_rmin"
-          rmax="TrackerEndcapPLayer1_rmax"
-          length="SiTrackerEndcapLayer_thickness"
-          zstart="TrackerEndcapPLayer1_zmin" />
+          rmin="TrackerEndcapPLayer1_rmin - 1*mm"
+          rmax="TrackerEndcapPLayer1_rmax + 1*mm"
+          length="SiTrackerEndcapLayer_thickness + 2*mm"
+          zstart="TrackerEndcapPLayer1_zmin - 1*mm"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <ring
@@ -247,10 +247,10 @@
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapNLayer1_rmin"
-          rmax="TrackerEndcapNLayer1_rmax"
-          length="SiTrackerEndcapLayer_thickness"
-          zstart="TrackerEndcapNLayer1_zmin" />
+          rmin="TrackerEndcapNLayer1_rmin - 1*mm"
+          rmax="TrackerEndcapNLayer1_rmax + 1*mm"
+          length="SiTrackerEndcapLayer_thickness + 2*mm"
+          zstart="TrackerEndcapNLayer1_zmin - 1*mm"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="5*SiTrackerEndcapMod_count" bins1="100"/>
         <ring
@@ -289,10 +289,10 @@
       </module>
       <layer id="2">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapPLayer2_rmin"
-          rmax="TrackerEndcapPLayer2_rmax"
-          length="SiTrackerEndcapLayer_thickness"
-          zstart="TrackerEndcapPLayer2_zmin" />
+          rmin="TrackerEndcapPLayer2_rmin - 1*mm"
+          rmax="TrackerEndcapPLayer2_rmax + 1*mm"
+          length="SiTrackerEndcapLayer_thickness + 2*mm"
+          zstart="TrackerEndcapPLayer2_zmin - 1*mm"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="20"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="20"/>
         <ring
@@ -304,10 +304,10 @@
       </layer>
       <layer id="3">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapPLayer3_rmin"
-          rmax="TrackerEndcapPLayer3_rmax"
-          length="SiTrackerEndcapLayer_thickness"
-          zstart="TrackerEndcapPLayer3_zmin" />
+          rmin="TrackerEndcapPLayer3_rmin - 1*mm"
+          rmax="TrackerEndcapPLayer3_rmax + 1*mm"
+          length="SiTrackerEndcapLayer_thickness + 2*mm"
+          zstart="TrackerEndcapPLayer3_zmin - 1*mm"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="20"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="20"/>
         <ring
@@ -319,10 +319,10 @@
       </layer>
       <layer id="4">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapPLayer4_rmin"
-          rmax="TrackerEndcapPLayer4_rmax"
-          length="SiTrackerEndcapLayer_thickness"
-          zstart="TrackerEndcapPLayer4_zmin" />
+          rmin="TrackerEndcapPLayer4_rmin - 1*mm"
+          rmax="TrackerEndcapPLayer4_rmax + 1*mm"
+          length="SiTrackerEndcapLayer_thickness + 2*mm"
+          zstart="TrackerEndcapPLayer4_zmin - 1*mm"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="10"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="10"/>
         <ring
@@ -361,10 +361,10 @@
       </module>
       <layer id="2">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapNLayer2_rmin"
-          rmax="TrackerEndcapNLayer2_rmax"
-          length="SiTrackerEndcapLayer_thickness"
-          zstart="TrackerEndcapNLayer2_zmin" />
+          rmin="TrackerEndcapNLayer2_rmin - 1*mm"
+          rmax="TrackerEndcapNLayer2_rmax + 1*mm"
+          length="SiTrackerEndcapLayer_thickness + 2*mm"
+          zstart="TrackerEndcapNLayer2_zmin - 1*mm"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="20"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="20"/>
         <ring
@@ -376,10 +376,10 @@
       </layer>
       <layer id="3">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapNLayer3_rmin"
-          rmax="TrackerEndcapNLayer3_rmax"
-          length="SiTrackerEndcapLayer_thickness"
-          zstart="TrackerEndcapNLayer3_zmin" />
+          rmin="TrackerEndcapNLayer3_rmin - 1*mm"
+          rmax="TrackerEndcapNLayer3_rmax + 1*mm"
+          length="SiTrackerEndcapLayer_thickness + 2*mm"
+          zstart="TrackerEndcapNLayer3_zmin - 1*mm"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="20"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="20"/>
         <ring
@@ -391,10 +391,10 @@
       </layer>
       <layer id="4">
         <envelope vis="TrackerLayerVis"
-          rmin="TrackerEndcapNLayer4_rmin"
-          rmax="TrackerEndcapNLayer4_rmax"
-          length="SiTrackerEndcapLayer_thickness"
-          zstart="TrackerEndcapNLayer4_zmin" />
+          rmin="TrackerEndcapNLayer4_rmin - 1*mm"
+          rmax="TrackerEndcapNLayer4_rmax + 1*mm"
+          length="SiTrackerEndcapLayer_thickness + 2*mm"
+          zstart="TrackerEndcapNLayer4_zmin - 1*mm"/>
         <layer_material surface="inner" binning="binPhi,binR" bins0="12" bins1="10"/>
         <layer_material surface="outer" binning="binPhi,binR" bins0="12" bins1="10"/>
         <ring

--- a/configurations/craterlake_material_map.yml
+++ b/configurations/craterlake_material_map.yml
@@ -24,7 +24,11 @@ features:
     dirc:
     pfrich:
     drich:
-  far_forward:
-    default:
+  #far_forward:
+    # FIXME: disabled due to:
+    #   16:39:13    StraightLine   VERBOSE   Step with size 10000 performed. We are now at      -131706      -162867 -9.98943e+06 with direction -0.0131817 -0.0163004   -0.99978
+    #   16:39:13    StraightLine   VERBOSE   PathLimit aborter | Target stepSize (path limit) updated to ( +∞,  +∞,  +∞, 10000)
+    #   16:39:13    StraightLine   ERROR     Propagation reached the step count limit of 1000 (did 1000 steps)
+    #default:
   far_backward:
     default:

--- a/configurations/craterlake_material_map.yml
+++ b/configurations/craterlake_material_map.yml
@@ -15,8 +15,11 @@ features:
     silicon_disks:
     tof_barrel:
     tof_endcap:
-  ecal:
-    bic_layer1_only:
+  #ecal:
+    # FIXME: disabled due to:
+    #   Error in <TGeoVoxelFinder::SortAll>:
+    #   Wrong bounding box for volume envelope26
+    #bic_layer1_only:
   pid:
     dirc:
     pfrich:

--- a/scripts/material_map/epic.py
+++ b/scripts/material_map/epic.py
@@ -35,15 +35,11 @@ def getDetector(
             level=customLogLevel(maxLevel=acts.logging.INFO),
         )
 
-    dd4hepConfig = acts.examples.dd4hep.DD4hepGeometryService.Config(
+    dd4hepConfig = acts.examples.dd4hep.DD4hepDetector.Config(
         xmlFileNames=[xmlFile],
         logLevel=logLevel,
         dd4hepLogLevel=customLogLevel(),
     )
-    detector = acts.examples.dd4hep.DD4hepDetector()
+    detector = acts.examples.dd4hep.DD4hepDetector(dd4hepConfig)
 
-    config = acts.MaterialMapJsonConverter.Config()
-
-    trackingGeometry, deco = detector.finalize(dd4hepConfig, matDeco)
-
-    return detector, trackingGeometry, deco
+    return detector

--- a/scripts/material_map/geometry_epic.py
+++ b/scripts/material_map/geometry_epic.py
@@ -27,7 +27,9 @@ if "__main__" == __name__:
     )
     args = p.parse_args()
 
-    detector, trackingGeometry, decorators = epic.getDetector(args.xmlFile)
+    detector = epic.getDetector(args.xmlFile)
+    trackingGeometry = detector.trackingGeometry()
+    decorators = detector.contextDecorators()
 
     runGeometry(
         trackingGeometry,

--- a/scripts/material_map/material_mapping_epic.py
+++ b/scripts/material_map/material_mapping_epic.py
@@ -44,9 +44,10 @@ if "__main__" == __name__:
         print('ERROR(material_mapping_epic.py): please provide a material map file in .json or .cbor format')
         exit()
 
-    detector, trackingGeometry, decorators = epic.getDetector(
+    detector = epic.getDetector(
         args.xmlFile, args.geoFile)
-
+    trackingGeometry = detector.trackingGeometry()
+    decorators = detector.contextDecorators()
 
     runMaterialMapping(
         trackingGeometry,

--- a/scripts/material_map/material_recording_epic.py
+++ b/scripts/material_map/material_recording_epic.py
@@ -18,7 +18,6 @@ from acts.examples import (
 
 import acts.examples.dd4hep
 import acts.examples.geant4
-import acts.examples.geant4.dd4hep
 
 import epic
 from material_recording import runMaterialRecording
@@ -57,15 +56,11 @@ def main():
     )
     args = p.parse_args()
 
-    detector, trackingGeometry, decorators = epic.getDetector(
+    detector = epic.getDetector(
         args.xmlFile)
 
-    detectorConstructionFactory = (
-        acts.examples.geant4.dd4hep.DDG4DetectorConstructionFactory(detector)
-    )
-
     runMaterialRecording(
-        detectorConstructionFactory=detectorConstructionFactory,
+        detector=detector,
         tracksPerEvent=args.tracks,
         outputDir=os.getcwd(),
         etaRange=(args.eta_min, args.eta_max),

--- a/scripts/material_map/material_validation_epic.py
+++ b/scripts/material_map/material_validation_epic.py
@@ -50,7 +50,9 @@ if "__main__" == __name__:
 
     args = p.parse_args()
 
-    detector, trackingGeometry, decorators = epic.getDetector(args.xmlFile, args.matFile)
+    detector = epic.getDetector(args.xmlFile, args.matFile)
+    trackingGeometry = detector.trackingGeometry()
+    decorators = detector.contextDecorators()
 
     field = acts.ConstantBField(acts.Vector3(0, 0, 0))
 

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -42,7 +42,7 @@ diff -aru a/Examples/Scripts/MaterialMapping/Mat_map.C b/Examples/Scripts/Materi
 
      // 2D map for Validation input
      TCanvas *VM = new TCanvas("VM","Validation Map") ;
--    Val_file->Draw("mat_y:mat_z","fabs(mat_x)<1");
+-    Val_file->Draw("mat_y:mat_z","std::abs(mat_x)<1");
 +    Val_file->Draw("sqrt(mat_x**2+mat_y**2):mat_z>>mat_map1","(mat_z>-5000)&(mat_z<8000)");
 +    VM->SetGrid();
 

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -75,7 +75,7 @@ export ACTS_SEQUENCER_DISABLE_FPEMON=1
 #   nparticles=5000
 # but reduced to get the job to complete...
 nevents=100
-nparticles=500
+nparticles=100
 
 function print_the_help {
   echo "USAGE:    [--nevents <int>] [--nparticles <int>]"

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -11,7 +11,7 @@ if [[ -z ${DETECTOR_PATH} ]] ; then
 fi
 
 # Download required Acts files
-ACTS_VERSION="v36.3.2"
+ACTS_VERSION="v39.2.0"
 ACTS_URL="https://github.com/acts-project/acts/raw/"
 ACTS_FILES=(
   "Examples/Scripts/Python/geometry.py"

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -69,8 +69,13 @@ export PYTHONPATH=$PWD/Examples/Scripts/Python:$PYTHONPATH
 export ACTS_SEQUENCER_DISABLE_FPEMON=1
 
 # Default arguments
-nevents=1000
-nparticles=5000
+# FIXME
+# This was originally
+#   nevents=1000
+#   nparticles=5000
+# but reduced to get the job to complete...
+nevents=100
+nparticles=500
 
 function print_the_help {
   echo "USAGE:    [--nevents <int>] [--nparticles <int>]"

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -154,7 +154,8 @@ echo "::group::----MAPPING------------"
 #         material-maps_tracks.root(recorded steps from geantino, for validation purpose)
 sed -i 's/acts\.logging\.INFO/acts.logging.VERBOSE/g' Examples/Scripts/Python/material_mapping.py
 sed -i 's/navigator = Navigator($/&level=acts.logging.VERBOSE,/' Examples/Scripts/Python/material_mapping.py
-sed -i 's/propagator = Propagator(stepper, navigator/&, loglevel=acts.logging.VERBOSE/' Examples/Scripts/Python/material_mapping.py
+sed -i 's/propagator = Propagator(stepper, navigator)$/propagator = Propagator(stepper, navigator, loglevel=acts.logging.VERBOSE)/' Examples/Scripts/Python/material_mapping.py
+set -o pipefail
 python material_mapping_epic.py --xmlFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml --geoFile ${geoFile} --matFile ${matFile} | tail -n 5000
 echo "::endgroup::"
 

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -155,7 +155,7 @@ echo "::group::----MAPPING------------"
 sed -i 's/acts\.logging\.INFO/acts.logging.VERBOSE/g' Examples/Scripts/Python/material_mapping.py
 sed -i 's/navigator = Navigator($/&level=acts.logging.VERBOSE,/' Examples/Scripts/Python/material_mapping.py
 sed -i 's/propagator = Propagator(stepper, navigator/&, loglevel=acts.logging.VERBOSE/' Examples/Scripts/Python/material_mapping.py
-python material_mapping_epic.py --xmlFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml --geoFile ${geoFile} --matFile ${matFile} | tail -n 500
+python material_mapping_epic.py --xmlFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml --geoFile ${geoFile} --matFile ${matFile} | tail -n 5000
 echo "::endgroup::"
 
 echo "::group::----Prepare validation rootfile--------"

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -154,6 +154,7 @@ echo "::group::----MAPPING------------"
 #         material-maps_tracks.root(recorded steps from geantino, for validation purpose)
 sed -i 's/acts\.logging\.INFO/acts.logging.VERBOSE/g' Examples/Scripts/Python/material_mapping.py
 sed -i 's/navigator = Navigator($/&level=acts.logging.VERBOSE,/' Examples/Scripts/Python/material_mapping.py
+sed -i 's/propagator = Propagator(stepper, navigator/&, loglevel=acts.logging.VERBOSE/' Examples/Scripts/Python/material_mapping.py
 python material_mapping_epic.py --xmlFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml --geoFile ${geoFile} --matFile ${matFile} | tail -n 500
 echo "::endgroup::"
 

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -75,7 +75,7 @@ export ACTS_SEQUENCER_DISABLE_FPEMON=1
 #   nparticles=5000
 # but reduced to get the job to complete...
 nevents=100
-nparticles=100
+nparticles=500
 
 function print_the_help {
   echo "USAGE:    [--nevents <int>] [--nparticles <int>]"

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -156,7 +156,7 @@ sed -i 's/acts\.logging\.INFO/acts.logging.VERBOSE/g' Examples/Scripts/Python/ma
 sed -i 's/navigator = Navigator($/&level=acts.logging.VERBOSE,/' Examples/Scripts/Python/material_mapping.py
 sed -i 's/propagator = Propagator(stepper, navigator)$/propagator = Propagator(stepper, navigator, loglevel=acts.logging.VERBOSE)/' Examples/Scripts/Python/material_mapping.py
 set -o pipefail
-python material_mapping_epic.py --xmlFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml --geoFile ${geoFile} --matFile ${matFile} | tail -n 5000 || true
+python material_mapping_epic.py --xmlFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml --geoFile ${geoFile} --matFile ${matFile} | tail -n 5000
 echo "::endgroup::"
 
 echo "::group::----Prepare validation rootfile--------"

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -143,7 +143,8 @@ echo "::group::----MAPPING------------"
 # input: geant4_material_tracks.root, geometry-map.json
 # output: material-maps.json or cbor. This is the material map that you want to provide to EICrecon, i.e.  -Pacts:MaterialMap=XXX  .Please --matFile to specify the name and type
 #         material-maps_tracks.root(recorded steps from geantino, for validation purpose)
-python material_mapping_epic.py --xmlFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml --geoFile ${geoFile} --matFile ${matFile}
+sed -i 's/acts\.logging\.INFO/acts.logging.VERBOSE/g' Examples/Scripts/Python/material_mapping.py
+python material_mapping_epic.py --xmlFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml --geoFile ${geoFile} --matFile ${matFile} | tail -n 500
 echo "::endgroup::"
 
 echo "::group::----Prepare validation rootfile--------"

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -69,13 +69,8 @@ export PYTHONPATH=$PWD/Examples/Scripts/Python:$PYTHONPATH
 export ACTS_SEQUENCER_DISABLE_FPEMON=1
 
 # Default arguments
-# FIXME
-# This was originally
-#   nevents=1000
-#   nparticles=5000
-# but reduced to get the job to complete...
-nevents=100
-nparticles=500
+nevents=1000
+nparticles=5000
 
 function print_the_help {
   echo "USAGE:    [--nevents <int>] [--nparticles <int>]"

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -144,6 +144,7 @@ echo "::group::----MAPPING------------"
 # output: material-maps.json or cbor. This is the material map that you want to provide to EICrecon, i.e.  -Pacts:MaterialMap=XXX  .Please --matFile to specify the name and type
 #         material-maps_tracks.root(recorded steps from geantino, for validation purpose)
 sed -i 's/acts\.logging\.INFO/acts.logging.VERBOSE/g' Examples/Scripts/Python/material_mapping.py
+sed -i 's/navigator = Navigator(/&level=acts.logging.VERBOSE,/' Examples/Scripts/Python/material_mapping.py
 python material_mapping_epic.py --xmlFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml --geoFile ${geoFile} --matFile ${matFile} | tail -n 500
 echo "::endgroup::"
 

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -139,12 +139,21 @@ mkdir -p plots
 python Examples/Scripts/MaterialMapping/GeometryVisualisationAndMaterialHandling.py --geometry ${geoFile}
 echo "::endgroup::"
 
+echo "::group::----MAPPING Debugging-----"
+echo "Volumes by name:"
+jq -r '.Volumes.entries[] | "vol=\(.volume): \(.value.NAME)"' geometry-map.json
+echo "Volume surfaces:"
+jq -r '.Surfaces.entries[] | select(.boundary != null) | "vol=\(.volume)|bnd=\(.boundary): \(.value.type) \(.value.bounds.type) \(.value.bounds.values) rot=\(.value.transform.rotation) pos=\(.value.transform.translation)"' geometry-map.json
+echo "Layer surfaces:"
+jq -r '.Surfaces.entries[] | select(.volume < 40 and .layer != null) | "vol=\(.volume)|lay=\(.layer): \(.value.type) \(.value.bounds.type) \(.value.bounds.values) rot=\(.value.transform.rotation) pos=\(.value.transform.translation)"' geometry-map.json
+echo "::endgroup::"
+
 echo "::group::----MAPPING------------"
 # input: geant4_material_tracks.root, geometry-map.json
 # output: material-maps.json or cbor. This is the material map that you want to provide to EICrecon, i.e.  -Pacts:MaterialMap=XXX  .Please --matFile to specify the name and type
 #         material-maps_tracks.root(recorded steps from geantino, for validation purpose)
 sed -i 's/acts\.logging\.INFO/acts.logging.VERBOSE/g' Examples/Scripts/Python/material_mapping.py
-sed -i 's/navigator = Navigator(/&level=acts.logging.VERBOSE,/' Examples/Scripts/Python/material_mapping.py
+sed -i 's/navigator = Navigator($/&level=acts.logging.VERBOSE,/' Examples/Scripts/Python/material_mapping.py
 python material_mapping_epic.py --xmlFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml --geoFile ${geoFile} --matFile ${matFile} | tail -n 500
 echo "::endgroup::"
 

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -161,7 +161,7 @@ sed -i 's/acts\.logging\.INFO/acts.logging.VERBOSE/g' Examples/Scripts/Python/ma
 sed -i 's/navigator = Navigator($/&level=acts.logging.VERBOSE,/' Examples/Scripts/Python/material_mapping.py
 sed -i 's/propagator = Propagator(stepper, navigator)$/propagator = Propagator(stepper, navigator, loglevel=acts.logging.VERBOSE)/' Examples/Scripts/Python/material_mapping.py
 set -o pipefail
-python material_mapping_epic.py --xmlFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml --geoFile ${geoFile} --matFile ${matFile} | tail -n 5000
+python material_mapping_epic.py --xmlFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml --geoFile ${geoFile} --matFile ${matFile} | tail -n 5000 || true
 echo "::endgroup::"
 
 echo "::group::----Prepare validation rootfile--------"

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -71,6 +71,18 @@ export ACTS_SEQUENCER_DISABLE_FPEMON=1
 # Default arguments
 nevents=1000
 nparticles=5000
+
+function print_the_help {
+  echo "USAGE:    [--nevents <int>] [--nparticles <int>]"
+  echo "OPTIONAL ARGUMENTS:"
+  echo "          --nevents       Number of events (default: $nevents)"
+  echo "          --nparticles    Number of particles per event (default: $nparticles)"
+  echo "          -h,--help     Print this message"
+  echo ""
+  echo "  Run material map validation."
+  exit
+}
+
 while [[ $# -gt 1 ]]
 do
   key="$1"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR is a minimal set of changes to bring the validate-material-map workflow back from the dead. It disables BIC and B0 for now, but at least should get us back on the road.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: validate-material-map not working)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.