### PR TITLE
feat: define regions for Ecals (for use in GPU offloading)

### DIFF
--- a/compact/ecal/backward_PbWO4.xml
+++ b/compact/ecal/backward_PbWO4.xml
@@ -63,6 +63,13 @@
 
   </define>
 
+  <limits>
+  </limits>
+
+  <regions>
+    <region name="EcalEndcapNRegion"/>
+  </regions>
+
   <detectors>
 
     <documentation level="10">
@@ -72,7 +79,8 @@
         id="EcalEndcapN_ID"
         name="EcalEndcapN"
         type="epic_HomogeneousCalorimeter"
-        readout="EcalEndcapNHits">
+        readout="EcalEndcapNHits"
+        region="EcalEndcapNRegion">
       <type_flags type="DetType_CALORIMETER + DetType_ENDCAP + DetType_ELECTROMAGNETIC"/>
       <position x="0" y="0" z="-(EcalEndcapN_zmin + EcalEndcapN_envelope_length / 2.)"/>
       <rotation x="0" y="0." z="0"/>

--- a/compact/ecal/bic/bic.xml
+++ b/compact/ecal/bic/bic.xml
@@ -117,6 +117,7 @@
   </limits>
 
   <regions>
+    <region name="EcalBarrelRegion"/>
   </regions>
 
   <display>
@@ -143,6 +144,7 @@
       type="epic_EcalBarrelImaging"
       readout="EcalBarrelImagingHits"
       calorimeterType="EM_BARREL"
+      region="EcalBarrelRegion"
       vis="EcalBarrelEnvelopeVis"
       offset="EcalBarrel_Calorimeter_offset">
       <type_flags type="DetType_TRACKER + DetType_CALORIMETER + DetType_BARREL + DetType_ELECTROMAGNETIC"/>
@@ -323,6 +325,7 @@
       type="epic_EcalBarrelScFi"
       readout="EcalBarrelScFiHits"
       calorimeterType="EM_BARREL"
+      region="EcalBarrelRegion"
       vis="EcalBarrelEnvelopeVis"
       offset="EcalBarrel_Calorimeter_offset">
       <type_flags type="DetType_CALORIMETER + DetType_BARREL + DetType_ELECTROMAGNETIC"/>

--- a/compact/ecal/bic/bic_layer1_only.xml
+++ b/compact/ecal/bic/bic_layer1_only.xml
@@ -112,6 +112,7 @@
   </limits>
 
   <regions>
+    <region name="EcalBarrelRegion"/>
   </regions>
 
   <display>
@@ -138,6 +139,7 @@
       type="epic_EcalBarrelImaging"
       readout="EcalBarrelImagingHits"
       calorimeterType="EM_BARREL"
+      region="EcalBarrelRegion"
       vis="EcalBarrelEnvelopeVis"
       offset="EcalBarrel_Calorimeter_offset">
       <type_flags type="DetType_TRACKER + DetType_CALORIMETER + DetType_BARREL + DetType_ELECTROMAGNETIC"/>

--- a/compact/ecal/forward_ScFi.xml
+++ b/compact/ecal/forward_ScFi.xml
@@ -21,6 +21,7 @@
   </limits>
 
   <regions>
+    <region name="EcalEndcapPRegion"/>
   </regions>
 
   <display>
@@ -36,7 +37,8 @@
     <detector id="EcalEndcapP_ID"
       name="EcalEndcapP"
       type="epic_ForwardEcal"
-      readout="EcalEndcapPHits">
+      readout="EcalEndcapPHits"
+      region="EcalEndcapPRegion">
       <type_flags type="DetType_CALORIMETER + DetType_ENDCAP + DetType_ELECTROMAGNETIC"/>
       <position x="0" y="0" z="EcalEndcapP_zmin"/>
       <dimensions rmin="EcalEndcapP_rmin" rmax="EcalEndcapP_rmax" z="EcalEndcapP_length"/>

--- a/compact/ecal/forward_averaged_homogeneous.xml
+++ b/compact/ecal/forward_averaged_homogeneous.xml
@@ -22,6 +22,7 @@
   </limits>
 
   <regions>
+    <region name="EcalEndcapPRegion"/>
   </regions>
 
   <display>
@@ -37,7 +38,8 @@
     <detector id="EcalEndcapP_ID"
       name="EcalEndcapP"
       type="epic_ForwardEcal"
-      readout="EcalEndcapPHits">
+      readout="EcalEndcapPHits"
+      region="EcalEndcapPRegion">
       <type_flags type="DetType_CALORIMETER + DetType_ENDCAP + DetType_ELECTROMAGNETIC"/>
       <position x="0" y="0" z="EcalEndcapP_zmin"/>
       <dimensions rmin="EcalEndcapP_rmin" rmax="EcalEndcapP_rmax" z="EcalEndcapP_length"/>

--- a/src/HomogeneousCalorimeter_geo.cpp
+++ b/src/HomogeneousCalorimeter_geo.cpp
@@ -121,6 +121,7 @@ static Ref_t create_detector(Detector& desc, xml::Handle_t handle, SensitiveDete
 
   // assembly
   Assembly assembly(detName);
+  assembly.setAttributes(desc, detElem.regionStr(), detElem.limitsStr(), detElem.visStr());
 
   // module placement
   xml::Component plm = detElem.child(_Unicode(placements));


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR defines regions for the Ecal detectors. This can be used for AdePT offloading of EM e+/e-/gamma physics to the GPU for those regions (without offloading other detectors where the efficiency would be low).

The regions are defined with default parameters, so there is no change to the production cuts by defining these regions (but theoretically we could now make that change if so desired).

This also ensures that the defined region is propagated to the EEEMC.

### What is the urgency of this PR?
- [ ] High
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: define Ecal regions)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

Copilot performed these changes based on instructions.