### PR TITLE
Standardization of MPGD description, facilitating the navigation thro…

### DIFF
--- a/compact/tracking/mpgd_backward_endcap.xml
+++ b/compact/tracking/mpgd_backward_endcap.xml
@@ -75,42 +75,42 @@
         <module name="BackwardModule1" vis="MPGDModuleVis">
           <trd x1="BackwardMPGDMod1_x1/2.0" x2="BackwardMPGDMod1_x2/2.0" z="BackwardMPGDMod1_y/2"/>
           <comment> Window and drift region </comment>
-          <module_component thickness="BackwardMPGDDriftGap_thickness" material="Ar90IsoButane" sensitive="true" vis="MPGDVis"/>
-          <module_component thickness="BackwardMPGDWindowGap_thickness" material="Ar90IsoButane" sensitive="false" vis="MPGDVis"/>
-          <module_component thickness="BackwardMPGDWindow_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="DriftGap"           thickness="BackwardMPGDDriftGap_thickness" material="Ar90IsoButane" sensitive="true" vis="MPGDVis"/>
+          <module_component name="WindowGasGap"       thickness="BackwardMPGDWindowGap_thickness" material="Ar90IsoButane" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Window"             thickness="BackwardMPGDWindow_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
           <comment> HV Cathode </comment>
-          <module_component name="Cathode Kapton" thickness="BackwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Cathode Cu" thickness="BackwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Cathode Kapton"     thickness="BackwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Cathode Cu"         thickness="BackwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
           <comment> Amplification foil (urwell) </comment>
-          <module_component name="RWell Cu" thickness="BackwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="RWell Kapton" thickness="BackwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="RWell Cu"           thickness="BackwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
+          <module_component name="RWell Kapton"       thickness="BackwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
           <comment> Readout/Backboard </comment>
-          <module_component name="Readout Nomex" thickness="BackwardMPGDReadOutNomex_thickness" material="Nomex" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Readout Nomex"      thickness="BackwardMPGDReadOutNomex_thickness" material="Nomex" sensitive="false" vis="MPGDVis"/>
           <module_component name="Readout Electrodes" thickness="BackwardMPGDReadOutElectrode_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout Kapton" thickness="BackwardMPGDReadOutKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout PCB" thickness="BackwardMPGDPCB_thickness" material="Fr4" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Readout Kapton"     thickness="BackwardMPGDReadOutKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Readout PCB"        thickness="BackwardMPGDPCB_thickness" material="Fr4" sensitive="false" vis="MPGDVis"/>
         </module>
 
         <module name="BackwardModule2" vis="MPGDModuleVis">
           <trd x1="BackwardMPGDMod2_x1/2.0" x2="BackwardMPGDMod2_x2/2.0" z="BackwardMPGDMod2_y/2"/>
           <comment> Window and drift region </comment>
-          <module_component thickness="BackwardMPGDDriftGap_thickness" material="Ar90IsoButane" sensitive="true" vis="MPGDVis"/>
-          <module_component thickness="BackwardMPGDWindowGap_thickness" material="Ar90IsoButane" sensitive="false" vis="MPGDVis"/>
-          <module_component thickness="BackwardMPGDWindow_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="DriftGap"           thickness="BackwardMPGDDriftGap_thickness" material="Ar90IsoButane" sensitive="true" vis="MPGDVis"/>
+          <module_component name="WindowGasGap"       thickness="BackwardMPGDWindowGap_thickness" material="Ar90IsoButane" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Window"             thickness="BackwardMPGDWindow_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
           <comment> HV Cathode </comment>
-          <module_component name="Cathode Kapton" thickness="BackwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Cathode Cu" thickness="BackwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Cathode Kapton"     thickness="BackwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Cathode Cu"         thickness="BackwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
           <comment> Amplification foil (urwell) </comment>
-          <module_component name="RWell Cu" thickness="BackwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="RWell Kapton" thickness="BackwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="RWell Cu"           thickness="BackwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
+          <module_component name="RWell Kapton"       thickness="BackwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
           <comment> Readout/Backboard </comment>
-          <module_component name="Readout Nomex" thickness="BackwardMPGDReadOutNomex_thickness" material="Nomex" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Readout Nomex"      thickness="BackwardMPGDReadOutNomex_thickness" material="Nomex" sensitive="false" vis="MPGDVis"/>
           <module_component name="Readout Electrodes" thickness="BackwardMPGDReadOutElectrode_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout Kapton" thickness="BackwardMPGDReadOutKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout PCB" thickness="BackwardMPGDPCB_thickness" material="Fr4" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Readout Kapton"     thickness="BackwardMPGDReadOutKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Readout PCB"        thickness="BackwardMPGDPCB_thickness" material="Fr4" sensitive="false" vis="MPGDVis"/>
         </module>
 
