### PR TITLE
BIC: group AstroPix chips into modules (24 modules × 9 chips per stave)

### DIFF
--- a/compact/ecal/bic/bic.xml
+++ b/compact/ecal/bic/bic.xml
@@ -58,7 +58,7 @@
 
     <constant name="EcalBarrel_AstroPix_width"        value="2*cm"/>
     <constant name="EcalBarrel_AstroPix_length"       value="2*cm"/>
-    <constant name="EcalBarrel_AstroPix_margin"       value="200*um"/>
+    <constant name="EcalBarrel_AstroPix_margin"       value="0*um"/>
     <constant name="EcalBarrel_AstroPix_thickness"
       value="EcalBarrel_SiliconThickness
       + EcalBarrel_ElectronicsThickness
@@ -66,11 +66,24 @@
       + EcalBarrel_KaptonThickness
       + EcalBarrel_EpoxyThickness"/>
 
+    <comment>
+      AstroPix chips are grouped into modules of EcalBarrel_AstroPix_chips_per_module chips.
+      EcalBarrel_AstroPix_margin is the intra-module margin between adjacent chips.
+      EcalBarrel_Module_margin is the inter-module margin between adjacent modules.
+      The C++ plugin will raise an error if the modules do not fit within the stave length.
+    </comment>
+    <constant name="EcalBarrel_AstroPix_chips_per_module" value="9"/>
+    <constant name="EcalBarrel_AstroPix_modules_num"      value="24"/>
+    <constant name="EcalBarrel_Module_margin"              value="1.25*mm"/>
+    <constant name="EcalBarrel_Module_length"
+      value="EcalBarrel_AstroPix_chips_per_module * (EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin)"/>
+    <constant name="EcalBarrel_Module_pitch"
+      value="EcalBarrel_Module_length + EcalBarrel_Module_margin"/>
+
     <constant name="EcalBarrel_Stave_width"           value="EcalBarrel_AstroPix_width + 2. * EcalBarrel_AstroPix_margin"/>
     <constant name="EcalBarrel_Stave_length"          value="EcalBarrel_Calorimeter_length"/>
     <constant name="EcalBarrel_Stave_thickness"       value="EcalBarrel_AstroPix_thickness + EcalBarrel_CarbonStaveThickness"/>
     <constant name="EcalBarrel_StaveTilt_angle"       value="10*degree"/>
-    <constant name="EcalBarrel_Stave_ModuleRepeat"    value="floor(EcalBarrel_Calorimeter_length / (EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin))"/>
 
     <constant name="EcalBarrel_FiberRadius"           value="0.5*mm"/>
     <constant name="EcalBarrel_FiberXSpacing"         value="1.34*mm"/>
@@ -178,7 +191,7 @@
 
       <sectors vis="EcalBarrelSectorVis"/>
 
-      <module name="AstroPix_Module"
+      <module name="AstroPix_Chip"
               vis="EcalBarrelModuleVis">
         <module_component name="AstroPix_Chip"
                           material="Silicon"
@@ -205,12 +218,15 @@
                length="EcalBarrel_Stave_length"
                thickness="EcalBarrel_Stave_thickness"
                angle="EcalBarrel_StaveTilt_angle"
-               module="AstroPix_Module"
+               module="AstroPix_Chip"
+               module_repeat="EcalBarrel_AstroPix_chips_per_module"
                vis="EcalBarrelStaveVis"
                enable="EcalBarrel_enable_staves_1">
           <xy_layout
             dx="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
             dy="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
+            module_dy="EcalBarrel_Module_pitch"
+            ny="EcalBarrel_AstroPix_modules_num"
           />
         </stave>
       </layer>
@@ -224,12 +240,15 @@
                length="EcalBarrel_Stave_length"
                thickness="EcalBarrel_Stave_thickness"
                angle="EcalBarrel_StaveTilt_angle"
