### PR TITLE
feat: use BoundedMultipoleMagnet with AABB pre-filter to MultipoleMagnet

### DIFF
--- a/compact/far_backward/lumi/lumi_magnets.xml
+++ b/compact/far_backward/lumi/lumi_magnets.xml
@@ -81,14 +81,14 @@ Construct the sweeper and analyzer dipole magnets for the luminosity subsystem.
 
     <comment> Ideal fields </comment>
     <comment>
-    <field name="LumiSweeperField" type="MultipoleMagnet">
+    <field name="LumiSweeperField" type="BoundedMultipoleMagnet">
       <position x="LumiSweepMag_X" y="LumiSweepMag_Y" z="LumiSweepMag_Z"/>
       <rotation x="0" y="0" z="0"/>
       <shape type="Box" dx="LumiMag_DX_InnerBox/2.0" dy="LumiMag_DY_InnerBox/2.0" dz="LumiMagMainBody_DZ/2.0"/>
       <coefficient coefficient="0" skew="LumiSweepIdealMag_B"/>
     </field>
 
-    <field name="LumiAnalyzerField" type="MultipoleMagnet">
+    <field name="LumiAnalyzerField" type="BoundedMultipoleMagnet">
       <position x="LumiAnalyzerMag_X" y="LumiAnalyzerMag_Y" z="LumiAnalyzerMag_Z"/>
       <rotation x="0" y="0" z="0"/>
       <shape type="Box" dx="LumiMag_DX_InnerBox/2.0" dy="LumiMag_DY_InnerBox/2.0" dz="LumiMagMainBody_DZ/2.0"/>

--- a/compact/far_backward/magnets.xml
+++ b/compact/far_backward/magnets.xml
@@ -476,21 +476,21 @@
 
     <comment> Magnetic fields </comment>
 
-    <field name="Magnet_Q1eR_Field" type="MultipoleMagnet">
+    <field name="Magnet_Q1eR_Field" type="BoundedMultipoleMagnet">
       <shape type="Tube" rmax="Q1eR_InnerRadius" dz="Q1eR_Length/2"/>
       <position x="0" y="0" z="Q1eR_CenterPosition"/>
       <coefficient/>
       <coefficient coefficient="Q1eR_Gradient"/>
     </field>
 
-    <field name="Magnet_Q2eR_Field" type="MultipoleMagnet">
+    <field name="Magnet_Q2eR_Field" type="BoundedMultipoleMagnet">
       <shape type="Tube" rmax="Q2eR_InnerRadius" dz="Q2eR_Length/2"/>
       <position x="0" y="0" z="Q2eR_CenterPosition"/>
       <coefficient/>
       <coefficient coefficient="Q2eR_Gradient"/>
     </field>
 
-    <field name="Magnet_Q3eR_Field" type="MultipoleMagnet">
+    <field name="Magnet_Q3eR_Field" type="BoundedMultipoleMagnet">
       <shape type="Tube" rmax="Q3eR_InnerRadius" dz="Q3eR_Length/2"/>
       <position x="Q3eR_XPosition" y="0" z="Q3eR_CenterPosition"/>
       <rotation x="0" y="Q3eR_Theta" z="0"/>
@@ -498,13 +498,13 @@
       <coefficient coefficient="Q3eR_Gradient"/>
     </field>
 
-    <field name="Magnet_B2AeR_Field" type="MultipoleMagnet">
+    <field name="Magnet_B2AeR_Field" type="BoundedMultipoleMagnet">
       <shape type="Tube" rmax="B2AeR_InnerRadius" dz="B2AeR_Length/2"/>
       <position x="0" y="0" z="B2AeR_CenterPosition"/>
       <coefficient coefficient="B2AeR_B"/>
     </field>
 