-        <layer id="1">
+        <layer id="0">
           <envelope  vis="MPGDLayerVis"
             rmin="BackwardMPGDLayer1_rmin"
             rmax="BackwardMPGDLayer1_rmax"
@@ -126,7 +126,7 @@
             module="BackwardModule1" />
         </layer>
 
-        <layer id="2">
+        <layer id="1">
           <envelope  vis="MPGDLayerVis"
             rmin="BackwardMPGDLayer2_rmin"
             rmax="BackwardMPGDLayer2_rmax"

--- a/compact/tracking/mpgd_barrel.xml
+++ b/compact/tracking/mpgd_barrel.xml
@@ -3,7 +3,7 @@
 
 <lccdd>
 <documentation>
-  Title: Micro Pattern Gas Detectors
+  Title: Micro Pattern Gas Detectors Cylindrical Barrel Layer
   Author: @mposik1983
   Status: development
   Version: 2.0
@@ -34,7 +34,7 @@
     <constant name="MMDriftCuGround_thickness"              value="0.41*um"/>
     <comment> FIXME: No support material is here, so fudge factor used to bring material budget to ~0.5% for barrel. </comment>
     <constant name="MMFudgeInnerMPGDBarrel_thickness"       value="570*um"/>
-    <comment> FIXME: No definite plan for connections/services to the inner sectors yet, so guess value. </comment>
+    <comment> FIXME: No definite plan for connections/services to the inner sections yet, so guess value. </comment>
     <constant name="MMInnerService_thickness"               value="0.05*cm"/>
     <comment> ...Dimensions </comment>
     <constant name="MMModuleWidth"                          value="46.0*cm"/>
@@ -71,7 +71,7 @@
         width="MMModuleWidth"
         length="MMModuleLength"/>
 
-      <module name="InnerMPGDBarrel_Mod1" vis="TrackerLayerVis" >
+      <module name="InnerMPGDBarrelModule" vis="TrackerLayerVis" >
         <comment> Models describe the overlapping of staves along phi, either (I) via  offsets or (II) via distinct radii ("rmin1/2"). Solution (II) is only partially implemented: would require FOUR distinct "radius" in the readout segmentation. Note that in any case "rsensor" must be set equal the "radius" of the corresponding segmentation and is used internally to double-check the consistency between the stack of "module_component" and the segmentation "radius". </comment>
         <model name="MMInnerSection" rmin1="MMInnerSection_R" rmin2="MMInnerSection_R" offset="MMRadial_offset" rsensor="MMInnerSensor_R"/>
         <model name="MMOuterSection" rmin1="MMOuterSection_R" rmin2="MMOuterSection_R" offset="MMRadial_offset" rsensor="MMOuterSensor_R"/>
@@ -82,7 +82,7 @@
         <module_component name="DriftCuGround" thickness="MMDriftCuGround_thickness" material="Copper" vis="TrackerModuleVis"/>
         <module_component name="DriftKapton" thickness="MMDriftKapton_thickness" material="Kapton" vis="TrackerVis" />
         <module_component name="DriftCuElectrode" thickness="MMDriftCuElectrode_thickness" material="Copper" vis="TrackerVis"/>
-        <module_component name="GasGap" thickness="MMGasGap_thickness" material="Ar90IsoButane" sensitive="True" key="0" vis="TrackerMPGDGasVis" />
+        <module_component name="DriftGap" thickness="MMGasGap_thickness" material="Ar90IsoButane" sensitive="True" key="0" vis="TrackerMPGDGasVis" />
         <module_component name="Mesh" thickness="MMMesh_thickness" material="MMGAS_InoxForMesh" vis="TrackerVis"/>
         <module_component name="Fudge" thickness="MMFudgeInnerMPGDBarrel_thickness" material="Kapton" vis="TrackerVis"/>
         <module_component name="Gas" thickness="MMGas_thickness" material="Ar90IsoButane" vis="TrackerMPGDGasVis"/>
@@ -94,7 +94,7 @@
         <module_component name="KaptonOverlay" thickness="MMKaptonOverlay_thickness" material="Kapton" vis="TrackerMPGDVis"/> <!-- Instead of "TrackerSupportVis" in order to highligh frames -->
       </module>
 
-      <layer module="InnerMPGDBarrel_Mod1" id="1" vis="InvisibleWithDaughters">
+      <layer module="InnerMPGDBarrelModule" id="0" vis="InvisibleWithDaughters">
         <barrel_envelope
           inner_r="InnerMPGDBarrelLayer_rmin"
           outer_r="InnerMPGDBarrelLayer_rmax"

