### PR TITLE
feat: add graphicalScan material and field scan pipeline

### DIFF
--- a/.github/graphical-scan-configs.yml
+++ b/.github/graphical-scan-configs.yml
@@ -1,0 +1,50 @@
+# graphical-scan-configs.yml
+#
+# Configuration for DD4hep graphicalScan runs.
+# Used by the graphical-scan workflow jobs in linux-eic-shell.yml.
+#
+# graphicalScan usage:
+#   graphicalScan <compact.xml> <axis> <xMin> <xMax> <yMin> <yMax> <zMin> <zMax>
+#                 <nSlices> <nBins> <nSamples> <F|M|FM> <output.root>
+#
+#   axis     - axis perpendicular to the slice planes (X, Y, or Z)
+#   xMin/xMax, yMin/yMax, zMin/zMax - full coordinate range of the scan [cm]
+#   nSlices  - number of equally-spaced slice positions along the chosen axis
+#   nBins    - number of bins per histogram axis (higher = finer spatial resolution)
+#   nSamples - number of random samples per bin (higher = less statistical noise)
+#   label    - short identifier used for artifact and file naming
+
+scans:
+
+  # Transverse (XY) view: slices perpendicular to the beam axis (Z).
+  # Five slices span the detector from upstream to downstream, revealing
+  # the circular barrel cross-section for both field and material maps.
+  - axis: Z
+    xMin: -450
+    xMax:  450
+    yMin: -450
+    yMax:  450
+    zMin: -700
+    zMax:  700
+    nSlices:  5
+    nBins:  200
+    nSamples: 10
+    label: XY
+
+  # Longitudinal (ZY) view: a single slice through the detector centre (X ≈ 0).
+  # Shows the full forward/backward geometry and solenoid field profile.
+  - axis: X
+    xMin:  -10
+    xMax:   10
+    yMin: -450
+    yMax:  450
+    zMin: -700
+    zMax:  700
+    nSlices:  1
+    nBins:  200
+    nSamples: 10
+    label: ZY
+
+# Detector configurations to scan (must match installed compact XML basenames).
+detector_configs:
+  - epic_craterlake

--- a/.github/graphical-scan-configs.yml
+++ b/.github/graphical-scan-configs.yml
@@ -27,7 +27,7 @@ scans:
     zMin: -700
     zMax:  700
     nSlices:  5
-    nBins:  200
+    nBins:  500
     nSamples: 10
     label: XY
 
@@ -41,7 +41,7 @@ scans:
     zMin: -700
     zMax:  700
     nSlices:  1
-    nBins:  200
+    nBins:  500
     nSamples: 10
     label: ZY
 

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -552,6 +552,109 @@ jobs:
         pattern: ${{ matrix.detector_config }}_views_*
         delete-merged: true
 