-    <field name="Magnet_B2BeR_Field" type="MultipoleMagnet">
+    <field name="Magnet_B2BeR_Field" type="BoundedMultipoleMagnet">
       <shape type="Tube" rmax="B2BeR_InnerRadius" dz="B2BeR_Length/2"/>
       <position x="0" y="0" z="B2BeR_CenterPosition"/>
       <coefficient coefficient="B2BeR_B"/>

--- a/compact/far_forward/electron_beamline.xml
+++ b/compact/far_forward/electron_beamline.xml
@@ -99,7 +99,7 @@
   <fields>
 
     <!-- Q0eF quadrupole field -->
-    <field name="Q0EF_field" type="MultipoleMagnet">
+    <field name="Q0EF_field" type="BoundedMultipoleMagnet">
       <shape type="Tube" rmax="Q0EF_InnerRadius" dz="(Q0EF_StartZ-Q0EF_EndZ)/2."/>
       <position x="0" y="0" z="(Q0EF_StartZ+Q0EF_EndZ)/2."/>
       <coefficient/>
@@ -107,7 +107,7 @@
     </field>
 
     <!-- Q1eF quadrupole field -->
-    <field name="Q1EF_field" type="MultipoleMagnet">
+    <field name="Q1EF_field" type="BoundedMultipoleMagnet">
       <shape type="Tube" rmax="Q1EF_InnerRadius" dz="(Q1EF_StartZ-Q1EF_EndZ)/2."/>
       <position x="0" y="0" z="(Q1EF_StartZ+Q1EF_EndZ)/2."/>
       <coefficient/>

--- a/compact/far_forward/magnets.xml
+++ b/compact/far_forward/magnets.xml
@@ -3,56 +3,56 @@
 
 <lccdd>
   <fields>
-    <field name="B0PF_Magnet" type="MultipoleMagnet">
+    <field name="B0PF_Magnet" type="BoundedMultipoleMagnet">
       <position x="B0PF_XPosition" y="0" z="B0PF_CenterPosition"/>
       <rotation x="0" y="B0PF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="B0PF_InnerRadius" dz="B0PF_Length*0.5"/>
       <coefficient coefficient="B0PF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
       <coefficient coefficient="B0PF_GradientMax*FieldScaleFactor" skew="0.0*tesla/m"/>
     </field>
-    <field name="B0APF_Magnet" type="MultipoleMagnet">
+    <field name="B0APF_Magnet" type="BoundedMultipoleMagnet">
       <position x="B0APF_XPosition" y="0" z="B0APF_CenterPosition"/>
       <rotation x="0" y="B0APF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="B0APF_InnerRadius" dz="B0APF_Length*0.5"/>
       <coefficient coefficient="B0APF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
           <coefficient coefficient="B0APF_GradientMax*FieldScaleFactor" skew="0.0*tesla"/>
     </field>
-    <field name="Q1APF_Magnet" type="MultipoleMagnet">
+    <field name="Q1APF_Magnet" type="BoundedMultipoleMagnet">
       <position x="Q1APF_XPosition" y="0" z="Q1APF_CenterPosition"/>
       <rotation x="0" y="Q1APF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="Q1APF_InnerRadius" dz="Q1APF_Length*0.5"/>
       <coefficient coefficient="Q1APF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
       <coefficient coefficient="Q1APF_GradientMax*FieldScaleFactor" skew="0.0*tesla/m"/>
     </field>
-    <field name="Q1BPF_Magnet" type="MultipoleMagnet">
+    <field name="Q1BPF_Magnet" type="BoundedMultipoleMagnet">
       <position x="Q1BPF_XPosition" y="0" z="Q1BPF_CenterPosition"/>
       <rotation x="0" y="Q1BPF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="Q1BPF_InnerRadius" dz="Q1BPF_Length*0.5"/>
       <coefficient coefficient="Q1BPF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
       <coefficient coefficient="Q1BPF_GradientMax*FieldScaleFactor" skew="0.0*tesla/m"/>
     </field>
