### PR TITLE
fix: re-enable B0 in material map

### DIFF
--- a/configurations/craterlake_material_map.yml
+++ b/configurations/craterlake_material_map.yml
@@ -24,11 +24,7 @@ features:
     dirc:
     pfrich:
     drich:
-  #far_forward:
-    # FIXME: disabled due to:
-    #   16:39:13    StraightLine   VERBOSE   Step with size 10000 performed. We are now at      -131706      -162867 -9.98943e+06 with direction -0.0131817 -0.0163004   -0.99978
-    #   16:39:13    StraightLine   VERBOSE   PathLimit aborter | Target stepSize (path limit) updated to ( +∞,  +∞,  +∞, 10000)
-    #   16:39:13    StraightLine   ERROR     Propagation reached the step count limit of 1000 (did 1000 steps)
-    #default:
+  far_forward:
+    default:
   far_backward:
     default:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR re-enables the B0 in the material map.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.