+  load-graphical-scan-configs:
+    runs-on: ubuntu-latest
+    outputs:
+      scan_matrix:   ${{ steps.read-config.outputs.scan_matrix }}
+      render_matrix: ${{ steps.read-config.outputs.render_matrix }}
+    steps:
+    - uses: actions/checkout@v6
+    - id: read-config
+      run: |
+        python3 << 'PYEOF'
+        import json, yaml, os
+        with open('.github/graphical-scan-configs.yml') as f:
+            config = yaml.safe_load(f)
+        scan_matrix   = {'scan': config['scans'],
+                         'detector_config': config['detector_configs']}
+        render_matrix = {'scan': [{'label': s['label']} for s in config['scans']],
+                         'detector_config': config['detector_configs']}
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as gho:
+            gho.write('scan_matrix='   + json.dumps(scan_matrix)   + '\n')
+            gho.write('render_matrix=' + json.dumps(render_matrix) + '\n')
+        PYEOF
+
+  graphical-scan:
+    runs-on: ubuntu-latest
+    needs:
+    - build
+    - load-graphical-scan-configs
+    strategy:
+      matrix: ${{ fromJSON(needs.load-graphical-scan-configs.outputs.scan_matrix) }}
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/download-artifact@v8
+      with:
+        name: build-gcc-nightly-full-eic-shell
+        path: install/
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
+    - uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        platform-release: "eic_xl:nightly"
+        setup: install/bin/thisepic.sh
+        run: |
+          export DETECTOR_CACHE=/opt/detector/epic-main/share/epic
+          mkdir -p scans
+          graphicalScan \
+            ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml \
+            ${{ matrix.scan.axis }} \
+            ${{ matrix.scan.xMin }} ${{ matrix.scan.xMax }} \
+            ${{ matrix.scan.yMin }} ${{ matrix.scan.yMax }} \
+            ${{ matrix.scan.zMin }} ${{ matrix.scan.zMax }} \
+            ${{ matrix.scan.nSlices }} ${{ matrix.scan.nBins }} ${{ matrix.scan.nSamples }} \
+            FM \
+            scans/${{ matrix.detector_config }}_scans_${{ matrix.scan.label }}.root
+    - uses: actions/upload-artifact@v7
+      with:
+        name: ${{ matrix.detector_config }}_scans_${{ matrix.scan.label }}
+        path: scans/${{ matrix.detector_config }}_scans_${{ matrix.scan.label }}.root
+        if-no-files-found: error
+
+  render-graphical-scans:
+    runs-on: ubuntu-latest
+    needs:
+    - graphical-scan
+    - load-graphical-scan-configs
+    strategy:
+      matrix: ${{ fromJSON(needs.load-graphical-scan-configs.outputs.render_matrix) }}
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/download-artifact@v8
+      with:
+        name: ${{ matrix.detector_config }}_scans_${{ matrix.scan.label }}
+        path: scans/
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
+    - uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        platform-release: "eic_xl:nightly"
+        run: |
+          pip install --quiet pillow
+          mkdir -p images/${{ matrix.detector_config }}_scans
+          bin/render_graphical_scans \
+            scans/${{ matrix.detector_config }}_scans_${{ matrix.scan.label }}.root \
+            images/${{ matrix.detector_config }}_scans
+    - uses: actions/upload-artifact@v7
+      with:
+        name: ${{ matrix.detector_config }}_scans_rendered_${{ matrix.scan.label }}
+        path: images/
+        if-no-files-found: error
+
+  merge-graphical-scans:
+    runs-on: ubuntu-latest
+    needs:
+    - render-graphical-scans
+    strategy:
+      matrix:
+        detector_config: [epic_craterlake]
+    steps:
+    - uses: actions/upload-artifact/merge@v7
+      with:
+        name: ${{ matrix.detector_config }}_scans
+        pattern: ${{ matrix.detector_config }}_scans_rendered_*
+        delete-merged: true
+
   npsim-gun:
     runs-on: ubuntu-latest
     needs: build
@@ -917,6 +1020,7 @@ jobs:
     - merge-constants
     - merge-parameter-table
     - merge-dawn-view
+    - merge-graphical-scans
     - get-docs-from-open-prs
     - get-docs-from-main
     if: |

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ header_pages:
   - reports/artifacts.md
   - reports/geoviewer.md
   - reports/craterlake_views.md
+  - reports/craterlake_scans.md
 
 exclude:
   - bin/

