### PR TITLE
feat(ci): reapply of capybara pages deployment and fix issues

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -666,7 +666,7 @@ jobs:
     steps:
     - uses: actions/upload-artifact/merge@v7
       with:
-        name: capybara
+        name: capybara-report
         pattern: |
           *.capy
         delete-merged: true
@@ -688,7 +688,7 @@ jobs:
         with:
           commit: ${{ matrix.head_sha }}
           path: publishing_docs/pr/${{ matrix.pr }}/capybara/
-          name: capybara
+          name: capybara-report
           workflow: ".github/workflows/linux-eic-shell.yml"
           workflow_conclusion: "completed"
           if_no_artifact_found: ignore
@@ -696,7 +696,7 @@ jobs:
         uses: actions/download-artifact@v8
         if: github.event.pull_request.number == matrix.pr
         with:
-          name: capybara
+          name: capybara-report
           path: publishing_docs/pr/${{ matrix.pr }}/capybara/
       - uses: actions/upload-artifact@v7
         with:
@@ -719,7 +719,7 @@ jobs:
         with:
           branch: main
           path: publishing_docs/capybara/
-          name: capybara
+          name: capybara-report
           workflow: ".github/workflows/linux-eic-shell.yml"
           workflow_conclusion: "completed"
           if_no_artifact_found: ignore
@@ -727,7 +727,7 @@ jobs:
         uses: actions/download-artifact@v8
         if: github.ref_name == 'main'
         with:
-          name: capybara
+          name: capybara-report
           path: publishing_docs/capybara/
       - name: Populate capybara summary (on main)
         if: github.ref_name == 'main' || steps.download_capybara.outputs.found_artifact == 'true'

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -523,7 +523,7 @@ jobs:
     - dawn-view
     - dawn-view-slices
     if: |
-      always() && 
+      always() &&
       (needs.dawn-view.result == 'success') &&
       (needs.dawn-view-slices.result == 'success' || needs.dawn-view-slices.result == 'skipped')
     strategy:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -755,6 +755,10 @@ jobs:
     - merge-dawn-view
     - get-docs-from-open-prs
     - get-docs-from-main
+    if: |
+      always() &&
+      !cancelled() &&
+      !failure()
     steps:
     - name: Checkout jekyll page
       uses: actions/checkout@v6
@@ -802,6 +806,10 @@ jobs:
   deploy-artifacts-page:
     needs:
     - build-artifacts-page
+    if: |
+      always() &&
+      !cancelled() &&
+      !failure()
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -793,8 +793,9 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       run: |
         echo "### Capybara summary for PR ${{ github.event.pull_request.number }}" >> capybara_${{ github.event.pull_request.number }}.md
-        find _site/pr/${{ github.event.pull_request.number }}/capybara/ -mindepth 1 -maxdepth 1 -type d -printf \
-          "- [%f](https://eicrecon.epic-eic.org/pr/${{ github.event.pull_request.number }}/capybara/%f/index.html)\n" | sort >> capybara_${{ github.event.pull_request.number }}.md
+        [ -d _site/pr/${{ github.event.pull_request.number }}/capybara/ ] && \
+          find _site/pr/${{ github.event.pull_request.number }}/capybara/ -mindepth 1 -maxdepth 1 -type d -printf \
+            "- [%f](https://eicrecon.epic-eic.org/pr/${{ github.event.pull_request.number }}/capybara/%f/index.html)\n" | sort >> capybara_${{ github.event.pull_request.number }}.md || true
         echo "<sup><sub>Last updated $(TZ=America/New_York date -Iminutes) ${{github.event.pull_request.head.sha}}</sub></sup>" >> capybara_${{ github.event.pull_request.number }}.md
     - name: Create capybara step summary
       if: ${{ github.event_name == 'pull_request' }}
@@ -825,6 +826,7 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
+      continue-on-error: true
       uses: actions/deploy-pages@v5
     - name: Find capybara comment
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -746,6 +746,7 @@ jobs:
           name: github-pages-staging-main
           path: publishing_docs/
           if-no-files-found: error
+          include-hidden-files: true
 
   build-artifacts-page:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -522,6 +522,10 @@ jobs:
     needs:
     - dawn-view
     - dawn-view-slices
+    if: |
+      always() && 
+      (needs.dawn-view.result == 'success') &&
+      (needs.dawn-view-slices.result == 'success' || needs.dawn-view-slices.result == 'skipped')
     strategy:
       matrix:
         detector_config: [epic_craterlake]

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -662,10 +662,84 @@ jobs:
     steps:
     - uses: actions/upload-artifact/merge@v7
       with:
-        name: capybara-report
+        name: capybara
         pattern: |
           *.capy
         delete-merged: true
