### PR TITLE
Add LightGuide and EndOfSectorBox lengths

### DIFF
--- a/compact/ecal/bic/bic.xml
+++ b/compact/ecal/bic/bic.xml
@@ -39,6 +39,15 @@
     <constant name="EcalBarrel_Calorimeter_offset"
       value="(EcalBarrel_Calorimeter_zmax - EcalBarrel_Calorimeter_zmin)/2.0"/>
 
+    <constant name="EcalBarrel_LightGuide_length"      value="5*cm"/>
+    <constant name="EcalBarrel_EndOfSectorBox_length"  value="12*cm"/>
+    <constant name="EcalBarrel_LightGuide_zmin"        value="EcalBarrel_Calorimeter_zmin + EcalBarrel_LightGuide_length"/>
+    <constant name="EcalBarrel_LightGuide_zmax"        value="EcalBarrel_Calorimeter_zmax + EcalBarrel_LightGuide_length"/>
+    <constant name="EcalBarrel_EndOfSectorBox_zmin"    value="EcalBarrel_Calorimeter_zmin + EcalBarrel_EndOfSectorBox_length"/>
+    <constant name="EcalBarrel_EndOfSectorBox_zmax"    value="EcalBarrel_Calorimeter_zmax + EcalBarrel_EndOfSectorBox_length"/>
+    <constant name="EcalBarrel_LightGuide_eGoing_posZ" value="-EcalBarrel_LightGuide_zmin"/>
+    <constant name="EcalBarrel_LightGuide_pGoing_posZ" value="EcalBarrel_LightGuide_zmax"/>
+
     <constant name="EcalBarrel_FrontSupportThickness" value="0.5*cm"/>
     <constant name="EcalBarrel_BackSupportThickness"  value="3*cm"/>
     <constant name="EcalBarrel_SiliconThickness"      value="500*um"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR is to add `LightGuild` and `EndOfSectorBox` lengths in `bic.xml`. Two position variables have also been added to be used in `SimCalorimeterHitProcessor` algorithm.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #954)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