--- a/bin/render_graphical_scans
+++ b/bin/render_graphical_scans
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 EIC Collaboration
+'''
+    Render TH2F histograms from graphicalScan ROOT output to PNG images,
+    with the ePIC collaboration logo overlaid in the bottom-right corner.
+
+    Usage:
+        render_graphical_scans <input.root> <output_dir>
+'''
+
+import io
+import os
+import sys
+import argparse
+import urllib.request
+
+from PIL import Image
+
+import ROOT
+
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat(0)
+ROOT.gStyle.SetPalette(ROOT.kRainBow)
+
+# White-on-transparent logo works well over COLZ colour-scale plots.
+LOGO_URL = 'https://zenodo.org/records/14058463/files/2560px-EPIC-logo_white_transparent.png?download=1'
+# Logo width as a fraction of the canvas width; placed in the bottom-right corner.
+LOGO_WIDTH_FRACTION = 0.18
+LOGO_MARGIN = 20  # pixels from the canvas edge
+
+
+def fetch_logo(url):
+    '''Download the ePIC logo and return a PIL Image (RGBA).'''
+    print(f'Fetching logo from {url}')
+    with urllib.request.urlopen(url) as resp:
+        data = resp.read()
+    return Image.open(io.BytesIO(data)).convert('RGBA')
+
+
+def overlay_logo(png_path, logo):
+    '''Composite *logo* onto the bottom-right corner of the PNG at *png_path*.'''
+    base = Image.open(png_path).convert('RGBA')
+    w, h = base.size
+
+    logo_w = int(w * LOGO_WIDTH_FRACTION)
+    logo_h = int(logo.height * logo_w / logo.width)
+    resized = logo.resize((logo_w, logo_h), Image.LANCZOS)
+
+    x = w - logo_w - LOGO_MARGIN
+    y = h - logo_h - LOGO_MARGIN
+    base.paste(resized, (x, y), resized)
+    base.save(png_path)
+
+
+def render_histogram(hist, output_path, base_width=1200,
+                     left_margin=0.10, right_margin=0.15,
+                     top_margin=0.10, bottom_margin=0.10):
+    '''Render *hist* to *output_path* with an aspect ratio that preserves equal
+    physical scale on both axes (no distortion of cylindrical geometry).
+
+    The canvas height is derived from the histogram axis ranges and the margin
+    fractions so that 1 cm on the x-axis occupies the same number of pixels as
+    1 cm on the y-axis.
+    '''
+    x_span = hist.GetXaxis().GetXmax() - hist.GetXaxis().GetXmin()
+    y_span = hist.GetYaxis().GetXmax() - hist.GetYaxis().GetXmin()
+
+    # Plot area fractions (excluding margins)
+    plot_w_frac = 1.0 - left_margin - right_margin
+    plot_h_frac = 1.0 - top_margin  - bottom_margin
+
+    # Equal physical scale: plot_width_px / x_span == plot_height_px / y_span
+    plot_width_px = base_width * plot_w_frac
+    canvas_height  = int(plot_width_px / x_span * y_span / plot_h_frac)
+
+    c = ROOT.TCanvas(f'c_{hist.GetName()}', '', base_width, canvas_height)
+    c.SetLeftMargin(left_margin)
+    c.SetRightMargin(right_margin)
+    c.SetTopMargin(top_margin)
+    c.SetBottomMargin(bottom_margin)
+    hist.Draw('COLZ')
+    hist.GetXaxis().SetTitleSize(0.04)
+    hist.GetYaxis().SetTitleSize(0.04)
+    c.SaveAs(output_path)
+    c.Close()
+
+
+def render_root_file(input_path, output_dir, logo):
+    os.makedirs(output_dir, exist_ok=True)
+
+    f = ROOT.TFile.Open(input_path)
+    if not f or f.IsZombie():
+        print(f'ERROR: Cannot open {input_path}', file=sys.stderr)
+        sys.exit(1)
+
+    for slice_key in f.GetListOfKeys():
+        obj = slice_key.ReadObj()
+        if not isinstance(obj, ROOT.TDirectoryFile):
+            continue
+        slice_name = slice_key.GetName()
+
+        for hist_key in obj.GetListOfKeys():
+            hist = hist_key.ReadObj()
+            if not isinstance(hist, ROOT.TH2F):
+                continue
+            hist_name = hist_key.GetName()
+            # Sanitise title for use in filename
+            safe_title = (hist.GetTitle()
+                          .replace(' ', '_').replace('[', '').replace(']', '')
+                          .replace('/', '_per_').replace('=', '').replace('.', 'p'))
+            png_name = f'{slice_name}_{hist_name}_{safe_title}.png'
+            output_path = os.path.join(output_dir, png_name)
+            print(f'Rendering {slice_name}/{hist_name} -> {output_path}')
+            render_histogram(hist, output_path)
+            if logo is not None:
+                overlay_logo(output_path, logo)
+
+    f.Close()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        prog='render_graphical_scans',
+        description='Render TH2F histograms from graphicalScan ROOT output to PNG images.',
+    )
+    parser.add_argument('input', help='Input ROOT file produced by graphicalScan')
+    parser.add_argument('output_dir', help='Directory to write PNG images into')
+    parser.add_argument('--no-logo', action='store_true',
+                        help='Skip logo overlay (useful when network is unavailable)')
+    args = parser.parse_args()
+
+    logo = None
+    if not args.no_logo:
+        try:
+            logo = fetch_logo(LOGO_URL)
+        except Exception as e:
+            print(f'WARNING: Could not fetch logo ({e}); continuing without overlay.', file=sys.stderr)
+
+    render_root_file(args.input, args.output_dir, logo)
+    print(f'Done. Images written to {args.output_dir}/')

