### PR TITLE
HOTFIX: cmake: require at least IRT 2.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ include(GNUInstallDirs)
 # Dependencies
 find_package(DD4hep 1.27 REQUIRED COMPONENTS DDCore DDRec)
 find_package(fmt REQUIRED)
-find_package(IRT2)
+find_package(IRT2 2.1.1)
 
 #-----------------------------------------------------------------------------------
 set(a_lib_name ${PROJECT_NAME})


### PR DESCRIPTION
2.1.1 is the first version with `CherenkovDetectorCollection` support, which is needed for epic to compile.

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No