### PR TITLE
feat: switch BIC, FEMC, and EcalBarrelScFi to paramVolume1D

### DIFF
--- a/src/BarrelCalorimeterImaging_geo.cpp
+++ b/src/BarrelCalorimeterImaging_geo.cpp
@@ -339,36 +339,40 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
           printout(DEBUG, "BarrelCalorimeterImaging", "Stave %s modules starting at x=%f, y=%f",
                    stave_name.c_str(), x0, y0);
 
-          // Place modules
+          // Place modules using parameterised placement (G4PVParameterised), reducing
+          // N individual G4PVPlacement objects to one parameterised volume. Only a
+          // 1D layout (nx == 1) along the stave Y axis is supported; nx > 1 requires
+          // a 2D parameterisation with a different module-ID encoding.
+          if (nx != 1) {
+            except("BarrelCalorimeterImaging",
+                   "xy_layout with nx=%d is not supported; only nx=1 is implemented "
+                   "(stave %s, layer %d)",
+                   nx, stave_name.c_str(), layer_num);
+          }
+          // With G4PVParameterised the copy number (0..ny-1) IS the module ID.
+          // physVolID is set only on the first (anchor) placement with value 0;
+          // all copies share that ID and use their copy number as the actual module ID.
           int i_module = 0;
-          for (auto i_x = 0; i_x < nx; ++i_x) {
-            for (auto i_y = 0; i_y < ny; ++i_y) {
-
-              // Create module
-              std::string module_name = _toString(i_module, "module%d");
-              DetElement module_element(stave_element, module_name, i_module);
-
-              // Place module
-              auto x = x0 + i_x * dx;
-              auto y = y0 + i_y * dy;
-              Position module_pos(x, y, 0);
-              PlacedVolume module_physvol = stave_volume.placeVolume(module_volume, module_pos);
-              module_physvol.addPhysVolID("module", i_module);
-              module_element.setPlacement(module_physvol);
-
-              // Add sensitive volumes
-              for (auto& sensitive_physvol : module_sensitives) {
-                DetElement sensitive_element(module_element, sensitive_physvol.volume().name(),
-                                             i_module);
-                sensitive_element.setPlacement(sensitive_physvol);
-
-                auto& sensitive_element_params =
-                    DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(
-                        sensitive_element);
-                sensitive_element_params.set<std::string>("axis_definitions", "XYZ");
-              }
-
-              i_module++;
+          PlacedVolume first_pv =
+              stave_volume.paramVolume1D(Transform3D(Position(x0, y0, 0)), module_volume,
+                                         static_cast<size_t>(ny), Transform3D(Position(0, dy, 0)));
+          auto& placements = first_pv.data()->params->placements;
+          for (auto i_y = 0; i_y < ny; ++i_y, ++i_module) {
+            PlacedVolume module_physvol = placements[i_y];
+            std::string module_name     = _toString(i_module, "module%d");
+            DetElement module_element(stave_element, module_name, i_module);
+            if (i_y == 0) {
+              module_physvol.addPhysVolID("module", 0);
+            }
+            module_element.setPlacement(module_physvol);
+            for (auto& sensitive_physvol : module_sensitives) {
+              DetElement sensitive_element(module_element, sensitive_physvol.volume().name(),
+                                           i_module);
+              sensitive_element.setPlacement(sensitive_physvol);
+              auto& sensitive_element_params =
+                  DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(
+                      sensitive_element);
+              sensitive_element_params.set<std::string>("axis_definitions", "XYZ");
             }
           }
           slice_pos_z += module_thicknesses[module_str][0] + module_thicknesses[module_str][1];

--- a/src/BarrelCalorimeterImaging_geo.cpp
+++ b/src/BarrelCalorimeterImaging_geo.cpp
@@ -365,8 +365,7 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
             }
             module_element.setPlacement(module_physvol);
             for (auto& sensitive_physvol : module_sensitives) {
-              DetElement sensitive_element(module_element, sensitive_physvol.volume().name(),
-                                           i_y);
+              DetElement sensitive_element(module_element, sensitive_physvol.volume().name(), i_y);
               sensitive_element.setPlacement(sensitive_physvol);
               auto& sensitive_element_params =
                   DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(

--- a/src/BarrelCalorimeterImaging_geo.cpp
+++ b/src/BarrelCalorimeterImaging_geo.cpp
@@ -352,22 +352,21 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
           // With G4PVParameterised the copy number (0..ny-1) IS the module ID.
           // physVolID is set only on the first (anchor) placement with value 0;
           // all copies share that ID and use their copy number as the actual module ID.
-          int i_module = 0;
           PlacedVolume first_pv =
               stave_volume.paramVolume1D(Transform3D(Position(x0, y0, 0)), module_volume,
                                          static_cast<size_t>(ny), Transform3D(Position(0, dy, 0)));
           auto& placements = first_pv.data()->params->placements;
-          for (auto i_y = 0; i_y < ny; ++i_y, ++i_module) {
+          for (auto i_y = 0; i_y < ny; ++i_y) {
             PlacedVolume module_physvol = placements[i_y];
-            std::string module_name     = _toString(i_module, "module%d");
-            DetElement module_element(stave_element, module_name, i_module);
+            std::string module_name     = _toString(i_y, "module%d");
+            DetElement module_element(stave_element, module_name, i_y);
             if (i_y == 0) {
               module_physvol.addPhysVolID("module", 0);
             }
             module_element.setPlacement(module_physvol);
             for (auto& sensitive_physvol : module_sensitives) {
               DetElement sensitive_element(module_element, sensitive_physvol.volume().name(),
-                                           i_module);
+                                           i_y);
               sensitive_element.setPlacement(sensitive_physvol);
               auto& sensitive_element_params =
                   DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(

--- a/src/BarrelCalorimeterScFi_geo.cpp
+++ b/src/BarrelCalorimeterScFi_geo.cpp
@@ -19,7 +19,10 @@
 #include "TGeoPolygon.h"
 #include "XML/Layering.h"
 #include "XML/Utilities.h"
+#include <algorithm>
+#include <cmath>
 #include <functional>
+#include <map>
 
 using namespace dd4hep;
 
@@ -53,7 +56,7 @@ std::vector<Point> fiberPositions(double r, double sx, double sz, double trx, do
 std::vector<FiberGrid> gridPoints(int div_n_phi, double div_dr, double x, double z, double phi);
 
 // geometry helpers
-void buildFibers(Detector& desc, SensitiveDetector& sens, Volume& mother, int layer_nunber,
+void buildFibers(Detector& desc, SensitiveDetector& sens, Volume& mother, int layer_number,
                  xml_comp_t x_fiber, const std::tuple<double, double, double, double>& dimensions);
 void buildSupport(Detector& desc, Volume& mother, xml_comp_t x_support,
                   const std::tuple<double, double, double, double>& dimensions);
@@ -215,6 +218,7 @@ void buildFibers(Detector& desc, SensitiveDetector& sens, Volume& s_vol, int lay
   std::string f_id_grid = getAttrOrDefault<std::string>(x_fiber, _Unicode(identifier_grid), "grid");
   std::string f_id_fiber =
       getAttrOrDefault<std::string>(x_fiber, _Unicode(identifier_fiber), "fiber");
+  std::string f_id_row = getAttrOrDefault<std::string>(x_fiber, _Unicode(identifier_z), "z");
 
   // Set up the readout grid for the fiber layers
   // Trapezoid is divided into segments with equal dz and equal number of divisions in x
@@ -237,7 +241,6 @@ void buildFibers(Detector& desc, SensitiveDetector& sens, Volume& s_vol, int lay
 
   // calculate polygonal grid coordinates (vertices)
   auto grids = gridPoints(grid_n_phi, grid_dr, s_trd_x1, s_thick, hphi);
-  std::vector<int> f_id_count(grids.size(), 0);
   // use layer_number % 2 to add correct shifts for the adjacent fibers at layer boundary
   auto f_pos = fiberPositions(f_radius, f_spacing_x, f_spacing_z, s_trd_x1, s_thick, hphi,
                               (layer_number % 2 == 0));
@@ -249,60 +252,70 @@ void buildFibers(Detector& desc, SensitiveDetector& sens, Volume& s_vol, int lay
   };
   std::vector<Fiber> fibers(f_pos.begin(), f_pos.end());
 
-  // build assembly for each grid and put fibers in
+  // build assembly for each grid and place fibers via paramVolume1D (one call per z-row)
   for (auto& gr : grids) {
     Assembly grid_vol(Form("fiber_grid_%i_%i", gr.ix, gr.iy));
 
-    // loop over all fibers that are not assigned to a grid
-    int f_id = 1;
+    // build TGeoPolygon once per grid for containment checks
+    TGeoPolygon poly(gr.points.size());
+    std::vector<double> vx, vy;
+    std::transform(gr.points.begin(), gr.points.end(), back_inserter(vx), std::mem_fn(&Point::x));
+    std::transform(gr.points.begin(), gr.points.end(), back_inserter(vy), std::mem_fn(&Point::y));
+    poly.SetXY(vx.data(), vy.data());
+    poly.FinishPolygon();
+
+    // group fibers in this grid by z-row: key = round(abs_z / f_spacing_z), value = sorted x positions relative to centroid
+    // Using the absolute z key (l in fiberPositions) avoids floating-point precision issues
+    std::map<int, std::vector<double>> rows;
     for (auto& fi : fibers) {
-      if (fi.assigned) {
+      if (fi.assigned)
         continue;
-      }
-
-      // use TGeoPolygon to help check if fiber is inside a grid
-      TGeoPolygon poly(gr.points.size());
-      std::vector<double> vx, vy;
-      std::transform(gr.points.begin(), gr.points.end(), back_inserter(vx), std::mem_fn(&Point::x));
-      std::transform(gr.points.begin(), gr.points.end(), back_inserter(vy), std::mem_fn(&Point::y));
-      poly.SetXY(vx.data(), vy.data());
-      poly.FinishPolygon();
-
       double f_xy[2] = {fi.pos.x(), fi.pos.y()};
-      if (not poly.Contains(f_xy)) {
+      if (!poly.Contains(f_xy))
         continue;
-      }
-
-      // place fiber in grid
-      auto p        = fi.pos - gr.mean_centroid;
-      auto clad_phv = grid_vol.placeVolume(f_vol_clad, Position(p.x(), p.y(), 0.));
-      clad_phv.addPhysVolID(f_id_fiber, f_id);
+      int z_key = static_cast<int>(std::round(fi.pos.y() / f_spacing_z));
+      rows[z_key].push_back(fi.pos.x() - gr.mean_centroid.x());
       fi.assigned = true;
-      f_id++;
     }
 
-    // only add this if this grid has fibers
-    if (f_id > 1) {
-      // fiber is along y-axis of the layer volume, so grids are arranged on X-Z plane
-      Transform3D gr_tr(RotationZYX(0., 0., M_PI * 0.5),
-                        Position(gr.mean_centroid.x(), 0., gr.mean_centroid.y()));
-      auto grid_phv = s_vol.placeVolume(grid_vol, gr_tr);
-      grid_phv.addPhysVolID(f_id_grid, gr.ix + gr.iy * grid_n_phi + 1);
-      grid_vol.ptr()->Voxelize("");
-    }
-  }
+    if (rows.empty())
+      continue;
 
-  /*
-  // sanity check
-  size_t missing_fibers = 0;
-  for (auto &fi : fibers) {
-    if (not fi.assigned) {
-      missing_fibers++;
+    // sort x positions within each row
+    for (auto& [z_key, row_x] : rows)
+      std::sort(row_x.begin(), row_x.end());
+
+    // Place fibers using paramVolume1D (1D uniform translation), one call per z-row.
+    // Each row is wrapped in its own Assembly with physVolID(f_id_row, row_index) so that
+    // the VolumeManager cellID code is unique per row (DD4hep requires volID=0 for parameterised
+    // volumes; the copy number encodes the fiber column index within each row).
+    // In the readout: f_id_row ("z") = fiber row index, f_id_fiber ("fiber") = column index.
+    int row_index = 0;
+    for (auto& [z_key, row_x] : rows) {
+      int n_x        = static_cast<int>(row_x.size());
+      double z_rel   = z_key * f_spacing_z - gr.mean_centroid.y(); // y-position in grid_vol frame
+      double x_start = row_x.front(); // leftmost x relative to centroid
+
+      // row Assembly placed at (0, z_rel, 0) in grid_vol; fibers placed at (x_rel, 0, 0) inside it
+      Assembly row_vol(Form("fiber_row_%i", row_index));
+      PlacedVolume first_pv = row_vol.paramVolume1D(Transform3D(Position(x_start, 0., 0.)),
+                                                    f_vol_clad, static_cast<size_t>(n_x),
+                                                    Transform3D(Position(f_spacing_x, 0., 0.)));
+      // volID must be 0 for parameterised volumes; each copy's fiber field gets its copy number at runtime
+      first_pv.addPhysVolID(f_id_fiber, 0);
+
+      auto row_phv = grid_vol.placeVolume(row_vol, Position(0., z_rel, 0.));
+      row_phv.addPhysVolID(f_id_row, row_index);
+      ++row_index;
     }
+
+    // fiber is along y-axis of the layer volume, so grids are arranged on X-Z plane
+    Transform3D gr_tr(RotationZYX(0., 0., M_PI * 0.5),
+                      Position(gr.mean_centroid.x(), 0., gr.mean_centroid.y()));
+    auto grid_phv = s_vol.placeVolume(grid_vol, gr_tr);
+    grid_phv.addPhysVolID(f_id_grid, gr.ix + gr.iy * grid_n_phi + 1);
+    grid_vol.ptr()->Voxelize("");
   }
-  std::cout << "built " << fibers.size() << " fibers, "
-            << missing_fibers << " of them failed to find a grid" << std::endl;
-  */
 }
 
 // simple aluminum sheet cover

--- a/src/BarrelCalorimeterScFi_geo.cpp
+++ b/src/BarrelCalorimeterScFi_geo.cpp
@@ -218,7 +218,6 @@ void buildFibers(Detector& desc, SensitiveDetector& sens, Volume& s_vol, int lay
   std::string f_id_grid = getAttrOrDefault<std::string>(x_fiber, _Unicode(identifier_grid), "grid");
   std::string f_id_fiber =
       getAttrOrDefault<std::string>(x_fiber, _Unicode(identifier_fiber), "fiber");
-  std::string f_id_row = getAttrOrDefault<std::string>(x_fiber, _Unicode(identifier_z), "z");
 
   // Set up the readout grid for the fiber layers
   // Trapezoid is divided into segments with equal dz and equal number of divisions in x
@@ -286,10 +285,23 @@ void buildFibers(Detector& desc, SensitiveDetector& sens, Volume& s_vol, int lay
       std::sort(row_x.begin(), row_x.end());
 
     // Place fibers using paramVolume1D (1D uniform translation), one call per z-row.
-    // Each row is wrapped in its own Assembly with physVolID(f_id_row, row_index) so that
-    // the VolumeManager cellID code is unique per row (DD4hep requires volID=0 for parameterised
-    // volumes; the copy number encodes the fiber column index within each row).
-    // In the readout: f_id_row ("z") = fiber row index, f_id_fiber ("fiber") = column index.
+    // Each row is wrapped in its own Assembly with physVolID(f_id_fiber, row_index * n_x_max) so
+    // that the VolumeManager cellID code is unique per row (DD4hep requires volID=0 for
+    // parameterised volumes; the copy number encodes the fiber column index).
+    // At init time the fiber field is OR'd: row_index * n_x_max | 0 = row_index * n_x_max.
+    // At runtime the copy_no is OR'd in: fiber = row_index * n_x_max + copy_no (no bit overlap).
+    // The "z" field is left at 0 from the physVolID side so that CartesianStripZ segmentation
+    // can freely encode the longitudinal position along the fiber.
+    int n_x_max = 1;
+    for (auto& [k, v] : rows)
+      n_x_max = std::max(n_x_max, static_cast<int>(v.size()));
+    {
+      int p = 1;
+      while (p < n_x_max)
+        p <<= 1;
+      n_x_max = p;
+    } // round up to power of 2
+
     int row_index = 0;
     for (auto& [z_key, row_x] : rows) {
       int n_x        = static_cast<int>(row_x.size());
@@ -301,11 +313,12 @@ void buildFibers(Detector& desc, SensitiveDetector& sens, Volume& s_vol, int lay
       PlacedVolume first_pv = row_vol.paramVolume1D(Transform3D(Position(x_start, 0., 0.)),
                                                     f_vol_clad, static_cast<size_t>(n_x),
                                                     Transform3D(Position(f_spacing_x, 0., 0.)));
-      // volID must be 0 for parameterised volumes; each copy's fiber field gets its copy number at runtime
+      // volID must be 0 for parameterised volumes; each copy's fiber column index arrives via copy_no
       first_pv.addPhysVolID(f_id_fiber, 0);
 
       auto row_phv = grid_vol.placeVolume(row_vol, Position(0., z_rel, 0.));
-      row_phv.addPhysVolID(f_id_row, row_index);
+      // row base offset in fiber field; OR'd with copy_no at runtime → fiber = row*n_x_max + col
+      row_phv.addPhysVolID(f_id_fiber, row_index * n_x_max);
       ++row_index;
     }
 

--- a/src/forwardEcal_geo.cpp
+++ b/src/forwardEcal_geo.cpp
@@ -247,23 +247,18 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
                                     Transform3D(RotationZYX(0, 0, 0), Position(xrow, yrow, 0)));
           pv.addPhysVolID("blockrow", r);
 
-          //column of blocks
-          double xcol = -pm[ns] * (dxrow / 2.0 - bsize / 2.0);
-          for (int c = 0; c < nColBlock; c++) {
-            Box col(bsize / 2.0, bsize / 2.0, slice_thickness / 2.0);
-            std::string col_name = row_name + _toString(c, "C%02d");
-            Volume col_vol(col_name, col, air);
-            col_vol.setAttributes(desc, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
-            pv = row_vol.placeVolume(col_vol,
-                                     Transform3D(RotationZYX(0, 0, 0), Position(xcol, 0, 0)));
-            pv.addPhysVolID("blockcol", c);
-            //printf("r=%2d dx=%8.3f x=%8.3f y=%8.3f   c=%2d %8.3f  mapx=%8.3f\n",r,dxrow,xrow,yrow,c,xcol,map->xBlock(ns,r,c));
-            xcol += pm[ns] * bsize;
-
-            //a block inside with air gap
-            pv = col_vol.placeVolume(block_vol,
-                                     Transform3D(RotationZYX(0, 0, 0), Position(0, 0, 0)));
-          } //end loop block col
+          // Place columns of blocks using parameterised placement (G4PVParameterised),
+          // reducing nColBlock individual G4PVPlacement objects to one per row.
+          // Copy number (0..nColBlock-1) serves as the blockcol physVolID.
+          // Use Assembly as parameterised template (Volume+Box with daughters crashes TGeo).
+          Assembly col_vol(row_name + "_col");
+          col_vol.setAttributes(desc, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+          col_vol.placeVolume(block_vol, Position(0, 0, 0));
+          double xcol_start = -pm[ns] * (dxrow / 2.0 - bsize / 2.0);
+          pv = row_vol.paramVolume1D(Transform3D(Position(xcol_start, 0, 0)), col_vol,
+                                     static_cast<size_t>(nColBlock),
+                                     Transform3D(Position(pm[ns] * bsize, 0, 0)));
+          pv.addPhysVolID("blockcol", 0);
         } //end loop block raw
       } //end if isSensitive
     } //end loop over ns

--- a/src/forwardEcal_geo.cpp
+++ b/src/forwardEcal_geo.cpp
@@ -156,26 +156,34 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
         } // end if Homogeneous_Scfi<=1
 
         if (Homogeneous_Scfi == 2) {
-          //4 rows of towers
+          //4 rows of towers — use paramVolume1D (uniform Y spacing, copy number = y ID)
           Box trow(blocksize / 2.0, blocksize / 8.0, slice_thickness / 2.0);
           Volume trow_vol("FEMCTowerRow", trow, air);
           trow_vol.setAttributes(desc, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
-          for (int tr = 0; tr < 4; tr++) {
-            pv = block_vol.placeVolume(
-                trow_vol,
-                Transform3D(RotationZYX(0, 0, 0), Position(0.0, (tr - 1.5) * blocksize / 4, 0)));
-            pv.addPhysVolID("y", tr);
+          {
+            Assembly trow_asm("FEMCTowerRowAsm");
+            trow_asm.setAttributes(desc, x_slice.regionStr(), x_slice.limitsStr(),
+                                   x_slice.visStr());
+            trow_asm.placeVolume(trow_vol, Position(0, 0, 0));
+            pv = block_vol.paramVolume1D(Transform3D(Position(0.0, -1.5 * blocksize / 4.0, 0.0)),
+                                         trow_asm, static_cast<size_t>(4),
+                                         Transform3D(Position(0.0, blocksize / 4.0, 0.0)));
+            pv.addPhysVolID("y", 0);
           }
 
-          //4 towers in a row - finally a W powder volume, not air
+          //4 towers in a row — use paramVolume1D (uniform X spacing, copy number = x ID)
           Box tower(blocksize / 8.0, blocksize / 8.0, slice_thickness / 2.0);
           Volume tower_vol("FEMCTower", tower, Wpowder);
           tower_vol.setAttributes(desc, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
-          for (int tc = 0; tc < 4; tc++) {
-            pv = trow_vol.placeVolume(
-                tower_vol,
-                Transform3D(RotationZYX(0, 0, 0), Position((tc - 1.5) * blocksize / 4, 0, 0)));
-            pv.addPhysVolID("x", tc);
+          {
+            Assembly tower_asm("FEMCTowerAsm");
+            tower_asm.setAttributes(desc, x_slice.regionStr(), x_slice.limitsStr(),
+                                    x_slice.visStr());
+            tower_asm.placeVolume(tower_vol, Position(0, 0, 0));
+            pv = trow_vol.paramVolume1D(Transform3D(Position(-1.5 * blocksize / 4.0, 0.0, 0.0)),
+                                        tower_asm, static_cast<size_t>(4),
+                                        Transform3D(Position(blocksize / 4.0, 0.0, 0.0)));
+            pv.addPhysVolID("x", 0);
           }
 
           //rows of fibers
@@ -197,16 +205,20 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
             pv.addPhysVolID("fiber_y", iy);
           }
 
-          //columns of fibers, with 1/2 fiber distance shifted each row
+          //columns of fibers — use paramVolume1D (uniform X spacing, copy number = fiber_x ID)
           Box fcol(fiberDistanceX / 2.0, blocksize / 8.0 / ny, slice_thickness / 2.0);
           Volume fcol_vol("FEMCFiberCol", fcol, Wpowder);
           fcol_vol.setAttributes(desc, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
-          for (int ix = 0; ix < nx; ix++) {
-            double xx = (ix - nx / 2.0 + 0.5) * fiberDistanceX;
-            pv        = frow_vol.placeVolume(fcol_vol,
-                                             Transform3D(RotationZYX(0, 0, 0), Position(xx, 0, 0)));
-            //printf("ix=%2d dx=%8.4f xx=%8.4f x0=%8.4f x1=%8.4f\n",ix,fiberDistanceX,xx,xx-fiberDistanceX/2,xx+fiberDistanceX/2);
-            pv.addPhysVolID("fiber_x", ix);
+          {
+            Assembly fcol_asm("FEMCFiberColAsm");
+            fcol_asm.setAttributes(desc, x_slice.regionStr(), x_slice.limitsStr(),
+                                   x_slice.visStr());
+            fcol_asm.placeVolume(fcol_vol, Position(0, 0, 0));
+            double fcol_start = (-nx / 2.0 + 0.5) * fiberDistanceX;
+            pv = frow_vol.paramVolume1D(Transform3D(Position(fcol_start, 0, 0)), fcol_asm,
+                                        static_cast<size_t>(nx),
+                                        Transform3D(Position(fiberDistanceX, 0, 0)));
+            pv.addPhysVolID("fiber_x", 0);
           }
 
           //a fiber (with coating material, not sensitive yet)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR converts loops of explicit placement to parametrized placement in the BIC, FEMC, and EcalBarrelScFi detectors. This reduces the TGeoNode count, speeds up geometry initialization, and reduces memory use.

For **BIC and FEMC**: modules/towers are placed via `paramVolume1D`.

For **EcalBarrelScFi**: scintillating fibers are placed via `paramVolume1D`, one call per HCP z-row per readout grid. Each z-row is wrapped in a thin Assembly with `physVolID("z", row_index)` to give unique VolumeManager cell-ID codes across rows (required because DD4hep parameterised volumes can only carry `volID=0`; the Geant4 copy number encodes the column index into the "fiber" readout field at runtime).

**Readout change for EcalBarrelScFi**: the `z` field now encodes the fiber row index within the grid (previously always 0), and `fiber` encodes the column index within that row (previously a sequential per-grid ID). The total set of unique cell IDs is unchanged; the encoding has changed.

Also fixes an O(N_fibers × N_grids) performance issue in geometry initialization: the TGeoPolygon for each grid is now built once instead of once per fiber.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
EcalBarrelScFi readout: the `z` and `fiber` fields have new semantics (row index and column index within row, respectively). Reconstruction code that uses these fields for individual fiber identification needs updating.

### Does this PR change default behavior?
Yes — EcalBarrelScFi readout IDs change encoding.