--- a/compact/tracking/mpgd_barrel_2DStrip.xml
+++ b/compact/tracking/mpgd_barrel_2DStrip.xml
@@ -11,7 +11,7 @@
 
   <define>
     <comment>
-      Inner MPGD tracking layer = CyMBaL
+      Inner MPGD tracking layer (= CyMBaL)
       Note: MPGDs come in two distinct flavours: pixel and 2DStrip.
     </comment>
     <constant name="InnerMPGDBarrel_2DStrip"                value="1"/>
@@ -57,8 +57,8 @@
     <constant name="rmin2Sensor" value="MMDriftCuGround_thickness + MMDriftKapton_thickness + MMDriftCuElectrode_thickness + MMGasGap_thickness / 2" />
     <constant name="MMInnerSensor_R" value="MMInnerSection_R + rmin2Sensor" />
     <constant name="MMOuterSensor_R" value="MMOuterSection_R + rmin2Sensor" />
-    <constant name="MMInnerAperture" value="MMModuleWidth/MMInnerSensor_R" />
-    <constant name="MMOuterAperture" value="MMModuleWidth/MMOuterSensor_R" />
+    <constant name="MMInnerAperture" value="MMModuleWidth/MMInnerSection_R" />
+    <constant name="MMOuterAperture" value="MMModuleWidth/MMOuterSection_R" />
   </define>
 
   <detectors>
@@ -74,7 +74,7 @@
         width="MMModuleWidth"
         length="MMModuleLength"/>
 
-      <module name="InnerMPGDBarrel_Mod1" vis="TrackerLayerVis" >
+      <module name="InnerMPGDBarrelModule" vis="TrackerLayerVis" >
         <comment> Models describe the overlapping of staves along phi, either (I) via  offsets or (II) via distinct radii ("rmin1/2"). Solution (II) is only partially implemented: would require FOUR distinct "radius" in the readout segmentation. Note that in any case "rsensor" must be set equal the "radius" of the corresponding segmentation and is used internally to double-check the consistency between the stack of "module_component" and the segmentation "radius". </comment>
         <model name="MMInnerSection" rmin1="MMInnerSection_R" rmin2="MMInnerSection_R" offset="MMRadial_offset" rsensor="MMInnerSensor_R"/>
         <model name="MMOuterSection" rmin1="MMOuterSection_R" rmin2="MMOuterSection_R" offset="MMRadial_offset" rsensor="MMOuterSensor_R"/>
@@ -85,11 +85,11 @@
         <module_component name="DriftCuGround" thickness="MMDriftCuGround_thickness" material="Copper" vis="TrackerModuleVis"/>
         <module_component name="DriftKapton" thickness="MMDriftKapton_thickness" material="Kapton" vis="TrackerVis" />
         <module_component name="DriftCuElectrode" thickness="MMDriftCuElectrode_thickness" material="Copper" vis="TrackerVis"/>
-        <module_component name="InnerRadiator" thickness="MMThickGap_thickness" material="Ar90IsoButane" sensitive="True" key="3" vis="TrackerMPGDGasVis"/>
-        <module_component name="pStripThinGap" thickness="MMThinGap_thickness"  material="Ar90IsoButane" sensitive="True" key="1" vis="TrackerMPGDGasVis"/>
-        <module_component name="pixelThinGap"  thickness="MMThinGap_thickness"  material="Ar90IsoButane" sensitive="True" key="0" vis="TrackerMPGDGasVis"/>
-        <module_component name="nStripThinGap" thickness="MMThinGap_thickness"  material="Ar90IsoButane" sensitive="True" key="2" vis="TrackerMPGDGasVis"/>
-        <module_component name="OuterRadiator" thickness="MMThickGap_thickness" material="Ar90IsoButane" sensitive="True" key="4" vis="TrackerMPGDGasVis"/>
+        <module_component name="InnerRadiator"    thickness="MMThickGap_thickness" material="Ar90IsoButane" sensitive="True" key="3" vis="TrackerMPGDGasVis"/>
+        <module_component name="pStripThinGap"    thickness="MMThinGap_thickness"  material="Ar90IsoButane" sensitive="True" key="1" vis="TrackerMPGDGasVis"/>
+        <module_component name="ReferenceThinGap" thickness="MMThinGap_thickness"  material="Ar90IsoButane" sensitive="True" key="0" vis="TrackerMPGDGasVis"/>
+        <module_component name="nStripThinGap"    thickness="MMThinGap_thickness"  material="Ar90IsoButane" sensitive="True" key="2" vis="TrackerMPGDGasVis"/>
+        <module_component name="OuterRadiator"    thickness="MMThickGap_thickness" material="Ar90IsoButane" sensitive="True" key="4" vis="TrackerMPGDGasVis"/>
         <module_component name="Mesh" thickness="MMMesh_thickness" material="MMGAS_InoxForMesh" vis="TrackerVis"/>
         <module_component name="Fudge" thickness="MMFudgeInnerMPGDBarrel_thickness" material="Kapton" vis="TrackerVis"/>
         <module_component name="Gas" thickness="MMGas_thickness" material="Ar90IsoButane" vis="TrackerMPGDGasVis"/>