-    <field name="Q2PF_Magnet" type="MultipoleMagnet">
+    <field name="Q2PF_Magnet" type="BoundedMultipoleMagnet">
       <position x="Q2PF_XPosition" y="0" z="Q2PF_CenterPosition"/>
       <rotation x="0" y="Q2PF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="Q2PF_InnerRadius" dz="Q2PF_Length*0.5"/>
       <coefficient coefficient="Q2PF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
       <coefficient coefficient="Q2PF_GradientMax*FieldScaleFactor" skew="0.0*tesla/m"/>
     </field>
-    <field name="B1PF_Magnet" type="MultipoleMagnet">
+    <field name="B1PF_Magnet" type="BoundedMultipoleMagnet">
       <position x="B1PF_XPosition" y="0" z="B1PF_CenterPosition"/>
       <rotation x="0" y="B1PF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="B1PF_InnerRadius" dz="B1PF_Length*0.5"/>
       <coefficient coefficient="B1PF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
           <coefficient coefficient="B1PF_GradientMax*FieldScaleFactor" skew="0.0*tesla/m"/>
     </field>
-    <field name="B1APF_Magnet" type="MultipoleMagnet">
+    <field name="B1APF_Magnet" type="BoundedMultipoleMagnet">
       <position x="B1APF_XPosition" y="0" z="B1APF_CenterPosition"/>
       <rotation x="0" y="B1APF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="B1APF_InnerRadius" dz="B1APF_Length*0.5"/>
       <coefficient coefficient="B1APF_Bmax*FieldScaleFactor" skew="0.0*tesla"/>
           <coefficient coefficient="B1APF_GradientMax*FieldScaleFactor" skew="0.0*tesla/m"/>
     </field>
-    <field name="B2PF_Magnet" type="MultipoleMagnet">
+    <field name="B2PF_Magnet" type="BoundedMultipoleMagnet">
       <position x="B2PF_XPosition" y="0" z="B2PF_CenterPosition"/>
       <rotation x="0" y="B2PF_RotationAngle" z="0"/>
       <shape type="Tube" rmin="0.0" rmax="B2PF_InnerRadius" dz="B2PF_Length*0.5"/>

--- a/src/BoundedMultipoleMagnet.cpp
+++ b/src/BoundedMultipoleMagnet.cpp
@@ -12,9 +12,9 @@
  *  work is skipped for the vast majority of tracks that are nowhere near the
  *  far-forward magnets.
  *
- *  Usage – replace `type="MultipoleMagnet"` with `type="epic_BoundedMultipoleMagnet"`:
+ *  Usage – replace `type="MultipoleMagnet"` with `type="BoundedMultipoleMagnet"`:
  *  \code
- *  <field name="B0PF_Magnet" type="epic_BoundedMultipoleMagnet">
+ *  <field name="B0PF_Magnet" type="BoundedMultipoleMagnet">
  *    <position x="..." y="0" z="..."/>
  *    <rotation x="0" y="..." z="0"/>
  *    <shape type="Tube" rmin="0" rmax="..." dz="..."/>
