### PR TITLE
HOTFIX: run_material_map_validation.sh: revert to `patch` only

### DIFF
--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -53,8 +53,8 @@ EOF
     fi
   fi
 done
-curl --location  https://github.com/acts-project/acts/pull/4931.diff | patch -p1
-curl --location  https://github.com/acts-project/acts/pull/5046.diff | patch -p1
+curl --location https://github.com/acts-project/acts/pull/4931.diff | patch -p1
+curl --location https://github.com/acts-project/acts/pull/5046.diff | patch -p1
 export PYTHONPATH=$PWD/Examples/Scripts/Python:$PYTHONPATH
 
 # FIXME


### PR DESCRIPTION
`git patch` silently fails when can't apply the patch (this appears to be the case on CI)