@@ -101,7 +101,7 @@
         <module_component name="KaptonOverlay" thickness="MMKaptonOverlay_thickness" material="Kapton" vis="TrackerMPGDVis"/> <!-- Instead of "TrackerSupportVis" in order to highligh frames -->
       </module>
 
-      <layer module="InnerMPGDBarrel_Mod1" id="1" vis="InvisibleWithDaughters">
+      <layer module="InnerMPGDBarrelModule" id="0" vis="InvisibleWithDaughters">
         <barrel_envelope
           inner_r="InnerMPGDBarrelLayer_rmin"
           outer_r="InnerMPGDBarrelLayer_rmax"

--- a/compact/tracking/mpgd_forward_endcap.xml
+++ b/compact/tracking/mpgd_forward_endcap.xml
@@ -75,41 +75,41 @@
         <module name="ForwardModule1" vis="MPGDModuleVis">
           <trd x1="ForwardMPGDMod1_x1/2.0" x2="ForwardMPGDMod1_x2/2.0" z="ForwardMPGDMod1_y/2"/>
           <comment> Window and drift region </comment>
-          <module_component thickness="ForwardMPGDDriftGap_thickness" material="Ar90IsoButane" sensitive="true" vis="MPGDVis"/>
-          <module_component thickness="ForwardMPGDWindowGap_thickness" material="Ar90IsoButane" sensitive="false" vis="MPGDVis"/>
-          <module_component thickness="ForwardMPGDWindow_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="DriftGap"           thickness="ForwardMPGDDriftGap_thickness" material="Ar90IsoButane" sensitive="true" vis="MPGDVis"/>
+          <module_component name="WindowGasGap"       thickness="ForwardMPGDWindowGap_thickness" material="Ar90IsoButane" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Window"             thickness="ForwardMPGDWindow_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
           <comment> HV Cathode </comment>
-          <module_component name="Cathode Kapton" thickness="ForwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Cathode Cu" thickness="ForwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Cathode Kapton"     thickness="ForwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Cathode Cu"         thickness="ForwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
           <comment> Amplification foil (urwell) </comment>
-          <module_component name="RWell Cu" thickness="ForwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="RWell Kapton" thickness="ForwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="RWell Cu"           thickness="ForwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
+          <module_component name="RWell Kapton"       thickness="ForwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
           <comment> Readout/Backboard </comment>
-          <module_component name="Readout Nomex" thickness="ForwardMPGDReadOutNomex_thickness" material="Nomex" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Readout Nomex"      thickness="ForwardMPGDReadOutNomex_thickness" material="Nomex" sensitive="false" vis="MPGDVis"/>
           <module_component name="Readout Electrodes" thickness="ForwardMPGDReadOutElectrode_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout Kapton" thickness="ForwardMPGDReadOutKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout PCB" thickness="ForwardMPGDPCB_thickness" material="Fr4" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Readout Kapton"     thickness="ForwardMPGDReadOutKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Readout PCB"        thickness="ForwardMPGDPCB_thickness" material="Fr4" sensitive="false" vis="MPGDVis"/>
         </module>
         <module name="ForwardModule2" vis="MPGDModuleVis">
           <trd x1="ForwardMPGDMod2_x1/2.0" x2="ForwardMPGDMod2_x2/2.0" z="ForwardMPGDMod2_y/2"/>
           <comment> Window and drift region </comment>
-          <module_component thickness="ForwardMPGDDriftGap_thickness" material="Ar90IsoButane" sensitive="true" vis="MPGDVis"/>
-          <module_component thickness="ForwardMPGDWindowGap_thickness" material="Ar90IsoButane" sensitive="false" vis="MPGDVis"/>
-          <module_component thickness="ForwardMPGDWindow_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="DriftGap"           thickness="ForwardMPGDDriftGap_thickness" material="Ar90IsoButane" sensitive="true" vis="MPGDVis"/>
+          <module_component name="WindowGasGap"       thickness="ForwardMPGDWindowGap_thickness" material="Ar90IsoButane" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Window"             thickness="ForwardMPGDWindow_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
           <comment> HV Cathode </comment>
