### PR TITLE
legacy polyhedron style type

### DIFF
--- a/compact/hcal/backward_template.xml
+++ b/compact/hcal/backward_template.xml
@@ -6,23 +6,18 @@
     <documentation>
       #### Material Thickness
     </documentation>
+
     <constant name="HcalEndcapNSteelThickness"          value="4.0 * cm"/>
-    <constant name="HcalEndcapNPolystyreneThickness" value="2.4 * cm"/>
-        <constant name="HcalEndcapNLayerGap"                    value="0.1 * cm"/> <!-- 2*thicker than LFHCAL -->
-
-        <constant name="HcalEndcapN_polyhedron_rmax"    value="251.444*cm"/>
-        <constant name="HcalEndcapN_segments_rmin"              value="19.9431*cm"/>
-        <constant name="HcalEndcapN_segments_rmax"              value="HcalEndcapN_rmax/(cos(180*deg/HcalEndcapN_CaloSides))"/>
-
+    <constant name="HcalEndcapNPolystyreneThickness"    value="2.4 * cm"/>
+    <constant name="HcalEndcapNLayerGap"                value="0.1 * cm"/> <!-- 2*thicker than LFHCAL -->
 
     <documentation>
       - Hcal Endcap N Layers and computed Thickness
     </documentation>
 
-    <constant name="HcalEndcapNSingleLayerThickness"
-             value="HcalEndcapNSteelThickness + HcalEndcapNPolystyreneThickness + HcalEndcapNLayerGap"/>
-    <constant name="HcalEndcapNLayer_NRepeat"   value="floor((HcalEndcapN_length + HcalEndcapN_extension_for_sampF) / HcalEndcapNSingleLayerThickness)"/>
-    <constant name="HcalEndcapN_thickness"              value="HcalEndcapNLayer_NRepeat * HcalEndcapNSingleLayerThickness"/>
+    <constant name="HcalEndcapNSingleLayerThickness" value="HcalEndcapNSteelThickness + HcalEndcapNPolystyreneThickness + HcalEndcapNLayerGap"/>
+    <constant name="HcalEndcapNLayer_NRepeat"        value="floor((HcalEndcapN_length + HcalEndcapN_extension_for_sampF) / HcalEndcapNSingleLayerThickness)"/>
+    <constant name="HcalEndcapN_thickness"           value="HcalEndcapNLayer_NRepeat * HcalEndcapNSingleLayerThickness"/>
   </define>
 
 
@@ -58,7 +53,7 @@
   <!--  Definition of the readout segmentation/definition  -->
   <readouts>
     <readout name="HcalEndcapNHits">
-                <segmentation type="CartesianGridXY" grid_size_x="100 * mm" grid_size_y ="100 * mm"/>
+                <segmentation type="CartesianGridXY" grid_size_x="100 * mm" grid_size_y="100 * mm"/>
         <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>
     </readout>
   </readouts>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Hi, I wanted to remove legacy calorimeter design features that are not used, in future also remake(+rename) `src/PolyhedraEndcapCalorimeter2_geo.cpp`
+ Removed space in < ... grid_size_y ="100 * mm"/> + visual formatting

### What kind of change does this PR introduce?
- [x] Documentation update