--- a/bin/render_graphical_scans
+++ b/bin/render_graphical_scans
@@ -25,7 +25,7 @@ ROOT.gStyle.SetOptStat(0)
 ROOT.gStyle.SetPalette(ROOT.kRainBow)
 
 # White-on-transparent logo works well over COLZ colour-scale plots.
-LOGO_URL = 'https://zenodo.org/records/14058463/files/2560px-EPIC-logo_white_transparent.png?download=1'
+LOGO_URL = 'https://zenodo.org/records/14058463/files/2560px-EPIC-logo_black_transparent.png?download=1'
 # Logo width as a fraction of the canvas width; placed in the bottom-right corner.
 LOGO_WIDTH_FRACTION = 0.18
 LOGO_MARGIN = 20  # pixels from the canvas edge

--- a/bin/render_graphical_scans
+++ b/bin/render_graphical_scans
@@ -24,7 +24,7 @@ ROOT.gROOT.SetBatch(True)
 ROOT.gStyle.SetOptStat(0)
 ROOT.gStyle.SetPalette(ROOT.kRainBow)
 
-# White-on-transparent logo works well over COLZ colour-scale plots.
+# Black-on-transparent logo works well over COLZ colour-scale plots.
 LOGO_URL = 'https://zenodo.org/records/14058463/files/2560px-EPIC-logo_black_transparent.png?download=1'
 # Logo width as a fraction of the canvas width; placed in the bottom-right corner.
 LOGO_WIDTH_FRACTION = 0.10

--- a/bin/render_graphical_scans
+++ b/bin/render_graphical_scans
@@ -27,8 +27,8 @@ ROOT.gStyle.SetPalette(ROOT.kRainBow)
 # White-on-transparent logo works well over COLZ colour-scale plots.
 LOGO_URL = 'https://zenodo.org/records/14058463/files/2560px-EPIC-logo_black_transparent.png?download=1'
 # Logo width as a fraction of the canvas width; placed in the bottom-right corner.
-LOGO_WIDTH_FRACTION = 0.18
-LOGO_MARGIN = 20  # pixels from the canvas edge
+LOGO_WIDTH_FRACTION = 0.10
+LOGO_MARGIN = 10  # pixels from the canvas edge
 
 
 def fetch_logo(url):

--- a/bin/render_graphical_scans
+++ b/bin/render_graphical_scans
@@ -54,7 +54,7 @@ def overlay_logo(png_path, logo):
     base.save(png_path)
 
 