-               module="AstroPix_Module"
+               module="AstroPix_Chip"
+               module_repeat="EcalBarrel_AstroPix_chips_per_module"
                vis="EcalBarrelStaveVis"
                enable="EcalBarrel_enable_staves_2">
           <xy_layout
             dx="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
             dy="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
+            module_dy="EcalBarrel_Module_pitch"
+            ny="EcalBarrel_AstroPix_modules_num"
           />
         </stave>
       </layer>
@@ -243,12 +262,15 @@
                length="EcalBarrel_Stave_length"
                thickness="EcalBarrel_Stave_thickness"
                angle="-EcalBarrel_StaveTilt_angle"
-               module="AstroPix_Module"
+               module="AstroPix_Chip"
+               module_repeat="EcalBarrel_AstroPix_chips_per_module"
                vis="EcalBarrelStaveVis"
                enable="EcalBarrel_enable_staves_3">
           <xy_layout
             dx="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
             dy="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
+            module_dy="EcalBarrel_Module_pitch"
+            ny="EcalBarrel_AstroPix_modules_num"
           />
         </stave>
       </layer>
@@ -262,12 +284,15 @@
                length="EcalBarrel_Stave_length"
                thickness="EcalBarrel_Stave_thickness"
                angle="-EcalBarrel_StaveTilt_angle"
-               module="AstroPix_Module"
+               module="AstroPix_Chip"
+               module_repeat="EcalBarrel_AstroPix_chips_per_module"
                vis="EcalBarrelStaveVis"
                enable="EcalBarrel_enable_staves_4">
           <xy_layout
             dx="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
             dy="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
+            module_dy="EcalBarrel_Module_pitch"
+            ny="EcalBarrel_AstroPix_modules_num"
           />
         </stave>
       </layer>
@@ -281,12 +306,15 @@
                length="EcalBarrel_Stave_length"
                thickness="EcalBarrel_Stave_thickness"
                angle="-EcalBarrel_StaveTilt_angle"
-               module="AstroPix_Module"
+               module="AstroPix_Chip"
+               module_repeat="EcalBarrel_AstroPix_chips_per_module"
                vis="EcalBarrelStaveVis"
                enable="EcalBarrel_enable_staves_5">
           <xy_layout
             dx="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
             dy="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
+            module_dy="EcalBarrel_Module_pitch"
+            ny="EcalBarrel_AstroPix_modules_num"
           />
         </stave>
       </layer>
@@ -301,12 +329,15 @@
                length="EcalBarrel_Stave_length"
                thickness="EcalBarrel_Stave_thickness"
                angle="EcalBarrel_StaveTilt_angle"
-               module="AstroPix_Module"
+               module="AstroPix_Chip"
+               module_repeat="EcalBarrel_AstroPix_chips_per_module"
                vis="EcalBarrelStaveVis"
                enable="EcalBarrel_enable_staves_6">
           <xy_layout
             dx="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
             dy="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
+            module_dy="EcalBarrel_Module_pitch"
+            ny="EcalBarrel_AstroPix_modules_num"
           />
         </stave>
       </layer>
@@ -407,7 +438,7 @@
   <readouts>
     <readout name="EcalBarrelImagingHits">
       <segmentation type="CartesianGridXY" grid_size_x="0.5 * mm" grid_size_y="0.5 * mm"/>
-      <id>system:8,sector:6,layer:4,stave:4,module:8,slice:2,x:32:-16,y:-16</id>
+      <id>system:8,sector:6,layer:4,stave:4,module:5,chip:4,slice:2,x:33:-16,y:-15</id>
     </readout>
     <readout name="EcalBarrelScFiHits">
       <segmentation type="CartesianStripZ" strip_size_x="1.0*cm" identifier_x="z"/>

