### PR TITLE
fix(ci): only produce stp files that are linked in README.md

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -197,6 +197,7 @@ jobs:
       - build
     uses: ./.github/workflows/convert-to-step.yml
     with:
+      # NOTE: This list of detector configurations must be kept in sync with the configurations linked in README.md.
       detector_configs: '["epic_craterlake_no_bhcal","epic_imaging_only","epic_drich_only","epic_dirc_only","epic_craterlake_tracking_only","epic_ip6"]'
 
   dump-constants:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -195,10 +195,9 @@ jobs:
   convert-to-step:
     needs:
       - build
-      - list-detector-configs
     uses: ./.github/workflows/convert-to-step.yml
     with:
-      detector_configs: ${{needs.list-detector-configs.outputs.configs_json}}
+      detector_configs: '["epic_craterlake_no_bhcal","epic_imaging_only","epic_drich_only","epic_dirc_only","epic_craterlake_tracking_only","epic_ip6"]'
 
   dump-constants:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The convert-to-step actions runs slower and slower, and people keep adding more geometry configuration for their own niche uses. This PR restricts the generation of step files to only those geometries linked from the README.md.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: slow CI)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.