+
+  get-docs-from-open-prs:
+    runs-on: ubuntu-latest
+    needs:
+      - list-open-prs
+      - merge-npsim-capybara
+    strategy:
+      matrix: ${{ fromJSON(needs.list-open-prs.outputs.json) }}
+      fail-fast: false
+      max-parallel: 4
+    steps:
+      - name: Download capybara artifact (other PRs)
+        id: download_capybara
+        uses: dawidd6/action-download-artifact@v20
+        if: github.event.pull_request.number != matrix.pr
+        with:
+          commit: ${{ matrix.head_sha }}
+          path: publishing_docs/pr/${{ matrix.pr }}/capybara/
+          name: capybara
+          workflow: ".github/workflows/linux-eic-shell.yml"
+          workflow_conclusion: "completed"
+          if_no_artifact_found: ignore
+      - name: Download capybara artifact (this PR)
+        uses: actions/download-artifact@v8
+        if: github.event.pull_request.number == matrix.pr
+        with:
+          name: capybara
+          path: publishing_docs/pr/${{ matrix.pr }}/capybara/
+      - uses: actions/upload-artifact@v7
+        with:
+          name: github-pages-staging-pr-${{ matrix.pr }}
+          path: publishing_docs/
+          if-no-files-found: ignore
+
+  get-docs-from-main:
+    runs-on: ubuntu-latest
+    needs:
+      - merge-npsim-capybara
+    steps:
+      # Note:
+      # - If we run this on a non-main branch, we download from main with action-download-artifact.
+      # - If we run this on the main branch, we have to download from this pipeline with download-artifact.
+      - name: Download capybara artifact (in PR)
+        id: download_capybara
+        uses: dawidd6/action-download-artifact@v20
+        if: github.ref_name != 'main'
+        with:
+          branch: main
+          path: publishing_docs/capybara/
+          name: capybara
+          workflow: ".github/workflows/linux-eic-shell.yml"
+          workflow_conclusion: "completed"
+          if_no_artifact_found: ignore
+      - name: Download capybara artifact (on main)
+        uses: actions/download-artifact@v8
+        if: github.ref_name == 'main'
+        with:
+          name: capybara
+          path: publishing_docs/capybara/
+      - name: Populate capybara summary (on main)
+        if: github.ref_name == 'main' || steps.download_capybara.outputs.found_artifact == 'true'
+        run: |
+         echo "### Capybara summary for main" >> publishing_docs/capybara/index.md
+         find publishing_docs/capybara/ -mindepth 1 -maxdepth 1 -type d -printf \
+           "- [%f](https://eicrecon.epic-eic.org/capybara/%f/index.html)\n" | sort >> publishing_docs/capybara/index.md
+      - name: Create capybara step summary (this PR)
+        if: github.ref_name == 'main'
+        run: |
+          cat publishing_docs/capybara/index.md >> $GITHUB_STEP_SUMMARY
+      - uses: actions/upload-artifact@v7
+        with:
+          name: github-pages-staging-main
+          path: publishing_docs/
+          if-no-files-found: ignore
 
   build-artifacts-page:
     runs-on: ubuntu-latest
@@ -675,23 +749,59 @@ jobs:
     - merge-constants
     - merge-parameter-table
     - merge-dawn-view
+    - get-docs-from-open-prs
+    - get-docs-from-main
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/download-artifact@v8
+    - name: Checkout jekyll page
+      uses: actions/checkout@v6
+    - name: Download artifacts for jekyll page
+      uses: actions/download-artifact@v8
       with:
         path: artifacts/
-    - uses: actions/jekyll-build-pages@v1
-    - uses: actions/upload-pages-artifact@v5
+    - name: Build jekyll page
+      uses: actions/jekyll-build-pages@v1
+    - name: Copy GitHub Pages staging content
+      run: |
+        for dir in artifacts/github-pages-staging-*/; do
+          [ -d "$dir" ] && cp -r "$dir"/. _site/ || true
+        done
+    - name: Make PR summary page
+      run: |
+        echo "### PRs" >> _site/pr/index.md
+        find _site/pr -mindepth 1 -maxdepth 1 -type d -printf "- [%f](%f/index.md)\n" | sort >> _site/pr/index.md
+    - name: List content to publish
+      run:
+        find _site/
+    - name: Upload GitHub Pages artifact
+      uses: actions/upload-pages-artifact@v5
       with:
+        path: _site/
         retention-days: 7
+    - name: Populate capybara summary
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        echo "### Capybara summary for PR ${{ github.event.pull_request.number }}" >> capybara_${{ github.event.pull_request.number }}.md
+        find _site/pr/${{ github.event.pull_request.number }}/capybara/ -mindepth 1 -maxdepth 1 -type d -printf \
+          "- [%f](https://eicrecon.epic-eic.org/pr/${{ github.event.pull_request.number }}/capybara/%f/index.html)\n" | sort >> capybara_${{ github.event.pull_request.number }}.md
+        echo "<sup><sub>Last updated $(TZ=America/New_York date -Iminutes) ${{github.event.pull_request.head.sha}}</sub></sup>" >> capybara_${{ github.event.pull_request.number }}.md
+    - name: Create capybara step summary
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        cat capybara_${{ github.event.pull_request.number }}.md >> $GITHUB_STEP_SUMMARY
+    - name: Upload capybara summary
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: capybara_${{ github.event.pull_request.number }}.md
+        path: capybara_${{ github.event.pull_request.number }}.md
 
   deploy-artifacts-page:
     needs:
     - build-artifacts-page