--- a/compact/ecal/bic/bic_layer1_only.xml
+++ b/compact/ecal/bic/bic_layer1_only.xml
@@ -53,7 +53,7 @@
 
     <constant name="EcalBarrel_AstroPix_width"        value="2*cm"/>
     <constant name="EcalBarrel_AstroPix_length"       value="2*cm"/>
-    <constant name="EcalBarrel_AstroPix_margin"       value="200*um"/>
+    <constant name="EcalBarrel_AstroPix_margin"       value="0*um"/>
     <constant name="EcalBarrel_AstroPix_thickness"
       value="EcalBarrel_SiliconThickness
       + EcalBarrel_ElectronicsThickness
@@ -61,11 +61,24 @@
       + EcalBarrel_KaptonThickness
       + EcalBarrel_EpoxyThickness"/>
 
+    <comment>
+      AstroPix chips are grouped into modules of EcalBarrel_AstroPix_chips_per_module chips.
+      EcalBarrel_AstroPix_margin is the intra-module margin between adjacent chips.
+      EcalBarrel_Module_margin is the inter-module margin between adjacent modules.
+      The C++ plugin will raise an error if the modules do not fit within the stave length.
+    </comment>
+    <constant name="EcalBarrel_AstroPix_chips_per_module" value="9"/>
+    <constant name="EcalBarrel_AstroPix_modules_num"      value="24"/>
+    <constant name="EcalBarrel_Module_margin"              value="1.25*mm"/>
+    <constant name="EcalBarrel_Module_length"
+      value="EcalBarrel_AstroPix_chips_per_module * (EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin)"/>
+    <constant name="EcalBarrel_Module_pitch"
+      value="EcalBarrel_Module_length + EcalBarrel_Module_margin"/>
+
     <constant name="EcalBarrel_Stave_width"           value="EcalBarrel_AstroPix_width + 2. * EcalBarrel_AstroPix_margin"/>
     <constant name="EcalBarrel_Stave_length"          value="EcalBarrel_Calorimeter_length"/>
     <constant name="EcalBarrel_Stave_thickness"       value="EcalBarrel_AstroPix_thickness + EcalBarrel_CarbonStaveThickness"/>
     <constant name="EcalBarrel_StaveTilt_angle"       value="10*degree"/>
-    <constant name="EcalBarrel_Stave_ModuleRepeat"    value="floor(EcalBarrel_Calorimeter_length / (EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin))"/>
 
     <constant name="EcalBarrel_FiberRadius"           value="0.5*mm"/>
     <constant name="EcalBarrel_FiberXSpacing"         value="1.34*mm"/>
@@ -173,7 +186,7 @@
 
       <sectors vis="EcalBarrelSectorVis"/>
 
-      <module name="AstroPix_Module"
+      <module name="AstroPix_Chip"
               vis="EcalBarrelModuleVis">
         <module_component name="AstroPix_Chip"
                           material="Silicon"
@@ -200,12 +213,15 @@
                length="EcalBarrel_Stave_length"
                thickness="EcalBarrel_Stave_thickness"
                angle="EcalBarrel_StaveTilt_angle"
-               module="AstroPix_Module"
+               module="AstroPix_Chip"
+               module_repeat="EcalBarrel_AstroPix_chips_per_module"
                vis="EcalBarrelStaveVis"
                enable="EcalBarrel_enable_staves_1">
           <xy_layout
             dx="EcalBarrel_AstroPix_width + EcalBarrel_AstroPix_margin"
             dy="EcalBarrel_AstroPix_length + EcalBarrel_AstroPix_margin"
+            module_dy="EcalBarrel_Module_pitch"
+            ny="EcalBarrel_AstroPix_modules_num"
           />
         </stave>
       </layer>
@@ -215,7 +231,7 @@
   <readouts>
     <readout name="EcalBarrelImagingHits">
       <segmentation type="CartesianGridXY" grid_size_x="0.5 * mm" grid_size_y="0.5 * mm"/>
