### PR TITLE
Add epic-specific PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
+
+### What is the urgency of this PR?
+- [ ] High
+- [ ] Medium
+- [ ] Low
+
+### What kind of change does this PR introduce?
+- [ ] Bug fix (issue #__)
+- [ ] New feature (issue #__)
+- [ ] Optimization (issue #__)
+- [ ] Updated constants (issue #__)
+- [ ] Updated documentation
+- [ ] other: __
+
+### Please check if any of the following apply
+- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
+- [ ] This PR changes default behavior. Please describe changes below.
+- [ ] (Optional) AI was used in preparing this PR. Please describe usage below.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,4 +17,3 @@
 - [ ] This PR introduces breaking changes. Please describe changes users need to make below.
 - [ ] This PR changes default behavior. Please describe changes below.
 - [ ] (Optional) AI was used in preparing this PR. Please describe usage below.
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,4 @@
 ### Please check if any of the following apply
 - [ ] This PR introduces breaking changes. Please describe changes users need to make below.
 - [ ] This PR changes default behavior. Please describe changes below.
-- [ ] (Optional) AI was used in preparing this PR. Please describe usage below.
+- [ ] AI was used in preparing this PR. Please describe usage below.


### PR DESCRIPTION
### Briefly, what does this PR introduce?

This PR implements an epic-specific PR template. It extends the default template introduced in https://github.com/eic/.github/pull/9 with options unique to epic as per the discussion in the ePIC Review Team.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No.

### Does this PR change default behavior?

Yes. The default epic PR template will now be different.