### PR TITLE
feat: add example Python geometry plugin infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ file(GLOB sources CONFIGURE_DEPENDS src/*.cpp)
 
 dd4hep_add_plugin(${a_lib_name}
   SOURCES ${sources}
-  USES ROOT::Core ROOT::Gdml
+  USES ROOT::Core ROOT::Gdml ROOT::ROOTTPython
   )
 target_link_libraries(${a_lib_name}
   PUBLIC DD4hep::DDCore DD4hep::DDRec fmt::fmt
@@ -99,6 +99,13 @@ endforeach()
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_full.xml
     DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/
     RENAME ${PROJECT_NAME}.xml
+    )
+
+#-----------------------------------------------------------------------------------
+# Install the Python geometry plugins.
+install(DIRECTORY python/
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/python
+    FILES_MATCHING PATTERN "*.py"
     )
 
 #-----------------------------------------------------------------------------------

--- a/compact/tests/python_disk.xml
+++ b/compact/tests/python_disk.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SPDX-License-Identifier: LGPL-3.0-or-later
+  Minimal compact XML that tests the Python geometry plugin trampoline.
+  Replicates one layer of SolenoidEndcapP using the Python port of
+  SimpleDiskDetector_geo.cpp instead of the C++ plugin.
+
+  Usage:
+    python -c "
+      import sys, dd4hep
+      d = dd4hep.Detector.getInstance()
+      d.fromXML('compact/tests/python_disk.xml')
+      print('Detector loaded:', d.detectors().size(), 'sub-detectors')
+    "
+-->
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+  <info name="python_disk_test"
+        title="Python geometry plugin smoke test"
+        author="ePIC"
+        url=""
+        status="test"
+        version="1.0">
+    <comment>Trivial endcap disk built from Python via epic_PythonDetector trampoline.</comment>
+  </info>
+
+  <define>
+    <include ref="${DETECTOR_PATH}/compact/definitions.xml"/>
+  </define>
+
+  <includes>
+    <gdmlFile ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile ref="${DETECTOR_PATH}/compact/materials.xml"/>
+  </includes>
+
+  <world material="Air">
+    <shape type="Box" dx="world_dx" dy="world_dy" dz="world_dz"/>
+  </world>
+
+  <display/>
+
+  <detectors>
+    <detector
+      id="1"
+      name="PythonDisk"
+      type="epic_PythonDetector"
+      module="SimpleDisk_python_geo"
+      function="create_detector"
+      reflect="false"
+      pythonpath="${DETECTOR_PATH}/python">
+      <position x="0" y="0" z="0*mm"/>
+      <layer id="1" name="Layer1"
+        inner_z="100*mm"
+        inner_r="300*mm"
+        outer_r="1500*mm">
+        <slice material="Aluminum" thickness="5*mm"/>
+      </layer>
+    </detector>
+  </detectors>
+
+</lccdd>

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,143 @@
+# Python Geometry Plugins
+
+DD4hep geometry plugins are normally written in C++ and registered via
+`DECLARE_DETELEMENT`.  This directory provides infrastructure that lets you
+write geometry plugins in **Python** instead, using DD4hep's cppyy bindings.
+
+## How it works
+
+The C++ plugin `epic_PythonDetector` (in `src/PythonDetector_geo.cpp`) acts as
+a *trampoline*: it is declared to DD4hep as a normal C++ plugin but immediately
+delegates to a Python function via ROOT's `TPython::Exec`.  C++ objects
+(`Detector&`, the XML handle, and `SensitiveDetector`) are passed to Python by
+address and reconstructed as cppyy proxies; the resulting `DetElement` is
+transferred back to C++ via `ROOT::Internal::SwapWithObjAtAddr`.
+
+## Compact XML usage
+
+```xml
+<detector id="1"
+          name="MyPythonDet"
+          type="epic_PythonDetector"
+          module="my_detector_geo"
+          function="create_detector"
+          readout="MyDetHits"
+          pythonpath="${DETECTOR_PATH}/python">
+  <!-- any sub-elements your Python function reads -->
+</detector>
+```
+
+| Attribute      | Required | Description |
+|----------------|----------|-------------|
+| `module`       | yes      | Python module name (`import module`) |
+| `function`     | yes      | Callable inside that module |
+| `pythonpath`   | no       | Directory prepended to `sys.path`; `${ENV_VAR}` is expanded |
+
+## Python function signature
+
+```python
+def create_detector(description, xml_element, sens) -> dd4hep.DetElement:
+    ...
+```
+
+The arguments arrive as cppyy proxies for:
+
+| Argument      | C++ type                    |
+|---------------|-----------------------------|
+| `description` | `dd4hep::Detector&`         |
+| `xml_element` | `dd4hep::xml::Handle_t`     |
+| `sens`        | `dd4hep::SensitiveDetector` |
+
+## Shared helper module
+
+All the cppyy boilerplate is collected in `python/epic_geo_helpers.py`.
+Start every plugin with a single import:
+
+```python
+from epic_geo_helpers import *
+```
+
+This provides:
+
+| Name | Description |
+|------|-------------|
+| `TMath` | ROOT math constants |
+| `_handle(el)` | Cast any XML element to `Handle_t` (required by `xml_coll_t`) |
+| `_collValid(c)` | Test whether an `xml_coll_t` iterator is still valid |
+| `_hasAttr(el, name)` | Test for an XML attribute (char* overload) |
+| `_getAttrBool(el, name)` | Read a bool XML attribute |
+| `Assembly`, `DetElement`, `PlacedVolume`, `Position`, `Transform3D`, `RotationY`, `Tube`, `Volume` | Common DD4hep geometry types |
+| `_U`, `_toString` | XML macro equivalents (`Strng_t`, `_toString`) |
+| `xml_det_t`, `xml_coll_t`, `xml_comp_t` | XML handle types |
+
+## Writing a plugin — key cppyy patterns
+
+### Minimal skeleton
+
+```python
+from epic_geo_helpers import *
+
+def create_detector(description, xml_element, sens):
+    x_det    = xml_det_t(xml_element)
+    det_name = x_det.nameStr()
+    sdet     = DetElement(det_name, x_det.id())
+    assembly = Assembly(det_name)
+    # ... build geometry ...
+    mother_pv = description.pickMotherVolume(sdet).placeVolume(assembly, Position(0, 0, 0))
+    mother_pv.addPhysVolID("system", x_det.id())
+    sdet.setPlacement(mother_pv)
+    return sdet
+```
+
+### Iterating over child XML elements
+
+```python
+# xml_coll_t constructor (const char* overload works fine)
+i = xml_coll_t(_handle(parent_element), "child_tag")
+while _collValid(i):                # NOT: while i: — always True!
+    child = xml_comp_t(i.current())
+    ...
+    i.__preinc__()
+```
+
+### Reading attributes
+
+```python
+# Regular string attributes work via nameStr() / materialStr() / visStr() etc.
+name = x_det.nameStr()
+
+# Numeric/bool attributes: use _hasAttr/_getAttrBool from epic_geo_helpers
+if _hasAttr(x_det, "reflect"):
+    reflect = _getAttrBool(x_det, "reflect")
+
+# Child element access via _U (Strng_t) works fine:
+pos = xml_comp_t(x_det.child(_U("position")))
+```
+
+## Example plugin
+
+`python/SimpleDisk_python_geo.py` is a complete Python port of
+`src/SimpleDiskDetector_geo.cpp`.  It builds a layered endcap disk detector
+with full layer/slice/PhysVolID support.
+
+Test it with:
+
+```bash
+source <install_prefix>/bin/thisepic.sh
+echo ".q" | geoDisplay -compact compact/tests/python_disk.xml -no-vis
+```
+
+Expected output:
+```
+Compact  INFO  ++ Converted subdetector:PythonDisk of type epic_PythonDetector
+```
+
+## Known limitations
+
+* **No re-entrant calls**: the trampoline uses a single static `DetElement` to
+  pass the result back to C++.  Nested Python detectors are not supported.
+* **`xml_coll_t` operator bool**: cppyy does not map `operator bool()` to
+  Python `__bool__` for this class.  Always use `_collValid()`.
+* **Attribute access**: `hasAttr` / `attr<T>` take `const char16_t*`; Python
+  `str` is incompatible.  Always use `_hasAttr()`, `_getAttrBool()`, and the
+  underlying `epic_python::getAttrDbl` helper from `epic_geo_helpers`.

--- a/python/SimpleDisk_python_geo.py
+++ b/python/SimpleDisk_python_geo.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2025 ePIC Collaboration
+#
+# Python port of SimpleDiskDetector_geo.cpp using DD4hep cppyy bindings.
+# Serves as the plugin target for the C++ trampoline epic_PythonDetector.
+#
+# Compact XML usage:
+#   <detector id="X_ID" name="X" type="epic_PythonDetector"
+#             module="SimpleDisk_python_geo" function="create_detector"
+#             reflect="false" readout="XHits"
+#             pythonpath="${DETECTOR_PATH}/python">
+#     <position x="0" y="0" z="0*cm"/>
+#     <layer inner_z="..." inner_r="..." outer_r="...">
+#       <slice material="Silicon" thickness="2*mm" sensitive="true"/>
+#     </layer>
+#   </detector>
+
+from epic_geo_helpers import *  # noqa: F401,F403
+
+
+def create_detector(description, xml_element, sens):
+    """
+    Create a simple disk detector (layered endcap).
+
+    Parameters
+    ----------
+    description : dd4hep::Detector &
+    xml_element : dd4hep::xml::Handle_t  (the <detector> node)
+    """
+    try:
+        return _create_detector_impl(description, xml_element, sens)
+    except Exception:
+        import traceback
+        traceback.print_exc()
+        raise
+
+
+def _create_detector_impl(description, xml_element, sens):
+    x_det    = xml_det_t(xml_element)
+    air      = description.air()
+    det_name = x_det.nameStr()
+    reflect  = _getAttrBool(x_det, "reflect") if _hasAttr(x_det, "reflect") else False
+    sdet     = DetElement(det_name, x_det.id())
+    assembly = Assembly(det_name)
+
+    pos   = xml_comp_t(x_det.child(_U("position")))
+    l_num = 0
+    pv    = PlacedVolume()
+
+    i = xml_coll_t(_handle(x_det), "layer")
+    while _collValid(i):
+        x_layer     = xml_comp_t(i.current())
+        l_nam       = det_name + _toString(l_num, "_layer%d")
+        zmin        = x_layer.inner_z()
+        rmin        = x_layer.inner_r()
+        rmax        = x_layer.outer_r()
+        layer_width = 0.0
+        s_num       = 0
+
+        j = xml_coll_t(_handle(x_layer), "slice")
+        while _collValid(j):
+            x_slice = xml_comp_t(j.current())
+            layer_width += x_slice.thickness()
+            j.__preinc__()
+
+        l_tub = Tube(rmin, rmax, layer_width / 2.0, 2 * TMath.Pi())
+        l_vol = Volume(l_nam, l_tub, air)
+        l_vol.setVisAttributes(description, x_layer.visStr())
+
+        if not reflect:
+            layer    = DetElement(sdet, l_nam + "_pos", l_num)
+            layer_pv = assembly.placeVolume(l_vol, Position(0, 0, zmin + layer_width / 2.0))
+            layer_pv.addPhysVolID("barrel", 3).addPhysVolID("layer", l_num)
+            layer.setPlacement(layer_pv)
+        else:
+            layer    = DetElement(sdet, l_nam + "_neg", l_num)
+            layer_pv = assembly.placeVolume(
+                l_vol, Transform3D(RotationY(TMath.Pi()), Position(0, 0, -zmin - layer_width / 2.0))
+            )
+            layer_pv.addPhysVolID("barrel", 2).addPhysVolID("layer", l_num)
+            layer.setPlacement(layer_pv)
+
+        tot_thickness = -layer_width / 2.0
+        j = xml_coll_t(_handle(x_layer), "slice")
+        while _collValid(j):
+            x_slice = xml_comp_t(j.current())
+            thick   = x_slice.thickness()
+            mat     = description.material(x_slice.materialStr())
+            s_nam   = l_nam + _toString(s_num, "_slice%d")
+            s_vol   = Volume(s_nam, Tube(rmin, rmax, thick / 2.0), mat)
+            s_nam  += "_pos" if not reflect else "_neg"
+            slice_de = DetElement(layer, s_nam, s_num)
+            if x_slice.isSensitive():
+                sens.setType("tracker")
+                s_vol.setSensitiveDetector(sens)
+            s_vol.setAttributes(description, x_slice.regionStr(), x_slice.limitsStr(), x_slice.visStr())
+            pv = l_vol.placeVolume(s_vol, Position(0, 0, tot_thickness + thick / 2.0))
+            pv.addPhysVolID("slice", s_num)
+            slice_de.setPlacement(pv)
+            tot_thickness += thick
+            s_num += 1
+            j.__preinc__()
+
+        i.__preinc__()
+        l_num += 1
+
+    if _hasAttr(x_det, "combineHits"):
+        sdet.setCombineHits(_getAttrBool(x_det, "combineHits"), sens)
+
+    mother_pv = description.pickMotherVolume(sdet).placeVolume(
+        assembly, Position(pos.x(), pos.y(), pos.z())
+    )
+    mother_pv.addPhysVolID("system", x_det.id())
+    sdet.setPlacement(mother_pv)
+    return sdet

--- a/python/SimpleDisk_python_geo.py
+++ b/python/SimpleDisk_python_geo.py
@@ -19,23 +19,6 @@ from epic_geo_helpers import *  # noqa: F401,F403
 
 
 def create_detector(description, xml_element, sens):
-    """
-    Create a simple disk detector (layered endcap).
-
-    Parameters
-    ----------
-    description : dd4hep::Detector &
-    xml_element : dd4hep::xml::Handle_t  (the <detector> node)
-    """
-    try:
-        return _create_detector_impl(description, xml_element, sens)
-    except Exception:
-        import traceback
-        traceback.print_exc()
-        raise
-
-
-def _create_detector_impl(description, xml_element, sens):
     x_det    = xml_det_t(xml_element)
     air      = description.air()
     det_name = x_det.nameStr()

--- a/python/epic_geo_helpers.py
+++ b/python/epic_geo_helpers.py
@@ -7,50 +7,67 @@
 #   from epic_geo_helpers import *
 #
 # Provides:
-#   - DD4hep header / cppyy initialisation (idempotent)
-#   - C++ helper namespace `epic_python` with hasAttr / getAttrDbl / getAttrBool / collValid
-#   - Python wrapper functions: _handle, _collValid, _hasAttr, _getAttrBool
-#   - Type aliases for the most-used DD4hep geometry types
+#   - DD4hep header and cppyy initialisation (idempotent)
+#   - C++ helper namespace `epic_python` with safe wrappers for XML
+#     attribute access and xml_coll_t iteration
+#   - Python wrapper functions: _handle, _collValid, _hasAttr,
+#     _getAttrStr, _getAttrDbl, _getAttrBool
+#   - Convenience type aliases covering common DD4hep geometry types
+#
+# Background — three cppyy limitations that require workarounds:
+#
+# 1. dd4hep::xml::Element::hasAttr / attr<T> accept const XmlChar* (= const
+#    char16_t* with the Xerces-C backend).  cppyy cannot auto-convert a Python
+#    str to char16_t*, so direct calls raise TypeError.  The C++ helpers below
+#    accept const char* and convert via dd4hep::xml::Strng_t.
+#
+# 2. xml_coll_t inherits from Collection_t but cppyy does NOT map its
+#    operator bool() to Python __bool__, so `while coll:` loops forever and
+#    eventually segfaults on a NULL pointer.  Use _collValid(coll) instead.
+#
+# 3. xml_coll_t's constructor expects a Handle_t but cppyy will not
+#    auto-upcast xml_det_t / xml_comp_t even though C++ would.  Use
+#    _handle(el) to perform the cast explicitly.
 
 import cppyy
 from ROOT import gInterpreter, TMath  # noqa: F401  (re-exported via __all__)
 
 # ---------------------------------------------------------------------------
-# Load DD4hep headers into cppyy (idempotent – safe to call multiple times)
+# Load DD4hep headers into cppyy (idempotent — safe to call multiple times)
 # ---------------------------------------------------------------------------
 gInterpreter.ProcessLine('#include "DD4hep/DetFactoryHelper.h"')
 
 # ---------------------------------------------------------------------------
-# Thin C++ helpers for DD4hep XML attribute access.
-#
-# Background: dd4hep::xml::Element::hasAttr / attr<T> require a const XmlChar*
-# argument (XmlChar = char16_t with the Xerces-C backend).  cppyy cannot
-# auto-convert a Python str to char16_t*, so direct calls raise TypeError.
-# The helpers below accept const char* and convert via dd4hep::xml::Strng_t.
-#
-# xml_coll_t::operator bool() is also not mapped to Python __bool__ by cppyy,
-# so a separate collValid() helper is provided.
+# Thin C++ helpers in namespace epic_python
 # ---------------------------------------------------------------------------
 cppyy.cppdef(r"""
 #include "DD4hep/DetFactoryHelper.h"
+#ifndef EPIC_PYTHON_HELPERS_DEFINED
+#define EPIC_PYTHON_HELPERS_DEFINED
 namespace epic_python {
+  /// Test for a named attribute; accepts plain C string (avoids char16_t* conversion).
   inline bool hasAttr(dd4hep::xml::Element el, const char* name) {
     return el.hasAttr(dd4hep::xml::Strng_t(name));
   }
+  /// Read a named attribute as std::string.
   inline std::string getAttrStr(dd4hep::xml::Element el, const char* name) {
     return el.attr<std::string>(dd4hep::xml::Strng_t(name));
   }
+  /// Read a named attribute as double (DD4hep unit-aware).
   inline double getAttrDbl(dd4hep::xml::Element el, const char* name) {
     return el.attr<double>(dd4hep::xml::Strng_t(name));
   }
+  /// Read a named attribute as bool.
   inline bool getAttrBool(dd4hep::xml::Element el, const char* name) {
     return el.attr<bool>(dd4hep::xml::Strng_t(name));
   }
-  // xml_coll_t::operator bool() is NOT mapped to Python __bool__; use this.
+  /// Return true if the xml_coll_t iterator is still valid.
+  /// Use instead of operator bool(), which cppyy does not map to __bool__.
   inline bool collValid(const dd4hep::xml::Collection_t& c) {
     return static_cast<bool>(c);
   }
 }
+#endif // EPIC_PYTHON_HELPERS_DEFINED
 """)
 
 
@@ -59,20 +76,21 @@ namespace epic_python {
 # ---------------------------------------------------------------------------
 
 def _handle(el):
-    """Cast any xml Element type to Handle_t (required by xml_coll_t constructor).
+    """Cast any xml Element type to Handle_t.
 
-    cppyy does not auto-upcast xml_det_t / xml_comp_t to Handle_t even though
-    C++ would do so implicitly.
+    Required because cppyy does not auto-upcast xml_det_t / xml_comp_t to
+    Handle_t even though C++ would do so implicitly.  xml_coll_t's constructor
+    expects a Handle_t, so pass _handle(el) instead of el directly.
     """
     return cppyy.gbl.dd4hep.xml.Handle_t(el.ptr())
 
 
 def _collValid(c) -> bool:
-    """Return True if the xml_coll_t iterator is still valid.
+    """Return True if an xml_coll_t iterator is still valid.
 
-    Use instead of ``while c:`` — cppyy maps Python __bool__ to the default
-    object truthiness, not to C++ operator bool(), so ``while c:`` loops
-    forever and eventually segfaults on a NULL pointer.
+    Never write ``while c:`` — cppyy maps Python __bool__ to the default
+    object truthiness (always True), not to C++ operator bool(). Use
+    ``while _collValid(c):`` instead to avoid an infinite loop and segfault.
     """
     return cppyy.gbl.epic_python.collValid(c)
 
@@ -80,6 +98,16 @@ def _collValid(c) -> bool:
 def _hasAttr(el, name: str) -> bool:
     """Return True if the XML element has the named attribute."""
     return cppyy.gbl.epic_python.hasAttr(el, name)
+
+
+def _getAttrStr(el, name: str) -> str:
+    """Return the named XML attribute as a string."""
+    return cppyy.gbl.epic_python.getAttrStr(el, name)
+
+
+def _getAttrDbl(el, name: str) -> float:
+    """Return the named XML attribute as a double (DD4hep unit-aware)."""
+    return cppyy.gbl.epic_python.getAttrDbl(el, name)
 
 
 def _getAttrBool(el, name: str) -> bool:
@@ -90,18 +118,41 @@ def _getAttrBool(el, name: str) -> bool:
 # ---------------------------------------------------------------------------
 # DD4hep type aliases
 # ---------------------------------------------------------------------------
-_dd4hep      = cppyy.gbl.dd4hep
+_dd4hep = cppyy.gbl.dd4hep
+
+# -- Core detector / volume types
 Assembly     = _dd4hep.Assembly
 DetElement   = _dd4hep.DetElement
 PlacedVolume = _dd4hep.PlacedVolume
-Position     = _dd4hep.Position
-Transform3D  = _dd4hep.Transform3D
-RotationY    = cppyy.gbl.ROOT.Math.RotationY
-Tube         = _dd4hep.Tube
 Volume       = _dd4hep.Volume
 
-_U        = _dd4hep.xml.Strng_t       # equivalent of the _U("tag") macro
-_toString = _dd4hep.xml._toString     # equivalent of the _toString(n, "fmt") macro
+# -- Transforms and positions
+Position      = _dd4hep.Position
+Transform3D   = _dd4hep.Transform3D
+Translation3D = _dd4hep.Translation3D
+Rotation3D    = _dd4hep.Rotation3D
+RotationX     = _dd4hep.RotationX
+RotationY     = _dd4hep.RotationY
+RotationZ     = _dd4hep.RotationZ
+RotationZYX   = _dd4hep.RotationZYX
+
+# -- Shapes (common subset sufficient for most detector geometry)
+Box               = _dd4hep.Box
+Tube              = _dd4hep.Tube
+CutTube           = _dd4hep.CutTube
+Cone              = _dd4hep.Cone
+ConeSegment       = _dd4hep.ConeSegment
+Sphere            = _dd4hep.Sphere
+Torus             = _dd4hep.Torus
+Polycone          = _dd4hep.Polycone
+Trapezoid         = _dd4hep.Trapezoid
+SubtractionSolid  = _dd4hep.SubtractionSolid
+UnionSolid        = _dd4hep.UnionSolid
+IntersectionSolid = _dd4hep.IntersectionSolid
+
+# -- XML handle types used in detector factory functions
+_U        = _dd4hep.xml.Strng_t       # equivalent of the C++ _U("tag") macro
+_toString = _dd4hep.xml._toString     # equivalent of the C++ _toString(n, "fmt") macro
 
 xml_det_t  = cppyy.gbl.xml_det_t
 xml_coll_t = cppyy.gbl.xml_coll_t
@@ -114,10 +165,17 @@ __all__ = [
     # ROOT helper
     "TMath",
     # Python wrapper functions
-    "_handle", "_collValid", "_hasAttr", "_getAttrBool",
-    # DD4hep geometry types
-    "Assembly", "DetElement", "PlacedVolume", "Position",
-    "Transform3D", "RotationY", "Tube", "Volume",
+    "_handle", "_collValid",
+    "_hasAttr", "_getAttrStr", "_getAttrDbl", "_getAttrBool",
+    # Core types
+    "Assembly", "DetElement", "PlacedVolume", "Volume",
+    # Transforms
+    "Position", "Transform3D", "Translation3D",
+    "Rotation3D", "RotationX", "RotationY", "RotationZ", "RotationZYX",
+    # Shapes
+    "Box", "Tube", "CutTube", "Cone", "ConeSegment",
+    "Sphere", "Torus", "Polycone", "Trapezoid",
+    "SubtractionSolid", "UnionSolid", "IntersectionSolid",
     # XML helpers
     "_U", "_toString", "xml_det_t", "xml_coll_t", "xml_comp_t",
 ]

--- a/python/epic_geo_helpers.py
+++ b/python/epic_geo_helpers.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2025 ePIC Collaboration
+#
+# Shared helpers for Python-based DD4hep geometry plugins.
+#
+# Usage in a plugin module:
+#   from epic_geo_helpers import *
+#
+# Provides:
+#   - DD4hep header / cppyy initialisation (idempotent)
+#   - C++ helper namespace `epic_python` with hasAttr / getAttrDbl / getAttrBool / collValid
+#   - Python wrapper functions: _handle, _collValid, _hasAttr, _getAttrBool
+#   - Type aliases for the most-used DD4hep geometry types
+
+import cppyy
+from ROOT import gInterpreter, TMath  # noqa: F401  (re-exported via __all__)
+
+# ---------------------------------------------------------------------------
+# Load DD4hep headers into cppyy (idempotent – safe to call multiple times)
+# ---------------------------------------------------------------------------
+gInterpreter.ProcessLine('#include "DD4hep/DetFactoryHelper.h"')
+
+# ---------------------------------------------------------------------------
+# Thin C++ helpers for DD4hep XML attribute access.
+#
+# Background: dd4hep::xml::Element::hasAttr / attr<T> require a const XmlChar*
+# argument (XmlChar = char16_t with the Xerces-C backend).  cppyy cannot
+# auto-convert a Python str to char16_t*, so direct calls raise TypeError.
+# The helpers below accept const char* and convert via dd4hep::xml::Strng_t.
+#
+# xml_coll_t::operator bool() is also not mapped to Python __bool__ by cppyy,
+# so a separate collValid() helper is provided.
+# ---------------------------------------------------------------------------
+cppyy.cppdef(r"""
+#include "DD4hep/DetFactoryHelper.h"
+namespace epic_python {
+  inline bool hasAttr(dd4hep::xml::Element el, const char* name) {
+    return el.hasAttr(dd4hep::xml::Strng_t(name));
+  }
+  inline std::string getAttrStr(dd4hep::xml::Element el, const char* name) {
+    return el.attr<std::string>(dd4hep::xml::Strng_t(name));
+  }
+  inline double getAttrDbl(dd4hep::xml::Element el, const char* name) {
+    return el.attr<double>(dd4hep::xml::Strng_t(name));
+  }
+  inline bool getAttrBool(dd4hep::xml::Element el, const char* name) {
+    return el.attr<bool>(dd4hep::xml::Strng_t(name));
+  }
+  // xml_coll_t::operator bool() is NOT mapped to Python __bool__; use this.
+  inline bool collValid(const dd4hep::xml::Collection_t& c) {
+    return static_cast<bool>(c);
+  }
+}
+""")
+
+
+# ---------------------------------------------------------------------------
+# Python wrapper functions
+# ---------------------------------------------------------------------------
+
+def _handle(el):
+    """Cast any xml Element type to Handle_t (required by xml_coll_t constructor).
+
+    cppyy does not auto-upcast xml_det_t / xml_comp_t to Handle_t even though
+    C++ would do so implicitly.
+    """
+    return cppyy.gbl.dd4hep.xml.Handle_t(el.ptr())
+
+
+def _collValid(c) -> bool:
+    """Return True if the xml_coll_t iterator is still valid.
+
+    Use instead of ``while c:`` — cppyy maps Python __bool__ to the default
+    object truthiness, not to C++ operator bool(), so ``while c:`` loops
+    forever and eventually segfaults on a NULL pointer.
+    """
+    return cppyy.gbl.epic_python.collValid(c)
+
+
+def _hasAttr(el, name: str) -> bool:
+    """Return True if the XML element has the named attribute."""
+    return cppyy.gbl.epic_python.hasAttr(el, name)
+
+
+def _getAttrBool(el, name: str) -> bool:
+    """Return the named XML attribute as a bool."""
+    return cppyy.gbl.epic_python.getAttrBool(el, name)
+
+
+# ---------------------------------------------------------------------------
+# DD4hep type aliases
+# ---------------------------------------------------------------------------
+_dd4hep      = cppyy.gbl.dd4hep
+Assembly     = _dd4hep.Assembly
+DetElement   = _dd4hep.DetElement
+PlacedVolume = _dd4hep.PlacedVolume
+Position     = _dd4hep.Position
+Transform3D  = _dd4hep.Transform3D
+RotationY    = cppyy.gbl.ROOT.Math.RotationY
+Tube         = _dd4hep.Tube
+Volume       = _dd4hep.Volume
+
+_U        = _dd4hep.xml.Strng_t       # equivalent of the _U("tag") macro
+_toString = _dd4hep.xml._toString     # equivalent of the _toString(n, "fmt") macro
+
+xml_det_t  = cppyy.gbl.xml_det_t
+xml_coll_t = cppyy.gbl.xml_coll_t
+xml_comp_t = cppyy.gbl.xml_comp_t
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+__all__ = [
+    # ROOT helper
+    "TMath",
+    # Python wrapper functions
+    "_handle", "_collValid", "_hasAttr", "_getAttrBool",
+    # DD4hep geometry types
+    "Assembly", "DetElement", "PlacedVolume", "Position",
+    "Transform3D", "RotationY", "Tube", "Volume",
+    # XML helpers
+    "_U", "_toString", "xml_det_t", "xml_coll_t", "xml_comp_t",
+]

--- a/src/PythonDetector_geo.cpp
+++ b/src/PythonDetector_geo.cpp
@@ -23,6 +23,7 @@
 #include "TPython.h"
 
 #include <cstdint>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 

--- a/src/PythonDetector_geo.cpp
+++ b/src/PythonDetector_geo.cpp
@@ -56,6 +56,41 @@ static std::string expand_env(const std::string& input) {
   return out;
 }
 
+/// Escape a C++ string into a Python single-quoted string literal.
+/// Handles backslashes, quotes, newlines, and non-printable bytes.
+static std::string py_str(const std::string& value) {
+  std::string result = "'";
+  for (unsigned char c : value) {
+    switch (c) {
+    case '\\':
+      result += "\\\\";
+      break;
+    case '\'':
+      result += "\\'";
+      break;
+    case '\n':
+      result += "\\n";
+      break;
+    case '\r':
+      result += "\\r";
+      break;
+    case '\t':
+      result += "\\t";
+      break;
+    default:
+      if (c < 0x20 || c == 0x7f) {
+        char buf[8];
+        snprintf(buf, sizeof(buf), "\\x%02x", c);
+        result += buf;
+      } else {
+        result += static_cast<char>(c);
+      }
+    }
+  }
+  result += "'";
+  return result;
+}
+
 static Ref_t create_python_detector(Detector& description, xml_h e, SensitiveDetector sens) {
   xml_det_t x_det  = e;
   std::string mod  = x_det.attr<std::string>(dd4hep::xml::Strng_t("module"));
@@ -75,15 +110,15 @@ static Ref_t create_python_detector(Detector& description, xml_h e, SensitiveDet
   std::ostringstream script;
   script << "import importlib.util, sys, cppyy\n";
   if (!pypath.empty()) {
-    script << "if '" << pypath << "' not in sys.path:\n"
-           << "    sys.path.insert(0, '" << pypath << "')\n";
+    script << "if " << py_str(pypath) << " not in sys.path:\n"
+           << "    sys.path.insert(0, " << py_str(pypath) << ")\n";
   }
-  script << "_m    = importlib.import_module('" << mod << "')\n"
+  script << "_m    = importlib.import_module(" << py_str(mod) << ")\n"
          << "_desc = cppyy.bind_object(" << desc_addr << ", 'dd4hep::Detector')\n"
          << "_xml  = cppyy.bind_object(" << xml_addr << ", 'dd4hep::xml::Handle_t')\n"
          << "_sens = cppyy.bind_object(" << sens_addr << ", 'dd4hep::SensitiveDetector')\n"
          << "try:\n"
-         << "    _res = _m." << func << "(_desc, _xml, _sens)\n"
+         << "    _res = getattr(_m, " << py_str(func) << ")(_desc, _xml, _sens)\n"
          << "except Exception:\n"
          << "    import traceback; traceback.print_exc()\n"
          << "    raise\n"

--- a/src/PythonDetector_geo.cpp
+++ b/src/PythonDetector_geo.cpp
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2025 ePIC Collaboration
+//
+// C++ trampoline plugin that delegates geometry construction to a Python function.
+//
+// Usage in compact XML:
+//   <detector id="X_ID" name="X" type="epic_PythonDetector"
+//             module="mydetector_geo" function="create_detector"
+//             readout="XHits">
+//     ...any sub-elements your Python function reads...
+//   </detector>
+//
+// The Python function must have the signature:
+//   def create_detector(description, xml_element, sens) -> dd4hep.DetElement
+//
+// Python module search path:
+//   The directory containing this plugin's compact XML (or $PYTHONPATH) is used.
+//   Optionally add a "pythonpath" attribute to the <detector> element to prepend
+//   an additional search directory.
+
+#include "DD4hep/DetFactoryHelper.h"
+#include "DD4hep/Printout.h"
+#include "TPython.h"
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+
+using namespace dd4hep;
+
+// Global DetElement that receives the result from Python via SwapWithObjAtAddr.
+// Using a module-level static means re-entrant calls are not supported, but that
+// matches the single-threaded geometry-build model of DD4hep.
+static dd4hep::DetElement _epic_python_det_result;
+
+// Expand ${VAR} environment variable references in a string path.
+static std::string expand_env(const std::string& s) {
+  std::string out;
+  for (std::size_t i = 0; i < s.size();) {
+    if (s[i] == '$' && i + 1 < s.size() && s[i + 1] == '{') {
+      std::size_t end = s.find('}', i + 2);
+      if (end != std::string::npos) {
+        std::string var = s.substr(i + 2, end - i - 2);
+        const char* val = std::getenv(var.c_str());
+        if (val)
+          out += val;
+        else
+          out += s.substr(i, end - i + 1);
+        i = end + 1;
+        continue;
+      }
+    }
+    out += s[i++];
+  }
+  return out;
+}
+
+static Ref_t create_python_detector(Detector& description, xml_h e, SensitiveDetector sens) {
+  xml_det_t x_det  = e;
+  std::string mod  = x_det.attr<std::string>(dd4hep::xml::Strng_t("module"));
+  std::string func = x_det.attr<std::string>(dd4hep::xml::Strng_t("function"));
+
+  // Pass addresses of C++ objects so Python can reconstruct cppyy proxies.
+  auto desc_addr   = reinterpret_cast<std::intptr_t>(&description);
+  auto xml_addr    = reinterpret_cast<std::intptr_t>(&e);
+  auto sens_addr   = reinterpret_cast<std::intptr_t>(&sens);
+  auto result_addr = reinterpret_cast<std::intptr_t>(&_epic_python_det_result);
+
+  std::string pypath;
+  if (x_det.hasAttr(dd4hep::xml::Strng_t("pythonpath"))) {
+    pypath = expand_env(x_det.attr<std::string>(dd4hep::xml::Strng_t("pythonpath")));
+  }
+
+  std::ostringstream script;
+  script << "import importlib.util, sys, cppyy\n";
+  if (!pypath.empty()) {
+    script << "if '" << pypath << "' not in sys.path:\n"
+           << "    sys.path.insert(0, '" << pypath << "')\n";
+  }
+  script << "_m    = importlib.import_module('" << mod << "')\n"
+         << "_desc = cppyy.bind_object(" << desc_addr << ", 'dd4hep::Detector')\n"
+         << "_xml  = cppyy.bind_object(" << xml_addr << ", 'dd4hep::xml::Handle_t')\n"
+         << "_sens = cppyy.bind_object(" << sens_addr << ", 'dd4hep::SensitiveDetector')\n"
+         << "_res  = _m." << func
+         << "(_desc, _xml, _sens)\n"
+         // Swap the result into the global C++ DetElement so C++ can retrieve it.
+         << "cppyy.gbl.ROOT.Internal.SwapWithObjAtAddr['dd4hep::DetElement']("
+         << "_res, " << result_addr << ")\n";
+
+  printout(DEBUG, "PythonDetector", "Calling %s.%s()", mod.c_str(), func.c_str());
+  if (!TPython::Exec(script.str().c_str())) {
+    except("PythonDetector", "Python call to %s.%s() failed", mod.c_str(), func.c_str());
+  }
+
+  return _epic_python_det_result;
+}
+
+DECLARE_DETELEMENT(epic_PythonDetector, create_python_detector)

--- a/src/PythonDetector_geo.cpp
+++ b/src/PythonDetector_geo.cpp
@@ -81,8 +81,11 @@ static Ref_t create_python_detector(Detector& description, xml_h e, SensitiveDet
          << "_desc = cppyy.bind_object(" << desc_addr << ", 'dd4hep::Detector')\n"
          << "_xml  = cppyy.bind_object(" << xml_addr << ", 'dd4hep::xml::Handle_t')\n"
          << "_sens = cppyy.bind_object(" << sens_addr << ", 'dd4hep::SensitiveDetector')\n"
-         << "_res  = _m." << func
-         << "(_desc, _xml, _sens)\n"
+         << "try:\n"
+         << "    _res = _m." << func << "(_desc, _xml, _sens)\n"
+         << "except Exception:\n"
+         << "    import traceback; traceback.print_exc()\n"
+         << "    raise\n"
          // Swap the result into the global C++ DetElement so C++ can retrieve it.
          << "cppyy.gbl.ROOT.Internal.SwapWithObjAtAddr['dd4hep::DetElement']("
          << "_res, " << result_addr << ")\n";

--- a/src/PythonDetector_geo.cpp
+++ b/src/PythonDetector_geo.cpp
@@ -34,23 +34,23 @@ using namespace dd4hep;
 static dd4hep::DetElement _epic_python_det_result;
 
 // Expand ${VAR} environment variable references in a string path.
-static std::string expand_env(const std::string& s) {
+static std::string expand_env(const std::string& input) {
   std::string out;
-  for (std::size_t i = 0; i < s.size();) {
-    if (s[i] == '$' && i + 1 < s.size() && s[i + 1] == '{') {
-      std::size_t end = s.find('}', i + 2);
+  for (std::size_t i = 0; i < input.size();) {
+    if (input[i] == '$' && i + 1 < input.size() && input[i + 1] == '{') {
+      std::size_t end = input.find('}', i + 2);
       if (end != std::string::npos) {
-        std::string var = s.substr(i + 2, end - i - 2);
+        std::string var = input.substr(i + 2, end - i - 2);
         const char* val = std::getenv(var.c_str());
         if (val)
           out += val;
         else
-          out += s.substr(i, end - i + 1);
+          out += input.substr(i, end - i + 1);
         i = end + 1;
         continue;
       }
     }
-    out += s[i++];
+    out += input[i++];
   }
   return out;
 }

--- a/src/PythonDetector_geo.cpp
+++ b/src/PythonDetector_geo.cpp
@@ -14,9 +14,9 @@
 //   def create_detector(description, xml_element, sens) -> dd4hep.DetElement
 //
 // Python module search path:
-//   The directory containing this plugin's compact XML (or $PYTHONPATH) is used.
-//   Optionally add a "pythonpath" attribute to the <detector> element to prepend
-//   an additional search directory.
+//   Python uses its normal module search path (for example, as configured by
+//   sys.path / $PYTHONPATH). Optionally add a "pythonpath" attribute to the
+//   <detector> element to prepend an additional search directory.
 
 #include "DD4hep/DetFactoryHelper.h"
 #include "DD4hep/Printout.h"


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR introduces a C++ trampoline plugin (`epic_PythonDetector`) that delegates detector construction to a Python function, enabling geometry to be written in Python using cppyy bindings instead of C++.

New files:
- `src/PythonDetector_geo.cpp`: `DECLARE_DETELEMENT` trampoline; reads 'module', 'function', and 'pythonpath' (with `${VAR}` expansion) from the compact XML `<detector>` element, calls the Python function via `TPython::Exec`, and retrieves the resulting `DetElement` via `SwapWithObjAtAddr`.
- `python/epic_geo_helpers.py`: shared helper module providing cppyy workarounds (`XmlChar*` helpers, `xml_coll_t` handle casting, `operator bool()` fix) and type aliases; import with `from epic_geo_helpers import *`.
- `python/SimpleDisk_python_geo.py`: working Python port of `SimpleDiskDetector_geo.cpp` demonstrating the plugin interface.
- `compact/tests/python_disk.xml`: test compact XML using `epic_PythonDetector`.
- `python/README.md`: documentation covering usage, function signature, helper module, and cppyy gotchas.

Modified files:
- `CMakeLists.txt`: link `ROOT::ROOTTPython` into the epic plugin library and install the `python/` directory to `share/epic/python/`.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

Ideation by human, problem space exploration with GitHub Copilot (Claude Sonnet 4.6), initial implementation by GitHub Copilot (Claude Sonnet 4.6), testing, review and modifications by human.