-      <id>system:8,sector:6,layer:4,stave:4,module:8,slice:2,x:32:-16,y:-16</id>
+      <id>system:8,sector:6,layer:4,stave:4,module:5,chip:4,slice:2,x:33:-16,y:-15</id>
     </readout>
     <readout name="EcalBarrelScFiHits">
       <segmentation type="CartesianStripZ" strip_size_x="1.0*cm" identifier_x="z"/>

--- a/src/BarrelCalorimeterImaging_geo.cpp
+++ b/src/BarrelCalorimeterImaging_geo.cpp
@@ -339,36 +339,40 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
           printout(DEBUG, "BarrelCalorimeterImaging", "Stave %s modules starting at x=%f, y=%f",
                    stave_name.c_str(), x0, y0);
 
-          // Place modules
+          // Place modules using parameterised placement (G4PVParameterised), reducing
+          // N individual G4PVPlacement objects to one parameterised volume. Only a
+          // 1D layout (nx == 1) along the stave Y axis is supported; nx > 1 requires
+          // a 2D parameterisation with a different module-ID encoding.
+          if (nx != 1) {
+            except("BarrelCalorimeterImaging",
+                   "xy_layout with nx=%d is not supported; only nx=1 is implemented "
+                   "(stave %s, layer %d)",
+                   nx, stave_name.c_str(), layer_num);
+          }
+          // With G4PVParameterised the copy number (0..ny-1) IS the module ID.
+          // physVolID is set only on the first (anchor) placement with value 0;
+          // all copies share that ID and use their copy number as the actual module ID.
           int i_module = 0;