-          <module_component name="Cathode Kapton" thickness="ForwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Cathode Cu" thickness="ForwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Cathode Kapton"     thickness="ForwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Cathode Cu"         thickness="ForwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
           <comment> Amplification foil (urwell) </comment>
-          <module_component name="RWell Cu" thickness="ForwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="RWell Kapton" thickness="ForwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="RWell Cu"           thickness="ForwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
+          <module_component name="RWell Kapton"       thickness="ForwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
           <comment> Readout/Backboard </comment>
-          <module_component name="Readout Nomex" thickness="ForwardMPGDReadOutNomex_thickness" material="Nomex" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Readout Nomex"      thickness="ForwardMPGDReadOutNomex_thickness" material="Nomex" sensitive="false" vis="MPGDVis"/>
           <module_component name="Readout Electrodes" thickness="ForwardMPGDReadOutElectrode_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout Kapton" thickness="ForwardMPGDReadOutKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout PCB" thickness="ForwardMPGDPCB_thickness" material="Fr4" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Readout Kapton"     thickness="ForwardMPGDReadOutKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
+          <module_component name="Readout PCB"        thickness="ForwardMPGDPCB_thickness" material="Fr4" sensitive="false" vis="MPGDVis"/>
         </module>
 
-        <layer id="1">
+        <layer id="0">
           <envelope  vis="MPGDLayerVis"
             rmin="ForwardMPGDLayer1_rmin"
             rmax="ForwardMPGDLayer1_rmax"
@@ -126,7 +126,7 @@
             module="ForwardModule1" />
         </layer>
 
-        <layer id="2">
+        <layer id="1">
           <envelope  vis="MPGDLayerVis"
             rmin="ForwardMPGDLayer2_rmin"
             rmax="ForwardMPGDLayer2_rmax"

--- a/compact/tracking/mpgd_outerbarrel_2DStrip.xml
+++ b/compact/tracking/mpgd_outerbarrel_2DStrip.xml
@@ -28,7 +28,6 @@
     <constant name="MPGDOuterBarrelModule_rmax"                    value="MPGDOuterBarrelModule_rmin + MPGDOuterBarrelModule_allowed_space" />
     <constant name="MPGDOuterBarrelModule_roffset"                 value="0.5*cm" />
     <constant name="MPGDOuterBarrelModule_width"                   value="360*mm"/>
-    <constant name="MPGDOuterBarrel_length"                        value="MPGDOuterBarrelModule_zmin1 + MPGDOuterBarrelModule_zmin2"/>
     <constant name="MPGDOuterBarrelModule_length"                  value="0.5*(MPGDOuterBarrelModule_zmin1 + MPGDOuterBarrelModule_zmin2 + MPGDOuterBarrelModule_zoverlap)"/>
     <constant name="MPGDOuterBarrelModule_offset"                  value="0.5*(MPGDOuterBarrelModule_zmin2 - MPGDOuterBarrelModule_zmin1)"/>
     <constant name="MPGDOuterBarrelModule_PCB_offset"              value="110*mm"/>
@@ -60,11 +59,11 @@
 
     <module name="MPGDOuterBarrelModule" vis="TrackerVis">
 
