### PR TITLE
DRICH_geo: construct mirror from sphere without phi cuts

### DIFF
--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -512,8 +512,8 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
       mirrorTheta2 = M_PI;
     }
 
-    // solid : create sphere at origin, with specified angular limits;
-    // phi limits are increased to fill gaps (overlaps are cut away later)
+    // solid: create sphere at origin with the specified radial and theta limits;
+    // phi trimming is applied later via intersection with the pie-slice wedge
     Sphere mirrorSolid1(mirrorRadius, mirrorRadius + mirrorThickness, mirrorTheta1, mirrorTheta2);
 
     // mirror placement transformation (note: transformations are in reverse order)

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -514,8 +514,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
 
     // solid : create sphere at origin, with specified angular limits;
     // phi limits are increased to fill gaps (overlaps are cut away later)
-    Sphere mirrorSolid1(mirrorRadius, mirrorRadius + mirrorThickness, mirrorTheta1, mirrorTheta2,
-                        -40 * degree, 40 * degree);
+    Sphere mirrorSolid1(mirrorRadius, mirrorRadius + mirrorThickness, mirrorTheta1, mirrorTheta2);
 
     // mirror placement transformation (note: transformations are in reverse order)
     auto mirrorPos = Position(mirrorCenterX, 0., mirrorCenterZ) + originFront;


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

The current implementation constructs mirror from a sphere section that spans some hardcoded 80 degrees in phi. In current GPU-accelerated opticks and simphony codes the phi cut is not implemented and produces an error. Since it does not (yet?) matter for DRICH implementation whether spheres can be cut in phi, let's not do it for now.

To better understand the meaning of phi in question see the following renderings:

<img width="3137" height="827" alt="image" src="https://github.com/user-attachments/assets/7eff92b2-014e-4df3-a213-9dc348906b9d" />

**Legend:** Left to right:
1. nominal geometry
2. geometry with 40 degrees values (80 degrees span) replaced by 10 degrees values (20 degrees span)
3. present PR

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