-          for (auto i_x = 0; i_x < nx; ++i_x) {
-            for (auto i_y = 0; i_y < ny; ++i_y) {
-
-              // Create module
-              std::string module_name = _toString(i_module, "module%d");
-              DetElement module_element(stave_element, module_name, i_module);
-
-              // Place module
-              auto x = x0 + i_x * dx;
-              auto y = y0 + i_y * dy;
-              Position module_pos(x, y, 0);
-              PlacedVolume module_physvol = stave_volume.placeVolume(module_volume, module_pos);
-              module_physvol.addPhysVolID("module", i_module);
-              module_element.setPlacement(module_physvol);
-
-              // Add sensitive volumes
-              for (auto& sensitive_physvol : module_sensitives) {
-                DetElement sensitive_element(module_element, sensitive_physvol.volume().name(),
-                                             i_module);
-                sensitive_element.setPlacement(sensitive_physvol);
-
-                auto& sensitive_element_params =
-                    DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(
-                        sensitive_element);
-                sensitive_element_params.set<std::string>("axis_definitions", "XYZ");
-              }
-
-              i_module++;
+          PlacedVolume first_pv =
+              stave_volume.paramVolume1D(Transform3D(Position(x0, y0, 0)), module_volume,
+                                         static_cast<size_t>(ny), Transform3D(Position(0, dy, 0)));
+          auto& placements = first_pv.data()->params->placements;
+          for (auto i_y = 0; i_y < ny; ++i_y, ++i_module) {
+            PlacedVolume module_physvol = placements[i_y];
+            std::string module_name     = _toString(i_module, "module%d");
+            DetElement module_element(stave_element, module_name, i_module);
+            if (i_y == 0) {
+              module_physvol.addPhysVolID("module", 0);
+            }
+            module_element.setPlacement(module_physvol);
+            for (auto& sensitive_physvol : module_sensitives) {
+              DetElement sensitive_element(module_element, sensitive_physvol.volume().name(),
+                                           i_module);
+              sensitive_element.setPlacement(sensitive_physvol);
+              auto& sensitive_element_params =
+                  DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(
+                      sensitive_element);
+              sensitive_element_params.set<std::string>("axis_definitions", "XYZ");
             }
           }
           slice_pos_z += module_thicknesses[module_str][0] + module_thicknesses[module_str][1];

--- a/src/BarrelCalorimeterImaging_geo.cpp
+++ b/src/BarrelCalorimeterImaging_geo.cpp
@@ -318,64 +318,151 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
 
         // Place in xy_layout
         if (x_stave.hasChild(_Unicode(xy_layout))) {
-          auto module_str         = x_stave.moduleStr();
-          auto& module_volume     = volumes[module_str];
-          auto& module_sensitives = sensitives[module_str];
+          auto chip_str         = x_stave.moduleStr();
+          auto& chip_volume     = volumes[chip_str];
+          auto& chip_sensitives = sensitives[chip_str];
 
-          // Get layout grid pitch
+          // Get layout grid pitch and optional module grouping
           xml_comp_t x_xy_layout = x_stave.child(_Unicode(xy_layout));
           auto dx                = x_xy_layout.attr<double>(_Unicode(dx));
           auto dy                = x_xy_layout.attr<double>(_Unicode(dy));
 
-          // Default to filling
+          // Number of chips per module group (default 1 = no grouping)
+          int n_chips_per_module = getAttrOrDefault<int>(x_stave, _Unicode(module_repeat), 1);
+
           auto nx = getAttrOrDefault<int>(x_xy_layout, _Unicode(nx), floor(2. * stave_dim_x / dx));
-          auto ny = getAttrOrDefault<int>(x_xy_layout, _Unicode(ny), floor(2. * stave_dim_y / dy));
-          printout(DEBUG, "BarrelCalorimeterImaging", "Stave %s layout with %d by %d modules",
-                   stave_name.c_str(), nx, ny);
 
-          // Default to centered
+          // Default to centered x
           auto x0 = getAttrOrDefault<double>(x_xy_layout, _Unicode(x0), -(nx - 1) * dx / 2.);
-          auto y0 = getAttrOrDefault<double>(x_xy_layout, _Unicode(x0), -(ny - 1) * dy / 2.);
-          printout(DEBUG, "BarrelCalorimeterImaging", "Stave %s modules starting at x=%f, y=%f",
-                   stave_name.c_str(), x0, y0);
 
-          // Place modules using parameterised placement (G4PVParameterised), reducing
-          // N individual G4PVPlacement objects to one parameterised volume. Only a
-          // 1D layout (nx == 1) along the stave Y axis is supported; nx > 1 requires
-          // a 2D parameterisation with a different module-ID encoding.
+          // Only 1D layout (nx == 1) is supported
           if (nx != 1) {
             except("BarrelCalorimeterImaging",
                    "xy_layout with nx=%d is not supported; only nx=1 is implemented "
                    "(stave %s, layer %d)",
                    nx, stave_name.c_str(), layer_num);
           }
-          // With G4PVParameterised the copy number (0..ny-1) IS the module ID.
-          // physVolID is set only on the first (anchor) placement with value 0;
-          // all copies share that ID and use their copy number as the actual module ID.
-          int i_module = 0;
-          PlacedVolume first_pv =
-              stave_volume.paramVolume1D(Transform3D(Position(x0, y0, 0)), module_volume,
-                                         static_cast<size_t>(ny), Transform3D(Position(0, dy, 0)));
-          auto& placements = first_pv.data()->params->placements;
-          for (auto i_y = 0; i_y < ny; ++i_y, ++i_module) {
-            PlacedVolume module_physvol = placements[i_y];
-            std::string module_name     = _toString(i_module, "module%d");
-            DetElement module_element(stave_element, module_name, i_module);
-            if (i_y == 0) {
-              module_physvol.addPhysVolID("module", 0);
+
+          if (n_chips_per_module == 1) {
+            // ── Ungrouped mode: one paramVolume1D of all chips along stave ──
+            // The parameterization copy number (0..ny-1) is the module ID (chip=0 implicitly).
+            auto ny = getAttrOrDefault<int>(x_xy_layout, _Unicode(ny),
+                                            static_cast<int>(floor(2. * stave_dim_y / dy)));
+            auto y0 = getAttrOrDefault<double>(x_xy_layout, _Unicode(y0), -(ny - 1) * dy / 2.);
+            printout(DEBUG, "BarrelCalorimeterImaging",
+                     "Stave %s layout with %d by %d modules (ungrouped)", stave_name.c_str(), nx,
+                     ny);
+            int i_module          = 0;
+            PlacedVolume first_pv = stave_volume.paramVolume1D(Transform3D(Position(x0, y0, 0)),
+                                                               chip_volume, static_cast<size_t>(ny),
+                                                               Transform3D(Position(0, dy, 0)));
+            auto& placements      = first_pv.data()->params->placements;
+            for (auto i_y = 0; i_y < ny; ++i_y, ++i_module) {
+              PlacedVolume module_physvol = placements[i_y];
+              std::string module_name     = _toString(i_module, "module%d");
+              DetElement module_element(stave_element, module_name, i_module);
+              if (i_y == 0) {
+                module_physvol.addPhysVolID("module", 0);
+              }
+              module_element.setPlacement(module_physvol);
+              for (auto& sensitive_physvol : chip_sensitives) {
+                DetElement sensitive_element(module_element, sensitive_physvol.volume().name(),
+                                             i_module);
+                sensitive_element.setPlacement(sensitive_physvol);
+                auto& sensitive_element_params =
+                    DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(
+                        sensitive_element);
+                sensitive_element_params.set<std::string>("axis_definitions", "XYZ");
+              }
             }
-            module_element.setPlacement(module_physvol);
-            for (auto& sensitive_physvol : module_sensitives) {
-              DetElement sensitive_element(module_element, sensitive_physvol.volume().name(),
-                                           i_module);
-              sensitive_element.setPlacement(sensitive_physvol);
-              auto& sensitive_element_params =
-                  DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(
-                      sensitive_element);
-              sensitive_element_params.set<std::string>("axis_definitions", "XYZ");
+          } else {
+            // ── Grouped mode: module_repeat chips per module, n_modules modules ──
+            // module_dy is the module-to-module pitch (module_length + module_margin);
+            // ny is the explicit module count (required when module grouping is active).
+            double module_dy = x_xy_layout.attr<double>(_Unicode(module_dy));
+            int n_modules    = getAttrOrDefault<int>(
+                x_xy_layout, _Unicode(ny), static_cast<int>(floor(2. * stave_dim_y / module_dy)));
+            printout(DEBUG, "BarrelCalorimeterImaging",
+                     "Stave %s: %d modules of %d chips, module_pitch=%f mm", stave_name.c_str(),
+                     n_modules, n_chips_per_module, module_dy / dd4hep::mm);
+
+            // module_length = space occupied by chips inside one module (no inter-module margin)
+            double module_length     = n_chips_per_module * dy;
+            double chip_y0_in_module = -(n_chips_per_module - 1) * dy / 2.;
+
+            // Sanity checks
+            if (module_dy < module_length - 1e-6) {
+              except(
+                  "BarrelCalorimeterImaging",
+                  "module_dy (%.3f mm) is less than module_length (%.3f mm): chips would overlap "
+                  "(stave %s, layer %d)",
+                  module_dy / dd4hep::mm, module_length / dd4hep::mm, stave_name.c_str(),
+                  layer_num);
+            }
+            double occupied_length = (n_modules - 1) * module_dy + module_length;
+            if (occupied_length > 2. * stave_dim_y + 1e-6) {
+              except("BarrelCalorimeterImaging",
+                     "Modules do not fit in stave: %d modules occupy %.3f mm > stave "
+                     "length %.3f mm (stave %s, layer %d)",
+                     n_modules, occupied_length / dd4hep::mm, 2. * stave_dim_y / dd4hep::mm,
+                     stave_name.c_str(), layer_num);
+            }
+
+            // Build a Nitrogen-filled Box volume with a single chip-group Assembly daughter.
+            // TGeo requires paramVolume1D template volumes to have exactly 1 daughter.
+            std::string chip_grp_name   = stave_name + "_chip_group";
+            std::string module_vol_name = stave_name + "_module";
+            Assembly chip_group(chip_grp_name);
+            Box module_shape(stave_dim_x, module_length / 2., stave_dim_z);
+            Volume module_volume(module_vol_name, module_shape, desc.material("Nitrogen"));
+            module_volume.setAttributes(desc, x_stave.regionStr(), x_stave.limitsStr(),
+                                        x_stave.visStr());
+
+            // Place chips inside the chip-group assembly and collect placed volumes.
+            std::vector<PlacedVolume> chip_placements;
+            for (int i_c = 0; i_c < n_chips_per_module; ++i_c) {
+              double chip_y   = chip_y0_in_module + i_c * dy;
+              PlacedVolume pv = chip_group.placeVolume(chip_volume, Position(x0, chip_y, 0));
+              pv.addPhysVolID("chip", i_c);
+              chip_placements.push_back(pv);
+            }
+            // Single daughter of module Box → satisfies paramVolume1D constraint.
+            module_volume.placeVolume(chip_group);
+
+            // Place modules along the stave using a 1D parametrised volume.
+            // Module copy number (0..n_modules-1) IS the module ID.
+            double module_y0 = -(n_modules - 1) * module_dy / 2.;
+            printout(DEBUG, "BarrelCalorimeterImaging", "Stave %s: %d modules starting at y=%f mm",
+                     stave_name.c_str(), n_modules, module_y0 / dd4hep::mm);
+            PlacedVolume first_module_pv = stave_volume.paramVolume1D(
+                Transform3D(Position(0, module_y0, 0)), module_volume,
+                static_cast<size_t>(n_modules), Transform3D(Position(0, module_dy, 0)));
+            first_module_pv.addPhysVolID("module", 0);
+            auto& module_placements = first_module_pv.data()->params->placements;
+
+            // Build DetElement tree: stave → module_N → chip_M
+            for (int i_mod = 0; i_mod < n_modules; ++i_mod) {
+              PlacedVolume module_physvol = module_placements[i_mod];
+              DetElement module_element(stave_element, _toString(i_mod, "module%d"), i_mod);
+              module_element.setPlacement(module_physvol);
+
+              for (int i_c = 0; i_c < n_chips_per_module; ++i_c) {
+                int chip_id = i_mod * n_chips_per_module + i_c;
+                DetElement chip_element(module_element, _toString(i_c, "chip%d"), i_c);
+                chip_element.setPlacement(chip_placements[i_c]);
+                for (auto& sensitive_physvol : chip_sensitives) {
+                  DetElement sensitive_element(chip_element, sensitive_physvol.volume().name(),
+                                               chip_id);
+                  sensitive_element.setPlacement(sensitive_physvol);
+                  auto& sensitive_element_params =
+                      DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(
+                          sensitive_element);
+                  sensitive_element_params.set<std::string>("axis_definitions", "XYZ");
+                }
+              }
             }
           }
-          slice_pos_z += module_thicknesses[module_str][0] + module_thicknesses[module_str][1];
+          slice_pos_z += module_thicknesses[chip_str][0] + module_thicknesses[chip_str][1];
         }
 
         // Loop over the slices for this stave

--- a/src/forwardEcal_geo.cpp
+++ b/src/forwardEcal_geo.cpp
@@ -247,23 +247,18 @@ static Ref_t createDetector(Detector& desc, xml_h handle, SensitiveDetector sens
                                     Transform3D(RotationZYX(0, 0, 0), Position(xrow, yrow, 0)));
           pv.addPhysVolID("blockrow", r);
 
-          //column of blocks
-          double xcol = -pm[ns] * (dxrow / 2.0 - bsize / 2.0);
-          for (int c = 0; c < nColBlock; c++) {
-            Box col(bsize / 2.0, bsize / 2.0, slice_thickness / 2.0);
-            std::string col_name = row_name + _toString(c, "C%02d");
-            Volume col_vol(col_name, col, air);
-            col_vol.setAttributes(desc, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
-            pv = row_vol.placeVolume(col_vol,
-                                     Transform3D(RotationZYX(0, 0, 0), Position(xcol, 0, 0)));
-            pv.addPhysVolID("blockcol", c);
-            //printf("r=%2d dx=%8.3f x=%8.3f y=%8.3f   c=%2d %8.3f  mapx=%8.3f\n",r,dxrow,xrow,yrow,c,xcol,map->xBlock(ns,r,c));
-            xcol += pm[ns] * bsize;
-
-            //a block inside with air gap
-            pv = col_vol.placeVolume(block_vol,
-                                     Transform3D(RotationZYX(0, 0, 0), Position(0, 0, 0)));
-          } //end loop block col
+          // Place columns of blocks using parameterised placement (G4PVParameterised),
+          // reducing nColBlock individual G4PVPlacement objects to one per row.
+          // Copy number (0..nColBlock-1) serves as the blockcol physVolID.
+          // Use Assembly as parameterised template (Volume+Box with daughters crashes TGeo).
+          Assembly col_vol(row_name + "_col");
+          col_vol.setAttributes(desc, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr());
+          col_vol.placeVolume(block_vol, Position(0, 0, 0));
+          double xcol_start = -pm[ns] * (dxrow / 2.0 - bsize / 2.0);
+          pv = row_vol.paramVolume1D(Transform3D(Position(xcol_start, 0, 0)), col_vol,
+                                     static_cast<size_t>(nColBlock),
+                                     Transform3D(Position(pm[ns] * bsize, 0, 0)));
+          pv.addPhysVolID("blockcol", 0);
         } //end loop block raw
       } //end if isSensitive
     } //end loop over ns


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

This PR reorganizes the BIC (Barrel Imaging Calorimeter) AstroPix sensor placement from a flat 1D array of individual chips into a two-level hierarchy of **modules** (groups of 9 **chips**), matching the actual detector design more closely.

**Motivation:**
1. **Physics fidelity**: The BIC design uses physical module assemblies of 9 AstroPix chips. Grouping chips into modules in the geometry brings the simulation closer to the real detector structure.
2. **AdePT performance**: Flat, large geometry trees with hundreds of sisters at one level cause significant imbalance in AdePT's GPU-accelerated simulation. Grouping 216 chips per stave (24 modules × 9 chips) into an intermediate module level reduces the breadth of the tree and addresses this performance issue.

**Geometry changes:**
- Individual AstroPix sensor: renamed `AstroPix_Module` → `AstroPix_Chip`
- New intermediate volume: Nitrogen-filled Box `AstroPix_Module` containing 9 chips, 24 per stave
- `AstroPix_margin = 0` (chips touch within a module; was 200 µm)
- `Module_margin = 1.25 mm` (inter-module gap) → 24 × 18.125 cm = 435 cm exactly ✓
- DetElement hierarchy: `stave → module_N → chip_M`

**Readout ID** updated to `system:8,sector:6,layer:4,stave:4,module:5,chip:4,slice:2,x:33:-16,y:-15` (64 bits).

**Backward compatibility:** ungrouped mode (`module_repeat=1`, the default if not specified) is preserved.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [x] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [x] This PR changes default behavior. Please describe changes below.
  - The readout ID schema changes: `module` field width changes from 8 to 5 bits, and a new `chip:4` field is added. Any reconstruction code relying on the old BIC readout schema will need to be updated.
- [x] AI was used in preparing this PR. Please describe usage below.
  - GitHub Copilot CLI (Claude Sonnet 4.6) was used to implement the geometry plugin changes and XML updates.