@@ -71,11 +71,13 @@ static Ref_t create_bounded_multipole_magnet(Detector& det, xml::Handle_t handle
   // 2. Derive a tight AABB in world (global) coordinates from the parsed state.
   //
   //    The transform translation is in DD4hep/Geant4 units (mm).
-  //    TGeoShape accessors (GetDz, GetRmax) return ROOT units (cm); multiply
-  //    by dd4hep::cm (= 10) to convert to mm.
+  //    TGeoShape accessors return ROOT units (cm); multiply by dd4hep::cm (= 10) to convert to mm.
   //
   //    For a cylinder with half-length dz, radius r, and world-frame axis d:
-  //      AABB half-extent_i = dz·|d_i| + r·√(1 − d_i²)
+  //      AABB half-extent_i = dz*|d_i| + r*sqrt(1 - d_i^2)
+  //
+  //    For a box with half-extents (dx, dy, dz_b) and rotation matrix R:
+  //      AABB half-extent_i = |R[i,0]|*dx + |R[i,1]|*dy + |R[i,2]|*dz_b
 
   double xmin, xmax, ymin, ymax, zmin, zmax;
 
@@ -83,20 +85,44 @@ static Ref_t create_bounded_multipole_magnet(Detector& det, xml::Handle_t handle
     Position center;
     mf->transform.GetTranslation(center); // world-frame center, mm
 
-    ROOT::Math::XYZVector axis =
-        mf->rotation * ROOT::Math::XYZVector(0, 0, 1); // world-frame tube axis (unit vector)
+    double hx, hy, hz;
+    std::string shape_class = mf->volume.ptr()->ClassName();
 
-    // Shape dimensions: ROOT cm → DD4hep mm
-    Tube tube_shape(mf->volume);
-    double r  = tube_shape.rMax() * dd4hep::cm;
-    double dz = tube_shape.dZ() * dd4hep::cm;
+    if (shape_class == "TGeoTubeSeg" || shape_class == "TGeoTube") {
+      // Tube: AABB via cylinder extent formula
+      ROOT::Math::XYZVector axis =
+          mf->rotation * ROOT::Math::XYZVector(0, 0, 1); // world-frame tube axis (unit vector)
 
-    auto half_extent = [&](double d_i) {
-      return dz * std::abs(d_i) + r * std::sqrt(std::max(0.0, 1.0 - d_i * d_i));
-    };
-    double hx = half_extent(axis.X());
-    double hy = half_extent(axis.Y());
-    double hz = half_extent(axis.Z());
+      // Shape dimensions: ROOT cm -> DD4hep mm
+      Tube tube_shape(mf->volume);
+      double r  = tube_shape.rMax() * dd4hep::cm;
+      double dz = tube_shape.dZ() * dd4hep::cm;
+
+      auto half_extent = [&](double d_i) {
+        return dz * std::abs(d_i) + r * std::sqrt(std::max(0.0, 1.0 - d_i * d_i));
+      };
+      hx = half_extent(axis.X());
+      hy = half_extent(axis.Y());
+      hz = half_extent(axis.Z());
+
+    } else if (shape_class == "TGeoBBox") {
+      // Box: AABB via rotation-matrix abs-sum formula
+      Box box_shape(mf->volume);
+      double dx   = box_shape.x() * dd4hep::cm; // half-length x, mm
+      double dy   = box_shape.y() * dd4hep::cm; // half-length y, mm
+      double dz_b = box_shape.z() * dd4hep::cm; // half-length z, mm
+
+      double xx, xy, xz, yx, yy, yz, zx, zy, zz;
+      mf->rotation.GetComponents(xx, xy, xz, yx, yy, yz, zx, zy, zz);
+      hx = std::abs(xx) * dx + std::abs(xy) * dy + std::abs(xz) * dz_b;
+      hy = std::abs(yx) * dx + std::abs(yy) * dy + std::abs(yz) * dz_b;
+      hz = std::abs(zx) * dx + std::abs(zy) * dy + std::abs(zz) * dz_b;
+
+    } else {
+      throw std::runtime_error("BoundedMultipoleMagnet: unsupported shape type '" + shape_class +
+                               "' for field '" + xml_comp_t(handle).nameStr() +
+                               "'; only Tube and Box are supported");
+    }
 
     xmin = center.X() - hx;
     xmax = center.X() + hx;

--- a/src/BoundedMultipoleMagnet.cpp
+++ b/src/BoundedMultipoleMagnet.cpp
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Wouter Deconinck
+
+/** \addtogroup Fields
+ *  \brief Multipole magnet field with an axis-aligned bounding-box (AABB) pre-filter.
+ *
+ *  Drop-in replacement for DD4hep's built-in `MultipoleMagnet` field type.
+ *  The upstream factory parses `<position>`, `<rotation>`, `<shape>`, and
+ *  `<coefficient>` from the compact XML unchanged.  Before delegating to the
+ *  full tube-containment check and multipole calculation, a cheap rectangular
+ *  AABB test in global coordinates is applied so that the expensive per-step
+ *  work is skipped for the vast majority of tracks that are nowhere near the
+ *  far-forward magnets.
+ *
+ *  Usage – replace `type="MultipoleMagnet"` with `type="epic_BoundedMultipoleMagnet"`:
+ *  \code
+ *  <field name="B0PF_Magnet" type="epic_BoundedMultipoleMagnet">
+ *    <position x="..." y="0" z="..."/>
+ *    <rotation x="0" y="..." z="0"/>
+ *    <shape type="Tube" rmin="0" rmax="..." dz="..."/>
+ *    <coefficient coefficient="..." skew="..."/>
+ *  </field>
+ *  \endcode
+ */
+
+#include <DD4hep/DetFactoryHelper.h>
+#include <DD4hep/FieldTypes.h>
+#include <DD4hep/Plugins.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Shapes.h>
+
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+using namespace dd4hep;
+
+// ---------------------------------------------------------------------------
+
+/** Multipole field that skips evaluation outside a world-axis-aligned bounding box.
+ *
+ *  Inherits all multipole state from dd4hep::MultipoleField.  The six AABB
+ *  limits are set by the factory function and never change afterwards.
+ */
+class BoundedMultipoleField : public MultipoleField {
+public:
+  double xmin{0}, xmax{0}, ymin{0}, ymax{0}, zmin{0}, zmax{0};
+
+  BoundedMultipoleField() : MultipoleField() {}
+
+  virtual void fieldComponents(const double* pos, double* field) override {
+    if (pos[0] < xmin || pos[0] > xmax || pos[1] < ymin || pos[1] > ymax || pos[2] < zmin ||
+        pos[2] > zmax)
+      return;
+    MultipoleField::fieldComponents(pos, field);
+  }
+};
+
+// ---------------------------------------------------------------------------
+
+static Ref_t create_bounded_multipole_magnet(Detector& det, xml::Handle_t handle) {
+
+  // 1. Let the upstream MultipoleMagnet factory handle all XML parsing
+  //    (position, rotation, shape, coefficients → transform/inverse/rotation/volume/B_z).
+  NamedObject* obj = PluginService::Create<NamedObject*>("MultipoleMagnet", &det, &handle);
+  auto* mf         = dynamic_cast<MultipoleField*>(obj);
+  if (!mf)
+    throw std::runtime_error(
+        "BoundedMultipoleMagnet: upstream MultipoleMagnet factory returned null or wrong type");
+
+  // 2. Derive a tight AABB in world (global) coordinates from the parsed state.
+  //
+  //    The transform translation is in DD4hep/Geant4 units (mm).
+  //    TGeoShape accessors (GetDz, GetRmax) return ROOT units (cm); multiply
+  //    by dd4hep::cm (= 10) to convert to mm.
+  //
+  //    For a cylinder with half-length dz, radius r, and world-frame axis d:
+  //      AABB half-extent_i = dz·|d_i| + r·√(1 − d_i²)
+
+  double xmin, xmax, ymin, ymax, zmin, zmax;
+
+  if (mf->volume.isValid()) {
+    Position center;
+    mf->transform.GetTranslation(center); // world-frame center, mm
+
+    ROOT::Math::XYZVector axis =
+        mf->rotation * ROOT::Math::XYZVector(0, 0, 1); // world-frame tube axis (unit vector)
+
+    // Shape dimensions: ROOT cm → DD4hep mm
+    Tube tube_shape(mf->volume);
+    double r  = tube_shape.rMax() * dd4hep::cm;
+    double dz = tube_shape.dZ() * dd4hep::cm;
+
+    auto half_extent = [&](double d_i) {
+      return dz * std::abs(d_i) + r * std::sqrt(std::max(0.0, 1.0 - d_i * d_i));
+    };
+    double hx = half_extent(axis.X());
+    double hy = half_extent(axis.Y());
+    double hz = half_extent(axis.Z());
+
+    xmin = center.X() - hx;
+    xmax = center.X() + hx;
+    ymin = center.Y() - hy;
+    ymax = center.Y() + hy;
+    zmin = center.Z() - hz;
+    zmax = center.Z() + hz;
+
+    printout(DEBUG, "BoundedMultipoleMagnet",
+             "%s  AABB  x[%.1f,%.1f]  y[%.1f,%.1f]  z[%.1f,%.1f] mm",
+             xml_comp_t(handle).nameStr().c_str(), xmin, xmax, ymin, ymax, zmin, zmax);
+  } else {
+    // No bounding shape: disable the pre-filter (field valid everywhere, same as upstream)
+    printout(WARNING, "BoundedMultipoleMagnet",
+             "%s has no bounding shape; AABB pre-filter disabled",
+             xml_comp_t(handle).nameStr().c_str());
+    constexpr double inf = std::numeric_limits<double>::infinity();
+    xmin = ymin = zmin = -inf;
+    xmax = ymax = zmax = +inf;
+  }
+
+  // 3. Move parsed data into a BoundedMultipoleField.
+  //    All MultipoleField public members are copied; the private `flag` and
+  //    `translation` members are left at their zero-initialised defaults and
+  //    will be lazily populated on the first fieldComponents() call.
+  auto* bounded        = new BoundedMultipoleField();
+  bounded->field_type  = mf->field_type;
+  bounded->coefficents = mf->coefficents;
+  bounded->skews       = mf->skews;
+  bounded->volume      = mf->volume;
+  bounded->transform   = mf->transform;
+  bounded->inverse     = mf->inverse;
+  bounded->rotation    = mf->rotation;
+  bounded->B_z         = mf->B_z;
+  delete mf; // temporary; not registered with the Detector
+
+  bounded->xmin = xmin;
+  bounded->xmax = xmax;
+  bounded->ymin = ymin;
+  bounded->ymax = ymax;
+  bounded->zmin = zmin;
+  bounded->zmax = zmax;
+
+  CartesianField field;
+  field.assign(bounded, xml_comp_t(handle).nameStr(), "BoundedMultipoleMagnet");
+  return field;
+}
+
+DECLARE_XMLELEMENT(BoundedMultipoleMagnet, create_bounded_multipole_magnet)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds a pre-filter to the MultipoleMagnet to apply  an axis-aligned bounding box. This avoids expensive rotated r-z Tube::Contains evaluation in many cases, in particular since our fields are all added in an OverlayField, and assigned to the global field manager (i.e. evaluate for the far forward and far backward regions for every particle in the EM calorimeter showers).

Profiling indicates we spend 30% of the total ddsim (no optical photons) simulation time (for DIS 18x275 Q2>1000) in dd4hep::MultipoleField::fieldComponents, of which 25% (of the total simulation time) in the Tube::Contains (this is based on callgrind). This PR aims to address that (more profiling below).

Other options considered:
- assigning the multipole fields to a geometry volume so we only need to evaluate them when inside those: discarded since it doesn't handle the stray fields in the gaps between magnets well (and I think @ajentsch once said that's important).
- placing the entire far forward and far backward regions inside their own volume (not assembly as currently): discarded since this would require changes to the geometry structure and a clean interface between inside/outside these volumes, which is hard to do without clear axis-aligned boundaries.

Comparing profiling in the ctree artifacts (for DIS 10x100 Q2 > 1000 this time, sorry), we see the total time of simulation go from 822s to 768s. The time in dd4hep::MultipoleField::fieldComponents (in the various places in the call tree where it is called) goes from 45+5+6+4s to 12+1+1+1s, for a 6% speed increase.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: MultipoleMagnet is performance hog)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.