### PR TITLE
fix(bic): correctly set y0 to xy_layout value

### DIFF
--- a/src/BarrelCalorimeterImaging_geo.cpp
+++ b/src/BarrelCalorimeterImaging_geo.cpp
@@ -335,7 +335,7 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
 
           // Default to centered
           auto x0 = getAttrOrDefault<double>(x_xy_layout, _Unicode(x0), -(nx - 1) * dx / 2.);
-          auto y0 = getAttrOrDefault<double>(x_xy_layout, _Unicode(x0), -(ny - 1) * dy / 2.);
+          auto y0 = getAttrOrDefault<double>(x_xy_layout, _Unicode(y0), -(ny - 1) * dy / 2.);
           printout(DEBUG, "BarrelCalorimeterImaging", "Stave %s modules starting at x=%f, y=%f",
                    stave_name.c_str(), x0, y0);
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes a tiny bug in the BIC geometry plugin, where we accidentally set `y0` to the value of `x0` in the xml file. If it is specified, that is, which it isn't. So this won't have any effect (until someone decides to specify a `y0` value).

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: accidentally set `y0` to the value of `x0` in the xml file)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

This bug was flagged by AI in unrelated work.