-def render_histogram(hist, output_path, base_width=1200,
+def render_histogram(hist, output_path, log_z=False, base_width=1200,
                      left_margin=0.10, right_margin=0.15,
                      top_margin=0.10, bottom_margin=0.10):
     '''Render *hist* to *output_path* with an aspect ratio that preserves equal
@@ -63,6 +63,8 @@ def render_histogram(hist, output_path, base_width=1200,
     The canvas height is derived from the histogram axis ranges and the margin
     fractions so that 1 cm on the x-axis occupies the same number of pixels as
     1 cm on the y-axis.
+
+    If *log_z* is True, the z-axis (color scale) is set to logarithmic.
     '''
     x_span = hist.GetXaxis().GetXmax() - hist.GetXaxis().GetXmin()
     y_span = hist.GetYaxis().GetXmax() - hist.GetYaxis().GetXmin()
@@ -80,9 +82,13 @@ def render_histogram(hist, output_path, base_width=1200,
     c.SetRightMargin(right_margin)
     c.SetTopMargin(top_margin)
     c.SetBottomMargin(bottom_margin)
+    if log_z:
+        c.SetLogz(True)
     hist.Draw('COLZ')
     hist.GetXaxis().SetTitleSize(0.04)
     hist.GetYaxis().SetTitleSize(0.04)
+    c.Modified()
+    c.Update()
     c.SaveAs(output_path)
     c.Close()
 
@@ -110,12 +116,22 @@ def render_root_file(input_path, output_dir, logo):
             safe_title = (hist.GetTitle()
                           .replace(' ', '_').replace('[', '').replace(']', '')
                           .replace('/', '_per_').replace('=', '').replace('.', 'p'))
-            png_name = f'{slice_name}_{hist_name}_{safe_title}.png'
-            output_path = os.path.join(output_dir, png_name)
-            print(f'Rendering {slice_name}/{hist_name} -> {output_path}')
-            render_histogram(hist, output_path)
+
+            # Render with linear scale
+            png_name_linear = f'{slice_name}_{hist_name}_{safe_title}.png'
+            output_path_linear = os.path.join(output_dir, png_name_linear)
+            print(f'Rendering {slice_name}/{hist_name} (linear) -> {output_path_linear}')
+            render_histogram(hist, output_path_linear, log_z=False)
             if logo is not None:
-                overlay_logo(output_path, logo)
+                overlay_logo(output_path_linear, logo)
+
+            # Render with logarithmic scale
+            png_name_log = f'{slice_name}_{hist_name}_{safe_title}_logz.png'
+            output_path_log = os.path.join(output_dir, png_name_log)
+            print(f'Rendering {slice_name}/{hist_name} (log) -> {output_path_log}')
+            render_histogram(hist, output_path_log, log_z=True)
+            if logo is not None:
+                overlay_logo(output_path_log, logo)
 
     f.Close()
 

--- a/bin/render_graphical_scans
+++ b/bin/render_graphical_scans
@@ -139,6 +139,20 @@ def render_root_file(input_path, output_dir, logo):
             else:
                 hist_for_log = hist
 
+            # For labmda/X0 histograms, suppress non-zero values for vacuum
+            is_lambda_hist = any(keyword in hist_name for keyword in ['lambda', 'X0'])
+
+            if is_lambda_hist:
+                # Create a clone and suppress below threshold values
+                hist_for_log = hist.Clone(f'{hist_name}_log')
+                for i in range(1, hist_for_log.GetNbinsX() + 1):
+                    for j in range(1, hist_for_log.GetNbinsY() + 1):
+                        val = hist_for_log.GetBinContent(i, j)
+                        if val < 1e-5:
+                            hist_for_log.SetBinContent(i, j, 0)
+            else:
+                hist_for_log = hist
+
             png_name_log = f'{slice_name}_{hist_name}_{safe_title}_logz.png'
             output_path_log = os.path.join(output_dir, png_name_log)
             print(f'Rendering {slice_name}/{hist_name} (log) -> {output_path_log}')

--- a/bin/render_graphical_scans
+++ b/bin/render_graphical_scans
@@ -126,10 +126,23 @@ def render_root_file(input_path, output_dir, logo):
                 overlay_logo(output_path_linear, logo)
 
             # Render with logarithmic scale
+            # For field histograms (B field), take absolute value first
+            is_field_hist = any(keyword in hist_name for keyword in ['Bx', 'By', 'Bz'])
+
+            if is_field_hist:
+                # Create a clone and take absolute values
+                hist_for_log = hist.Clone(f'{hist_name}_abs')
+                for i in range(1, hist_for_log.GetNbinsX() + 1):
+                    for j in range(1, hist_for_log.GetNbinsY() + 1):
+                        val = hist_for_log.GetBinContent(i, j)
+                        hist_for_log.SetBinContent(i, j, abs(val))
+            else:
+                hist_for_log = hist
+
             png_name_log = f'{slice_name}_{hist_name}_{safe_title}_logz.png'
             output_path_log = os.path.join(output_dir, png_name_log)
             print(f'Rendering {slice_name}/{hist_name} (log) -> {output_path_log}')
-            render_histogram(hist, output_path_log, log_z=True)
+            render_histogram(hist_for_log, output_path_log, log_z=True)
             if logo is not None:
                 overlay_logo(output_path_log, logo)
 

--- a/reports/craterlake_scans.md
+++ b/reports/craterlake_scans.md
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Scans (craterlake)
+permalink: /craterlake_scans
+---
+{% for image in site.static_files %}
+  {% if image.path contains 'epic_craterlake_scans/' %}
+<p><a href="{{ site.baseurl }}/{{ image.path }}">{{ image.path }}</a></p>
+    {% if image.extname contains 'png' %}
+<img src="{{ site.baseurl }}/{{ image.path }}" width="400px"/>
+    {% endif %}
+  {% endif %}
+{% endfor %}


### PR DESCRIPTION
## Summary

Adds a CI pipeline that runs DD4hep's `graphicalScan` tool on the `epic_craterlake` geometry and publishes the resulting images to the GitHub Pages site at [`/craterlake_scans`](https://eic.github.io/epic/craterlake_scans), analogous to the existing dawn views at [`/craterlake_views`](https://eic.github.io/epic/craterlake_views).

## New files

- **`.github/graphical-scan-configs.yml`** — documented YAML configuration file defining all scan parameters. Adding or modifying a scan requires editing only this file (no workflow changes needed).
- **`bin/render_graphical_scans`** — Python/PyROOT script that opens the `graphicalScan` ROOT output, renders each TH2F slice as a PNG with a correct equal-physical-scale aspect ratio (no distortion of cylindrical geometry into ellipses), and overlays the ePIC black-transparent logo from [Zenodo](https://zenodo.org/records/14058463) in the bottom-right corner.
- **`reports/craterlake_scans.md`** — Jekyll page at `/craterlake_scans`.

## Modified files

- **`.github/workflows/linux-eic-shell.yml`** — four new jobs:
  - `load-graphical-scan-configs`: reads the YAML config and outputs matrices for the downstream jobs
  - `graphical-scan`: runs `graphicalScan` for each scan config × detector config
  - `render-graphical-scans`: converts ROOT output to logo-stamped PNGs
  - `merge-graphical-scans`: merges per-scan artifacts into `epic_craterlake_scans` for Jekyll
  - `merge-graphical-scans` added to `build-artifacts-page` needs
- **`_config.yml`** — adds `/craterlake_scans` to the site navigation bar

## Scan configurations

| Label | Axis | X range (cm) | Y range (cm) | Z range (cm) | Slices | Bins | Samples |
|-------|------|-------------|-------------|-------------|--------|------|---------|
| XY | Z | −450 to 450 | −450 to 450 | −700 to 700 | 5 | 200 | 10 |
| ZY | X | −10 to 10 | −450 to 450 | −700 to 700 | 1 | 200 | 10 |

Both scans use `FM` (field + material).