-    if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write
+      pull-requests: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -700,6 +810,27 @@ jobs:
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v5
+    - name: Find capybara comment
+      if: ${{ github.event_name == 'pull_request' }}
+      id: find_comment
+      uses: peter-evans/find-comment@v3
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: Capybara summary
+    - name: Fetch capybara summary
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/download-artifact@v8
+      with:
+        name: capybara_${{ github.event.pull_request.number }}.md
+    - name: Create or update capybara comment
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ steps.find_comment.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body-file: capybara_${{ github.event.pull_request.number }}.md
+        edit-mode: replace
 
   cancel-container:
     if: cancelled() || failure()

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -734,7 +734,7 @@ jobs:
         run: |
          echo "### Capybara summary for main" >> publishing_docs/capybara/index.md
          find publishing_docs/capybara/ -mindepth 1 -maxdepth 1 -type d -printf \
-           "- [%f](https://eicrecon.epic-eic.org/capybara/%f/index.html)\n" | sort >> publishing_docs/capybara/index.md
+           "- [%f](https://eic.github.io/epic/capybara/%f/index.html)\n" | sort >> publishing_docs/capybara/index.md
       - name: Create capybara step summary (this PR)
         if: github.ref_name == 'main'
         run: |
@@ -796,7 +796,7 @@ jobs:
         echo "### Capybara summary for PR ${{ github.event.pull_request.number }}" >> capybara_${{ github.event.pull_request.number }}.md
         [ -d _site/pr/${{ github.event.pull_request.number }}/capybara/ ] && \
           find _site/pr/${{ github.event.pull_request.number }}/capybara/ -mindepth 1 -maxdepth 1 -type d -printf \
-            "- [%f](https://eicrecon.epic-eic.org/pr/${{ github.event.pull_request.number }}/capybara/%f/index.html)\n" | sort >> capybara_${{ github.event.pull_request.number }}.md || true
+            "- [%f](https://eic.github.io/epic/pr/${{ github.event.pull_request.number }}/capybara/%f/index.html)\n" | sort >> capybara_${{ github.event.pull_request.number }}.md || true
         echo "<sup><sub>Last updated $(TZ=America/New_York date -Iminutes) ${{github.event.pull_request.head.sha}}</sub></sup>" >> capybara_${{ github.event.pull_request.number }}.md
     - name: Create capybara step summary
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -771,6 +771,8 @@ jobs:
         path: artifacts/
     - name: Build jekyll page
       uses: actions/jekyll-build-pages@v1
+    - name: Fix _site permissions
+      run: sudo chown -R $(id -u):$(id -g) _site/
     - name: Copy GitHub Pages staging content
       run: |
         for dir in artifacts/github-pages-staging-*/; do
@@ -782,8 +784,7 @@ jobs:
         echo "### PRs" >> _site/pr/index.md
         find _site/pr -mindepth 1 -maxdepth 1 -type d -printf "- [%f](%f/index.md)\n" | sort >> _site/pr/index.md
     - name: List content to publish
-      run:
-        find _site/
+      run: find _site/
     - name: Upload GitHub Pages artifact
       uses: actions/upload-pages-artifact@v5
       with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -778,6 +778,7 @@ jobs:
         done
     - name: Make PR summary page
       run: |
+        mkdir -p _site/pr
         echo "### PRs" >> _site/pr/index.md
         find _site/pr -mindepth 1 -maxdepth 1 -type d -printf "- [%f](%f/index.md)\n" | sort >> _site/pr/index.md
     - name: List content to publish

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -739,11 +739,13 @@ jobs:
         if: github.ref_name == 'main'
         run: |
           cat publishing_docs/capybara/index.md >> $GITHUB_STEP_SUMMARY
+      - name: Ensure publishing_docs is non-empty
+        run: mkdir -p publishing_docs && touch publishing_docs/.keep
       - uses: actions/upload-artifact@v7
         with:
           name: github-pages-staging-main
           path: publishing_docs/
-          if-no-files-found: ignore
+          if-no-files-found: error
 
   build-artifacts-page:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Reverts 6821c012ee225d86067d1f03d9212a0c2a84eb71 (re-applies a6044997586cf5335a4ce4d1bf13aead4c14d791) with the following fixes:

- Fix `matrix.head_sha` reference in `get-docs-from-main` (no matrix in that job), and use 'branch: main' to download from the main branch
- Fix download path in `build-artifacts-page`: copy `github-pages-staging-*` artifacts from already-downloaded `artifacts/` into `_site/` after Jekyll build, avoiding unreliable parallel multi-artifact downloads
- Use `if-no-files-found: ignore` for `get-docs-from-main` upload to handle case where main branch has no capybara artifact yet
- Add `continue-on-error: true` to deploy-pages step so PR comments are still posted even if GitHub Pages environment protection blocks deployment from PR branches
- Guard capybara `find` against missing directory when npsim has not yet produced reports
- Update action versions to match current workflow (dawidd6 v20, upload-artifact v7, download-artifact v8, upload-pages-artifact v5, deploy-pages v5)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: capybara)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.