-        <module_component name="OuterRadiator" material="Ar90IsoButane" sensitive="true" width="MPGDOuterBarrelModule_width" thickness="RWELLThickGap_thickness" vis="TrackerMPGDGasVis" offset="0" length="MPGDOuterBarrelModule_Inset_length" key="3" />
-        <module_component name="pStripThinGap" material="Ar90IsoButane" sensitive="true" width="MPGDOuterBarrelModule_width" thickness="RWELLThinGap_thickness"  vis="TrackerMPGDGasVis" offset="0" length="MPGDOuterBarrelModule_Inset_length" key="1" />
-        <module_component name="pixelThinGap"  material="Ar90IsoButane" sensitive="true" width="MPGDOuterBarrelModule_width" thickness="RWELLThinGap_thickness"  vis="TrackerMPGDGasVis" offset="0" length="MPGDOuterBarrelModule_Inset_length" key="0" />
-        <module_component name="nStripThinGap" material="Ar90IsoButane" sensitive="true" width="MPGDOuterBarrelModule_width" thickness="RWELLThinGap_thickness"  vis="TrackerMPGDGasVis" offset="0" length="MPGDOuterBarrelModule_Inset_length" key="2" />
-        <module_component name="InnerRadiator" material="Ar90IsoButane" sensitive="true" width="MPGDOuterBarrelModule_width" thickness="RWELLThickGap_thickness" vis="TrackerMPGDGasVis" offset="0" length="MPGDOuterBarrelModule_Inset_length" key="4" />
+        <module_component name="OuterRadiator"    material="Ar90IsoButane" sensitive="true" width="MPGDOuterBarrelModule_width" thickness="RWELLThickGap_thickness" vis="TrackerMPGDGasVis" offset="0" length="MPGDOuterBarrelModule_Inset_length" key="3" />
+        <module_component name="pStripThinGap"    material="Ar90IsoButane" sensitive="true" width="MPGDOuterBarrelModule_width" thickness="RWELLThinGap_thickness"  vis="TrackerMPGDGasVis" offset="0" length="MPGDOuterBarrelModule_Inset_length" key="1" />
+        <module_component name="ReferenceThinGap" material="Ar90IsoButane" sensitive="true" width="MPGDOuterBarrelModule_width" thickness="RWELLThinGap_thickness"  vis="TrackerMPGDGasVis" offset="0" length="MPGDOuterBarrelModule_Inset_length" key="0" />
+        <module_component name="nStripThinGap"    material="Ar90IsoButane" sensitive="true" width="MPGDOuterBarrelModule_width" thickness="RWELLThinGap_thickness"  vis="TrackerMPGDGasVis" offset="0" length="MPGDOuterBarrelModule_Inset_length" key="2" />
+        <module_component name="InnerRadiator"    material="Ar90IsoButane" sensitive="true" width="MPGDOuterBarrelModule_width" thickness="RWELLThickGap_thickness" vis="TrackerMPGDGasVis" offset="0" length="MPGDOuterBarrelModule_Inset_length" key="4" />
 
         <module_component name="WindowGasGap"
                material="Ar90IsoButane"

--- a/src/BarrelPlanarMPGDTracker_geo.cpp
+++ b/src/BarrelPlanarMPGDTracker_geo.cpp
@@ -36,10 +36,13 @@ using namespace dd4hep::rec;
  *   and surrounds the rectangular perimeter)
  * - Detector is setup as a "tracker" so we can use the hits
  *
