### PR TITLE
B0_tracker: set envelope_z_{min,max} to 1 mm

### DIFF
--- a/compact/far_forward/B0_tracker.xml
+++ b/compact/far_forward/B0_tracker.xml
@@ -112,7 +112,7 @@
       </module>
       <layer id="1">
         <envelope  vis="FFTrackerLayerVis" rmin_tolerance="0*mm" rmax_tolerance="0*mm"
-                   zmin_tolerance="0*mm" zmax_tolerance="0*mm" length="1.0*cm"
+                   zmin_tolerance="1*mm" zmax_tolerance="1*mm" length="1.0*cm"
                    zstart="B0TrackerLayer1_zstart" />
         <ring phi0="B0TrackerLayerBigMod_phi0" dphi="B0TrackerModOpeningAngle"
           r="B0TrackerMod1Inner_r+B0TrackerMod1_y/2.0" zstart="0.0*mm"
@@ -125,7 +125,7 @@
       </layer>
       <layer id="2" >
         <envelope vis="FFTrackerLayerVis" rmin_tolerance="0*mm" rmax_tolerance="0*mm"
-                  zmin_tolerance="0*mm" zmax_tolerance="0*mm" length="1.0*cm"
+                  zmin_tolerance="1*mm" zmax_tolerance="1*mm" length="1.0*cm"
                   zstart="B0TrackerLayer2_zstart" />
         <ring phi0="B0TrackerLayerBigMod_phi0" dphi="B0TrackerModOpeningAngle"
           r="B0TrackerMod1Inner_r+B0TrackerMod1_y/2.0" zstart="0.0*mm"
@@ -138,7 +138,7 @@
       </layer>
       <layer id="3" >
         <envelope vis="FFTrackerLayerVis" rmin_tolerance="0*mm" rmax_tolerance="0*mm"
-                  zmin_tolerance="0*mm" zmax_tolerance="0*mm" length="1.0*cm"
+                  zmin_tolerance="1*mm" zmax_tolerance="1*mm" length="1.0*cm"
                   zstart="B0TrackerLayer3_zstart" />
         <ring phi0="B0TrackerLayerBigMod_phi0" dphi="B0TrackerModOpeningAngle"
           r="B0TrackerMod1Inner_r+B0TrackerMod1_y/2.0" zstart="0.0*mm"
@@ -151,7 +151,7 @@
       </layer>
       <layer id="4" >
         <envelope vis="FFTrackerLayerVis" rmin_tolerance="0*mm" rmax_tolerance="0*mm"
-                  zmin_tolerance="0*cm" zmax_tolerance="0*cm" length="1.0*cm"
+                  zmin_tolerance="1*mm" zmax_tolerance="1*mm" length="1.0*cm"
                   zstart="B0TrackerLayer4_zstart" />
         <ring phi0="B0TrackerLayerBigMod_phi0" dphi="B0TrackerModOpeningAngle"
           r="B0TrackerMod1Inner_r+B0TrackerMod1_y/2.0" zstart="0.0*mm"

--- a/src/B0Tracker_geo.cpp
+++ b/src/B0Tracker_geo.cpp
@@ -53,7 +53,7 @@ static Ref_t create_B0Tracker(Detector& description, xml_h e, SensitiveDetector 
                                                     "boundary_material");
   }
 
-  assembly.setVisAttributes(description.invisible());
+  assembly.setVisAttributes("InvisibleWithDaughters");
   sens.setType("tracker");
 
   for (xml_coll_t mi(x_det, _U(module)); mi; ++mi, ++m_id) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Since update to Acts 39, @wdconinc had implemented several fixes to correct Acts routines used for automatic DD4hep to Acts surface conversion (https://github.com/acts-project/acts/pull/4496, https://github.com/acts-project/acts/pull/4502, https://github.com/acts-project/acts/pull/4620). Those patches were applied to Acts in our nightly containers since July, but we had to revert those for the stable releases because they were killing the B0 reconstruction as seen in before & after of the tracking_performance_dis benchmark:
<img width="920" height="327" alt="image" src="https://github.com/user-attachments/assets/3f9b69dc-2e76-45e0-b625-6acff81eb84b" />
Recent issue like #987 can take advantage of resolving some of the issues with Acts surface dimensions. We also need to make sure that EICrecon can advance to using the newer versions of Acts that include the patches.

It looks like the issue with broken tracking has to do with placement of "approach" surfaces. The surfaces are simple shapes (e.g. disk) that are supposed to enclose the actual sensitive surfaces to which hits belong. CKF tracking relies on being able to correctly visit sensitive surfaces that belong to those bins.

This schematic shows the coordinates of the surfaces in Acts 39 before all the fixes:
<img width="2000" height="1000" alt="before" src="https://github.com/user-attachments/assets/a3fa85aa-d071-4fb6-821f-ea53bebc53fd" />
and this is how they look with the patches
<img width="2000" height="1000" alt="nominal" src="https://github.com/user-attachments/assets/a91ec0ce-5688-4f21-ac8c-a9cf6d94e6f1" />
the issue is apparently is with how tight is the space between the surfaces.

One way to fix this is to see that current implementation of the geometry uses the Assembly volume associated with layer's DetElement and sets the dimensions of the layer via
https://github.com/eic/epic/blob/cf46b7c046d56dd57ff0df7e85fa6a03a03b2037/src/B0Tracker_geo.cpp#L229-L232
https://github.com/eic/epic/blob/cf46b7c046d56dd57ff0df7e85fa6a03a03b2037/compact/far_forward/B0_tracker.xml#L114-L115
https://github.com/eic/epic/blob/cf46b7c046d56dd57ff0df7e85fa6a03a03b2037/compact/far_forward/B0_tracker.xml#L127-L128
https://github.com/eic/epic/blob/cf46b7c046d56dd57ff0df7e85fa6a03a03b2037/compact/far_forward/B0_tracker.xml#L140-L141
https://github.com/eic/epic/blob/cf46b7c046d56dd57ff0df7e85fa6a03a03b2037/compact/far_forward/B0_tracker.xml#L153-L154
The zero-valued envelopes appear to be consistent with approach surfaces almost touching each other, it must be the right behaviour, and the setting is inadequate. This PR adjusts the envelope to 1 mm, which results in the following arrangement
<img width="2000" height="1000" alt="1mm" src="https://github.com/user-attachments/assets/fac14bd4-a8dd-462b-befe-31d900880864" />

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
