### PR TITLE
fix: use ePIC in github pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
-title: EPIC
-description: DD4hep Geometry Description of the EPIC Experiment
+title: ePIC
+description: DD4hep Geometry Description of the ePIC Experiment
 
-url: https://wdconinc.github.io
+url: https://eic.github.io
 baseurl: /epic
 
 theme: minima


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes the capitalization on https://eic.github.io/epic/, and moves it away from somehow still relying on my namespace...

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