- * - Two distinct versions of ".xml" are covered:
- *  I) Single Sensitive Volume (which name is then "DriftGap"): "eicrecon" is to
- *   be executed while setting bit 0x2 of option "MPGD:SiFactoryPattern".
- * II) Multiple Sensitive Volume: Bit 0x2 of above-mentioned option not set.
+ * - Two distinct versions of XML are covered:
+ *  I) Multiple Sensitive Volume (fileName typically tagged "_2DStrip"),
+ * II) Single Sensitive Volume (which single volume is then named "DriftGap").
+ *   The XMLs have a distinctive setting of the <constant>
+ *        "MPGDOuterBarrel_2DStrip",
+ *   which "eicrecon" bases itself on to determine which version is in force.
+ *   This can still be overridden by option "MPGD:SiFactoryPattern".
  *
  */
 static Ref_t create_BarrelPlanarMPGDTracker_geo(Detector& description, xml_h e,
@@ -138,8 +141,7 @@ static Ref_t create_BarrelPlanarMPGDTracker_geo(Detector& description, xml_h e,
   int nSensitives = 0;
   for (xml_coll_t mci(x_mod, _U(module_component)); mci; ++mci, ++ncomponents) {
     xml_comp_t x_comp     = mci;
-    string c_nam          = _toString(ncomponents, "component%d");
-    string comp_name      = x_comp.nameStr();
+    string c_nam          = x_comp.nameStr();
     double comp_thickness = x_comp.thickness();
     double box_width      = x_comp.width();
     double box_length     = x_comp.length();
@@ -157,23 +159,23 @@ static Ref_t create_BarrelPlanarMPGDTracker_geo(Detector& description, xml_h e,
     // FIXME: these module names are hard coded for now. Should find
     // a way to set an attribute via the module tag to flag what components
     // need to have frame thickness subtracted.
-    bool isDriftGap = comp_name == "DriftGap" ||
-                      /* */ comp_name.find("ThinGap") != std::string::npos ||
-                      /* */ comp_name.find("Radiator") != std::string::npos;
-    if (isDriftGap || comp_name == "WindowGasGap") {
+    bool isDriftGap = c_nam == "DriftGap" ||
+                      /* */ c_nam.find("ThinGap") != std::string::npos ||
+                      /* */ c_nam.find("Radiator") != std::string::npos;
+    if (isDriftGap || c_nam == "WindowGasGap") {
       box_width            = x_comp.width() - 2.0 * frame_width;
       box_length           = x_comp.length() - 2.0 * frame_width;
       max_component_width  = box_width;
       max_component_length = box_length;
       gas_thickness += comp_thickness;
       c_box = {box_width / 2, box_length / 2, comp_thickness / 2};
-      printout(DEBUG, "BarrelPlanarMPGDTracker_geo", "gas: %s", comp_name.c_str());
+      printout(DEBUG, "BarrelPlanarMPGDTracker_geo", "gas: %s", c_nam.c_str());
       printout(DEBUG, "BarrelPlanarMPGDTracker_geo", "box_width: %f", box_width);
       printout(DEBUG, "BarrelPlanarMPGDTracker_geo", "box_length: %f", box_length);
       printout(DEBUG, "BarrelPlanarMPGDTracker_geo", "box_thickness: %f", comp_thickness);
     } else {
       c_box = {x_comp.width() / 2, x_comp.length() / 2, comp_thickness / 2};
-      printout(DEBUG, "BarrelPlanarMPGDTracker_geo", "Not gas: %s", comp_name.c_str());
+      printout(DEBUG, "BarrelPlanarMPGDTracker_geo", "Not gas: %s", c_nam.c_str());
       printout(DEBUG, "BarrelPlanarMPGDTracker_geo", "box_comp_width: %f", x_comp.width());
       printout(DEBUG, "BarrelPlanarMPGDTracker_geo", "box_comp_length: %f", x_comp.length());
       printout(DEBUG, "BarrelPlanarMPGDTracker_geo", "box_comp_thickness: %f", comp_thickness);
@@ -197,7 +199,7 @@ static Ref_t create_BarrelPlanarMPGDTracker_geo(Detector& description, xml_h e,
       }
       pv.addPhysVolID("sensor", sensor_number);
       // StripID. Single Sensitive Volume?
-      if (comp_name == "DriftGap") {
+      if (c_nam == "DriftGap") {
         if (nSensitives != 0) {
           sensitiveVolumeSet = -1;
           break;
@@ -319,7 +321,7 @@ static Ref_t create_BarrelPlanarMPGDTracker_geo(Detector& description, xml_h e,
   }
 
   double phi0     = x_layout.phi0();     // starting phi of first module
-  double phi_tilt = x_layout.phi_tilt(); // Phi tilit of module
+  double phi_tilt = x_layout.phi_tilt(); // Phi tilt of module
   double rc       = x_layout.rc();       // Radius of the module
   int nphi        = x_layout.nphi();     // Number of modules in phi
   double rphi_dr  = x_layout.dr();       // The delta radius of every other module

--- a/src/MPGDCylinderBarrelTracker_geo.cpp
+++ b/src/MPGDCylinderBarrelTracker_geo.cpp
@@ -42,7 +42,7 @@ using ROOT::Math::XYVector;
  *  but a single XML <module> and a single <layer>.
  *
  * - Two distinct versions of ".xml" are covered:
- *  I) Single Sensitive Volume (which name is then "GasGap"): "eicrecon" is to
+ *  I) Single Sensitive Volume (which name is then "DriftGap"): "eicrecon" is to
  *   be executed while setting bit 0x1 of option "MPGD:SiFactoryPattern".
  * II) Multiple Sensitive Volume: Bit 0x1 of above-mentioned option not set.
  *
@@ -405,8 +405,9 @@ static Ref_t create_MPGDCylinderBarrelTracker(Detector& description, xml_h e,
     double comp_rmin        = stave_rmin;
     double thickness_so_far = 0;
     // Pattern of Multiple Sensitive Volumes
-    // - The "GasGap" may be subdivided into SUBVOLUMES (this order to have one
-    //  sensitive component per strip coordinate (and accessorily, some extras).
+    // - The "DriftGap" may be subdivided into SUBVOLUMES (this in order to
+    //  have one sensitive component per strip coordinate (and accessorily,
+    //  some extras).
     int nSensitives = 0;
     for (xml_coll_t mci(x_mod, _U(module_component)); mci; ++mci) {
       xml_comp_t x_comp     = mci;
@@ -426,7 +427,7 @@ static Ref_t create_MPGDCylinderBarrelTracker(Detector& description, xml_h e,
         }
         pv.addPhysVolID("sensor", sensor_number);
         // StripID. Single Sensitive Volume?
-        if (c_nam == "GasGap") {
+        if (c_nam == "DriftGap") {
           if (nSensitives != 0) {
             sensitiveVolumeSet = -1;
             break;
@@ -488,7 +489,7 @@ static Ref_t create_MPGDCylinderBarrelTracker(Detector& description, xml_h e,
     } //end of module component loop
     if (sensitiveVolumeSet < 0 || sensitiveVolumeSet != nSensitives) {
       printout(ERROR, "MPGDCylinderBarrelTracker",
-               "Invalid set of Sensitive Volumes: it's either one (named \"GasGap\") or 5");
+               "Invalid set of Sensitive Volumes: it's either one (named \"DriftGap\") or 5");
       throw runtime_error("Logics error in building modules.");
     }
   } //end of stave model loop

--- a/src/MPGDCylinderBarrelTracker_geo.cpp
+++ b/src/MPGDCylinderBarrelTracker_geo.cpp
@@ -137,9 +137,9 @@ static Ref_t create_MPGDCylinderBarrelTracker(Detector& description, xml_h e,
   // the user this is no longer the case, let's forbid the use of the
   // corresponding (and a few more) tags.
   const int nInvalids                     = 4;
-  const xml::Tag_t unvalidTags[nInvalids] = {_U(phi_tilt), _U(nphi), _U(rc), _U(dr)};
+  const xml::Tag_t invalidTags[nInvalids] = {_U(phi_tilt), _U(nphi), _U(rc), _U(dr)};
   for (int uv = 0; uv < nInvalids; uv++) {
-    if (x_barrel.hasChild(unvalidTags[uv])) {
+    if (x_barrel.hasChild(invalidTags[uv])) {
       const string tag = _U(nphi);
       printout(ERROR, "MPGDCylinderBarrelTracker",
                "Layer \"%s\": Invalid property \"%s\" in \"rphi_layout\"", m_nam.c_str(),
@@ -336,7 +336,7 @@ static Ref_t create_MPGDCylinderBarrelTracker(Detector& description, xml_h e,
     double phi_start = -dphi, phi_end = dphi;
 
     // ***** ASSEMBLY VOLUME: ONE PER STAVE MODEL
-    Assembly m_vol(staveModel.name);
+    Assembly m_vol(m_nam);
     volumes.push_back(m_vol);
     m_vol.setVisAttributes(description.visAttributes(x_mod.visStr()));
 
@@ -516,7 +516,8 @@ static Ref_t create_MPGDCylinderBarrelTracker(Detector& description, xml_h e,
   // These are the 4 central values in Z where the four sets of modules, called
   // sectors, will be placed.
   double modz_pos[nSections] = {-barrel_length / 2 + (total_length) / 2,
-                                -(total_length + z_gap) / 2, +(total_length + z_gap) / 2,
+                                -(total_length + z_gap) / 2,
+                                +(total_length + z_gap) / 2,
                                 +barrel_length / 2 - (total_length) / 2};
   int nModules               = 0;
   for (int iz = 0; iz < nSections; iz++) {

--- a/src/MPGDCylinderBarrelTracker_geo.cpp
+++ b/src/MPGDCylinderBarrelTracker_geo.cpp
@@ -516,8 +516,7 @@ static Ref_t create_MPGDCylinderBarrelTracker(Detector& description, xml_h e,
   // These are the 4 central values in Z where the four sets of modules, called
   // sectors, will be placed.
   double modz_pos[nSections] = {-barrel_length / 2 + (total_length) / 2,
-                                -(total_length + z_gap) / 2,
-                                +(total_length + z_gap) / 2,
+                                -(total_length + z_gap) / 2, +(total_length + z_gap) / 2,
                                 +barrel_length / 2 - (total_length) / 2};
   int nModules               = 0;
   for (int iz = 0; iz < nSections; iz++) {

--- a/src/TrapEndcapTracker_geo.cpp
+++ b/src/TrapEndcapTracker_geo.cpp
@@ -155,7 +155,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       auto comp_height = getAttrOrDefault(c, _Unicode(height), z);
 
       Material c_mat = description.material(c.materialStr());
-      string c_name  = _toString(c_id, "component%d");
+      string c_name  = getAttrOrDefault(c, _Unicode(name), _toString(c_id, "component%d"));
 
       Trapezoid comp_s1(comp_x1, comp_x2, c_thick / 2e0, c_thick / 2e0, comp_height);
       Solid comp_shape = comp_s1;


### PR DESCRIPTION
…ugh TGeometry.

This is in particular taken advantage by the "hit_matching" script.
  i) Numbering: starts @ 0 (this concerns layer and module).
 ii) The name of layer and module nodes contains the word "Layer"/"Module" .
iii) The name of the Sensitive Volume is "DriftGap" or for the 2DStrip version,
    where there are Multiple Sensitive Volumes, "ReferenceThinGap".
Also, the angular aperture of CyMBaL used in segmentation is also corrected.

### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

### What is the urgency of this PR?
- [* ] Medium

### What kind of change does this PR introduce?
- [ *] other:  Required by PR#23 of `eic/snippets` (https://github.com/eic/snippets/pull/23).

