### PR TITLE
run_material_map_validation.sh: re-enable dist and 1D scripts

### DIFF
--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -11,8 +11,8 @@ if [[ -z ${DETECTOR_PATH} ]] ; then
 fi
 
 # Download required Acts files
-ACTS_VERSION="v44.4.0"
-ACTS_URL="https://github.com/acts-project/acts/raw/"
+ACTS_VERSION="pr/fix_dist_and_1D_macro"
+ACTS_URL="https://github.com/veprbl/acts/raw/"
 ACTS_FILES=(
   "Examples/Scripts/Python/geometry.py"
   "Examples/Scripts/Python/material_mapping.py"
@@ -196,7 +196,6 @@ mkdir -p Surfaces/1D_plot
 
 root -l -b -q Examples/Scripts/MaterialMapping/Mat_map_surface_plot_ratio.C'("'${propFile}_regenerated'.root","'${trackFile}'",-1,"Surfaces/regenerated/ratio_plot","Surfaces/regenerated/prop_plot","Surfaces/regenerated/map_plot")'
 root -l -b -q Examples/Scripts/MaterialMapping/Mat_map_surface_plot_ratio.C'("'${propFile}_current'.root","'${trackFile}'",-1,"Surfaces/current/ratio_plot","Surfaces/current/prop_plot","Surfaces/current/map_plot")'
-# These scripts still need to be patched to work with missing sur_type
-#root -l -b -q Examples/Scripts/MaterialMapping/Mat_map_surface_plot_dist.C'("'${trackFile}'",-1,"Surfaces/dist_plot")'
-#root -l -b -q Examples/Scripts/MaterialMapping/Mat_map_surface_plot_1D.C'("'${trackFile}'",-1,"Surfaces/1D_plot")'
+root -l -b -q Examples/Scripts/MaterialMapping/Mat_map_surface_plot_dist.C'("'${trackFile}'",-1,"Surfaces/dist_plot")'
+root -l -b -q Examples/Scripts/MaterialMapping/Mat_map_surface_plot_1D.C'("'${trackFile}'",-1,"Surfaces/1D_plot")'
 echo "::endgroup::"

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -53,8 +53,6 @@ EOF
     fi
   fi
 done
-curl --location https://github.com/acts-project/acts/pull/4931.diff | patch -p1
-curl --location https://github.com/acts-project/acts/pull/5046.diff | patch -p1
 export PYTHONPATH=$PWD/Examples/Scripts/Python:$PYTHONPATH
 
 # FIXME

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -58,7 +58,7 @@ function patch_acts() {
   local file="$(basename "$1")"
   if [ ! -e "$file" ]; then
     wget "$url"
-    patch -p1 --forward --input-file="$file"
+    patch -p1 --forward --input="$file"
   fi
 }
 patch_acts https://github.com/acts-project/acts/pull/4931.diff

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -11,8 +11,8 @@ if [[ -z ${DETECTOR_PATH} ]] ; then
 fi
 
 # Download required Acts files
-ACTS_VERSION="pr/fix_dist_and_1D_macro"
-ACTS_URL="https://github.com/veprbl/acts/raw/"
+ACTS_VERSION="v44.4.0"
+ACTS_URL="https://github.com/acts-project/acts/raw/"
 ACTS_FILES=(
   "Examples/Scripts/Python/geometry.py"
   "Examples/Scripts/Python/material_mapping.py"
@@ -55,6 +55,7 @@ EOF
 done
 curl --location https://github.com/acts-project/acts/pull/4931.diff | patch -p1
 curl --location https://github.com/acts-project/acts/pull/5046.diff | patch -p1
+curl --location https://github.com/acts-project/acts/pull/5359.diff | patch -p1
 export PYTHONPATH=$PWD/Examples/Scripts/Python:$PYTHONPATH
 
 # FIXME

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -53,6 +53,8 @@ EOF
     fi
   fi
 done
+curl --location https://github.com/acts-project/acts/pull/4931.diff | patch -p1
+curl --location https://github.com/acts-project/acts/pull/5046.diff | patch -p1
 export PYTHONPATH=$PWD/Examples/Scripts/Python:$PYTHONPATH
 
 # FIXME

--- a/scripts/material_map/run_material_map_validation.sh
+++ b/scripts/material_map/run_material_map_validation.sh
@@ -53,9 +53,17 @@ EOF
     fi
   fi
 done
-curl --location https://github.com/acts-project/acts/pull/4931.diff | patch -p1
-curl --location https://github.com/acts-project/acts/pull/5046.diff | patch -p1
-curl --location https://github.com/acts-project/acts/pull/5359.diff | patch -p1
+function patch_acts() {
+  local url="$1"
+  local file="$(basename "$1")"
+  if [ ! -e "$file" ]; then
+    wget "$url"
+    patch -p1 --forward --input-file="$file"
+  fi
+}
+patch_acts https://github.com/acts-project/acts/pull/4931.diff
+patch_acts https://github.com/acts-project/acts/pull/5046.diff
+patch_acts https://github.com/acts-project/acts/pull/5359.diff
 export PYTHONPATH=$PWD/Examples/Scripts/Python:$PYTHONPATH
 
 # FIXME


### PR DESCRIPTION
This is a small follow-up on #1008, resolving some remaining technical debt.