### PR TITLE
HcalBarrel: replace tessellated tiles and end ring with primitive solids

### DIFF
--- a/compact/hcal/barrel_gdml.xml
+++ b/compact/hcal/barrel_gdml.xml
@@ -25,23 +25,236 @@
         <type_flags type="DetType_CALORIMETER + DetType_BARREL + DetType_HADRONIC"/>
         <sec_gdmlfile file="gdml/barrel_hcal_steel_sector_nocombs.gdml" url="https://github.com/eic/epic-data/raw/c1ef9dca1781047fe9485eec6c0f986ec7d27f41/barrel_HCAL_gdml/barrel_hcal_steel_sector_nocombs.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="Steel1020"/>
         <csec_gdmlfile file="gdml/barrel_hcal_steel_chimneysector_nocombs.gdml" url="https://github.com/eic/epic-data/raw/c1ef9dca1781047fe9485eec6c0f986ec7d27f41/barrel_HCAL_gdml/barrel_hcal_steel_chimneysector_nocombs.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="Steel1020"/>
-        <er_gdmlfile file="gdml/barrel_hcal_steel_endring.gdml" url="https://github.com/eic/epic-data/raw/c1ef9dca1781047fe9485eec6c0f986ec7d27f41/barrel_HCAL_gdml/barrel_hcal_steel_endring.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="Steel1020"/>
-        <tile1_gdmlfile file="gdml/Tile01_Reduced.gdml" url="https://github.com/eic/epic-data/raw/2edf54d71b069acb81d969a75717427a0bf77217/barrel_HCAL_gdml/tiles/Tile01_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <tile2_gdmlfile file="gdml/Tile02_Reduced.gdml" url="https://github.com/eic/epic-data/raw/2edf54d71b069acb81d969a75717427a0bf77217/barrel_HCAL_gdml/tiles/Tile02_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <tile3_gdmlfile file="gdml/Tile03_Reduced.gdml" url="https://github.com/eic/epic-data/raw/2edf54d71b069acb81d969a75717427a0bf77217/barrel_HCAL_gdml/tiles/Tile03_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <tile4_gdmlfile file="gdml/Tile04_Reduced.gdml" url="https://github.com/eic/epic-data/raw/2edf54d71b069acb81d969a75717427a0bf77217/barrel_HCAL_gdml/tiles/Tile04_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <tile5_gdmlfile file="gdml/Tile05_Reduced.gdml" url="https://github.com/eic/epic-data/raw/557595947d6423b8925a917c09461654e9df2d45/barrel_HCAL_gdml/tiles/Tile05_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <tile6_gdmlfile file="gdml/Tile06_Reduced.gdml" url="https://github.com/eic/epic-data/raw/2edf54d71b069acb81d969a75717427a0bf77217/barrel_HCAL_gdml/tiles/Tile06_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <tile7_gdmlfile file="gdml/Tile07_Reduced.gdml" url="https://github.com/eic/epic-data/raw/2edf54d71b069acb81d969a75717427a0bf77217/barrel_HCAL_gdml/tiles/Tile07_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <tile8_gdmlfile file="gdml/Tile08_Reduced.gdml" url="https://github.com/eic/epic-data/raw/582c777d1f17886da4619b1a2b047c507db43672/barrel_HCAL_gdml/tiles/Tile08_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <tile9_gdmlfile file="gdml/Tile09_Reduced.gdml" url="https://github.com/eic/epic-data/raw/66733a76b758ce9d85d270e59fdd560f84bc70ec/barrel_HCAL_gdml/tiles/Tile09_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <tile10_gdmlfile file="gdml/Tile10_Reduced.gdml" url="https://github.com/eic/epic-data/raw/66733a76b758ce9d85d270e59fdd560f84bc70ec/barrel_HCAL_gdml/tiles/Tile10_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <tile11_gdmlfile file="gdml/Tile11_Reduced.gdml" url="https://github.com/eic/epic-data/raw/66733a76b758ce9d85d270e59fdd560f84bc70ec/barrel_HCAL_gdml/tiles/Tile11_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <tile12_gdmlfile file="gdml/Tile12_Reduced.gdml" url="https://github.com/eic/epic-data/raw/66733a76b758ce9d85d270e59fdd560f84bc70ec/barrel_HCAL_gdml/tiles/Tile12_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <ctile9_gdmlfile file="gdml/CTile09_Reduced.gdml" url="https://github.com/eic/epic-data/raw/2edf54d71b069acb81d969a75717427a0bf77217/barrel_HCAL_gdml/tiles/CTile09_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <ctile10_gdmlfile file="gdml/CTile10_Reduced.gdml" url="https://github.com/eic/epic-data/raw/2edf54d71b069acb81d969a75717427a0bf77217/barrel_HCAL_gdml/tiles/CTile10_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <ctile11_gdmlfile file="gdml/CTile11_Reduced.gdml" url="https://github.com/eic/epic-data/raw/2edf54d71b069acb81d969a75717427a0bf77217/barrel_HCAL_gdml/tiles/CTile11_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
-        <ctile12_gdmlfile file="gdml/CTile12_Reduced.gdml" url="https://github.com/eic/epic-data/raw/2edf54d71b069acb81d969a75717427a0bf77217/barrel_HCAL_gdml/tiles/CTile12_Reduced.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="PlasticScint"/>
+        <er_gdmlfile material="Steel1020">
+          <dimensions rinner="1980.15" router="2619.85" zhalf="19.304" zcenter="3178.406"
+                      nholes="32" rhole="152.4" rhole_ctr="2293.86069"/>
+        </er_gdmlfile>
+        <tile1_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="1.9212" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition="8.9212" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="-102.207000" y="-426.850000"/>
+            <twoDimVertex x="-102.207000" y=" 381.494482"/>
+            <twoDimVertex x=" -35.668670" y=" 381.494482"/>
+            <twoDimVertex x=" -35.668670" y=" 372.824500"/>
+            <twoDimVertex x="  35.801331" y=" 372.824500"/>
+            <twoDimVertex x="  35.801331" y=" 381.494482"/>
+            <twoDimVertex x=" 136.273087" y=" 381.494482"/>
+            <twoDimVertex x="  63.817399" y="-426.850000"/>
+          </shape>
+        </tile1_gdmlfile>
+        <tile2_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="-143.321588" y="-426.422000"/>
+            <twoDimVertex x=" -70.865900" y=" 381.922482"/>
+            <twoDimVertex x="  -7.278375" y=" 381.922482"/>
+            <twoDimVertex x="  -7.278375" y=" 372.872495"/>
+            <twoDimVertex x="  64.191626" y=" 372.872495"/>
+            <twoDimVertex x="  64.191626" y=" 381.922482"/>
+            <twoDimVertex x=" 173.766669" y=" 381.922482"/>
+            <twoDimVertex x="  28.060339" y="-426.422000"/>
+          </shape>
+        </tile2_gdmlfile>
+        <tile3_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="-180.683547" y="-427.080000"/>
+            <twoDimVertex x=" -34.977218" y=" 381.264482"/>
+            <twoDimVertex x="  22.907151" y=" 381.264482"/>
+            <twoDimVertex x="  22.907151" y=" 372.214495"/>
+            <twoDimVertex x="  94.377183" y=" 372.214495"/>
+            <twoDimVertex x="  94.377183" y=" 381.264482"/>
+            <twoDimVertex x=" 207.250291" y=" 381.264482"/>
+            <twoDimVertex x=" -12.735671" y="-427.080000"/>
+          </shape>
+        </tile3_gdmlfile>
+        <tile4_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="  -3.905333" y=" 381.526482"/>
+            <twoDimVertex x="-223.891325" y="-426.818000"/>
+            <twoDimVertex x=" -48.887693" y="-426.818000"/>
+            <twoDimVertex x=" 247.276369" y=" 381.526482"/>
+            <twoDimVertex x=" 124.100161" y=" 381.526482"/>
+            <twoDimVertex x=" 124.100161" y=" 372.476495"/>
+            <twoDimVertex x="  52.630129" y=" 372.476495"/>
+            <twoDimVertex x="  52.630129" y=" 381.526482"/>
+          </shape>
+        </tile4_gdmlfile>
+        <tile5_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="  28.549372" y=" 381.478482"/>
+            <twoDimVertex x="-267.614691" y="-426.866000"/>
+            <twoDimVertex x=" -86.592779" y="-426.866000"/>
+            <twoDimVertex x=" 288.371088" y=" 381.478482"/>
+            <twoDimVertex x=" 219.066645" y=" 381.478482"/>
+            <twoDimVertex x=" 219.066645" y=" 372.428495"/>
+            <twoDimVertex x=" 147.596552" y=" 372.428495"/>
+            <twoDimVertex x=" 147.596552" y=" 381.478482"/>
+          </shape>
+        </tile5_gdmlfile>
+        <tile6_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="-313.621423" y="-426.919000"/>
+            <twoDimVertex x="  61.342383" y=" 381.425482"/>
+            <twoDimVertex x=" 115.199561" y=" 381.425482"/>
+            <twoDimVertex x=" 115.199561" y=" 372.375495"/>
+            <twoDimVertex x=" 186.669531" y=" 372.375495"/>
+            <twoDimVertex x=" 186.669531" y=" 381.425482"/>
+            <twoDimVertex x=" 330.776465" y=" 381.425482"/>
+            <twoDimVertex x="-125.911157" y="-426.919000"/>
+          </shape>
+        </tile6_gdmlfile>
+        <tile7_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="-362.442598" y="-426.976000"/>
+            <twoDimVertex x="  94.245024" y=" 381.368482"/>
+            <twoDimVertex x=" 149.082549" y=" 381.368482"/>
+            <twoDimVertex x=" 149.082549" y=" 372.318495"/>
+            <twoDimVertex x=" 220.552520" y=" 372.318495"/>
+            <twoDimVertex x=" 220.552520" y=" 381.368482"/>
+            <twoDimVertex x=" 376.774077" y=" 381.368482"/>
+            <twoDimVertex x="-165.592134" y="-426.976000"/>
+          </shape>
+        </tile7_gdmlfile>
+        <tile8_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="-414.647910" y="-426.824000"/>
+            <twoDimVertex x=" 127.718301" y=" 381.520482"/>
+            <twoDimVertex x=" 184.142861" y=" 381.520482"/>
+            <twoDimVertex x=" 184.142861" y=" 372.470495"/>
+            <twoDimVertex x=" 255.612832" y=" 372.470495"/>
+            <twoDimVertex x=" 255.612832" y=" 381.520482"/>
+            <twoDimVertex x=" 426.309854" y=" 381.520482"/>
+            <twoDimVertex x="-205.897178" y="-426.824000"/>
+          </shape>
+        </tile8_gdmlfile>
+        <tile9_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="-118.545385" y=" 326.307482"/>
+            <twoDimVertex x=" 416.710475" y="-358.074498"/>
+            <twoDimVertex x=" 181.886622" y="-358.074498"/>
+            <twoDimVertex x="-435.632543" y=" 326.307482"/>
+            <twoDimVertex x="-243.662816" y=" 326.307482"/>
+            <twoDimVertex x="-243.662816" y=" 317.257495"/>
+            <twoDimVertex x="-172.192846" y=" 317.257495"/>
+            <twoDimVertex x="-172.192846" y=" 326.307482"/>
+          </shape>
+        </tile9_gdmlfile>
+        <tile10_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="-149.569467" y=" 326.436482"/>
+            <twoDimVertex x=" 467.949698" y="-357.945498"/>
+            <twoDimVertex x=" 218.585807" y="-357.945498"/>
+            <twoDimVertex x="-485.130502" y=" 326.436482"/>
+            <twoDimVertex x="-272.052865" y=" 326.436482"/>
+            <twoDimVertex x="-272.052865" y=" 317.386495"/>
+            <twoDimVertex x="-200.582895" y=" 317.386495"/>
+            <twoDimVertex x="-200.582895" y=" 326.436482"/>
+          </shape>
+        </tile10_gdmlfile>
+        <tile11_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x=" 480.269480" y="-346.196498"/>
+            <twoDimVertex x="-223.446828" y=" 338.185482"/>
+            <twoDimVertex x="-246.227834" y=" 338.185482"/>
+            <twoDimVertex x="-246.227834" y=" 329.135495"/>
+            <twoDimVertex x="-317.697805" y=" 329.135495"/>
+            <twoDimVertex x="-317.697805" y=" 338.185482"/>
+            <twoDimVertex x="-488.055959" y=" 338.185482"/>
+            <twoDimVertex x=" 239.031199" y="-346.196498"/>
+          </shape>
+        </tile11_gdmlfile>
+        <tile12_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x=" 492.771215" y="-308.834498"/>
+            <twoDimVertex x="-234.315943" y=" 375.547482"/>
+            <twoDimVertex x="-256.116480" y=" 375.547482"/>
+            <twoDimVertex x="-256.116480" y=" 366.497495"/>
+            <twoDimVertex x="-327.586451" y=" 366.497495"/>
+            <twoDimVertex x="-327.586451" y=" 375.547482"/>
+            <twoDimVertex x="-333.086451" y=" 375.547482"/>
+            <twoDimVertex x="-333.086451" y="  86.981442"/>
+            <twoDimVertex x=" 183.030736" y="-308.834498"/>
+          </shape>
+        </tile12_gdmlfile>
+        <ctile9_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="-280.572737" y="-167.969510"/>
+            <twoDimVertex x=" -21.947615" y=" 162.710482"/>
+            <twoDimVertex x="  31.699846" y=" 162.710482"/>
+            <twoDimVertex x="  31.699846" y=" 153.660495"/>
+            <twoDimVertex x=" 103.169816" y=" 153.660495"/>
+            <twoDimVertex x=" 103.169816" y=" 162.710482"/>
+            <twoDimVertex x=" 295.139543" y=" 162.710482"/>
+            <twoDimVertex x="  -3.233504" y="-167.969510"/>
+          </shape>
+        </ctile9_gdmlfile>
+        <ctile10_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x=" -11.216533" y=" 162.699482"/>
+            <twoDimVertex x="-309.607646" y="-168.000499"/>
+            <twoDimVertex x=" -15.697979" y="-168.000499"/>
+            <twoDimVertex x=" 324.344502" y=" 162.699482"/>
+            <twoDimVertex x=" 111.266865" y=" 162.699482"/>
+            <twoDimVertex x=" 111.266865" y=" 153.649495"/>
+            <twoDimVertex x="  39.796895" y=" 153.649495"/>
+            <twoDimVertex x="  39.796895" y=" 162.699482"/>
+          </shape>
+        </ctile10_gdmlfile>
+        <ctile11_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="-300.003652" y="-165.319499"/>
+            <twoDimVertex x="  40.038828" y=" 165.380482"/>
+            <twoDimVertex x="  62.819834" y=" 165.380482"/>
+            <twoDimVertex x="  62.819834" y=" 156.330495"/>
+            <twoDimVertex x=" 134.289805" y=" 156.330495"/>
+            <twoDimVertex x=" 134.289805" y=" 165.380482"/>
+            <twoDimVertex x=" 304.647959" y=" 165.380482"/>
+            <twoDimVertex x=" -46.687490" y="-165.319499"/>
+          </shape>
+        </ctile11_gdmlfile>
+        <ctile12_gdmlfile material="PlasticScint">
+          <shape type="Xtru">
+            <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="-291.496266" y="-130.125510"/>
+            <twoDimVertex x="  59.817943" y=" 200.554482"/>
+            <twoDimVertex x="  81.618480" y=" 200.554482"/>
+            <twoDimVertex x="  81.618480" y=" 191.504495"/>
+            <twoDimVertex x=" 153.088451" y=" 191.504495"/>
+            <twoDimVertex x=" 153.088451" y=" 200.554482"/>
+            <twoDimVertex x=" 158.588451" y=" 200.554482"/>
+            <twoDimVertex x=" 158.588451" y=" -88.011558"/>
+            <twoDimVertex x=" 103.674877" y="-130.125510"/>
+          </shape>
+        </ctile12_gdmlfile>
 
   <define>
 

--- a/compact/hcal/barrel_gdml.xml
+++ b/compact/hcal/barrel_gdml.xml
@@ -25,11 +25,11 @@
         <type_flags type="DetType_CALORIMETER + DetType_BARREL + DetType_HADRONIC"/>
         <sec_gdmlfile file="gdml/barrel_hcal_steel_sector_nocombs.gdml" url="https://github.com/eic/epic-data/raw/c1ef9dca1781047fe9485eec6c0f986ec7d27f41/barrel_HCAL_gdml/barrel_hcal_steel_sector_nocombs.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="Steel1020"/>
         <csec_gdmlfile file="gdml/barrel_hcal_steel_chimneysector_nocombs.gdml" url="https://github.com/eic/epic-data/raw/c1ef9dca1781047fe9485eec6c0f986ec7d27f41/barrel_HCAL_gdml/barrel_hcal_steel_chimneysector_nocombs.gdml" cache="$DETECTOR_CACHE:/opt/detector" material="Steel1020"/>
-        <er_gdmlfile material="Steel1020">
+        <end_ring material="Steel1020">
           <dimensions rinner="1980.15" router="2619.85" zhalf="19.304" zcenter="3178.406"
                       nholes="32" rhole="152.4" rhole_ctr="2293.86069"/>
-        </er_gdmlfile>
-        <tile1_gdmlfile material="PlasticScint">
+        </end_ring>
+        <tile1 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="1.9212" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition="8.9212" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -42,8 +42,8 @@
             <twoDimVertex x=" 136.273087" y=" 381.494482"/>
             <twoDimVertex x="  63.817399" y="-426.850000"/>
           </shape>
-        </tile1_gdmlfile>
-        <tile2_gdmlfile material="PlasticScint">
+        </tile1>
+        <tile2 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -56,8 +56,8 @@
             <twoDimVertex x=" 173.766669" y=" 381.922482"/>
             <twoDimVertex x="  28.060339" y="-426.422000"/>
           </shape>
-        </tile2_gdmlfile>
-        <tile3_gdmlfile material="PlasticScint">
+        </tile2>
+        <tile3 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -70,8 +70,8 @@
             <twoDimVertex x=" 207.250291" y=" 381.264482"/>
             <twoDimVertex x=" -12.735671" y="-427.080000"/>
           </shape>
-        </tile3_gdmlfile>
-        <tile4_gdmlfile material="PlasticScint">
+        </tile3>
+        <tile4 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -84,8 +84,8 @@
             <twoDimVertex x="  52.630129" y=" 372.476495"/>
             <twoDimVertex x="  52.630129" y=" 381.526482"/>
           </shape>
-        </tile4_gdmlfile>
-        <tile5_gdmlfile material="PlasticScint">
+        </tile4>
+        <tile5 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -98,8 +98,8 @@
             <twoDimVertex x=" 147.596552" y=" 372.428495"/>
             <twoDimVertex x=" 147.596552" y=" 381.478482"/>
           </shape>
-        </tile5_gdmlfile>
-        <tile6_gdmlfile material="PlasticScint">
+        </tile5>
+        <tile6 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -112,8 +112,8 @@
             <twoDimVertex x=" 330.776465" y=" 381.425482"/>
             <twoDimVertex x="-125.911157" y="-426.919000"/>
           </shape>
-        </tile6_gdmlfile>
-        <tile7_gdmlfile material="PlasticScint">
+        </tile6>
+        <tile7 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -126,8 +126,8 @@
             <twoDimVertex x=" 376.774077" y=" 381.368482"/>
             <twoDimVertex x="-165.592134" y="-426.976000"/>
           </shape>
-        </tile7_gdmlfile>
-        <tile8_gdmlfile material="PlasticScint">
+        </tile7>
+        <tile8 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -140,8 +140,8 @@
             <twoDimVertex x=" 426.309854" y=" 381.520482"/>
             <twoDimVertex x="-205.897178" y="-426.824000"/>
           </shape>
-        </tile8_gdmlfile>
-        <tile9_gdmlfile material="PlasticScint">
+        </tile8>
+        <tile9 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -154,8 +154,8 @@
             <twoDimVertex x="-172.192846" y=" 317.257495"/>
             <twoDimVertex x="-172.192846" y=" 326.307482"/>
           </shape>
-        </tile9_gdmlfile>
-        <tile10_gdmlfile material="PlasticScint">
+        </tile9>
+        <tile10 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -168,8 +168,8 @@
             <twoDimVertex x="-200.582895" y=" 317.386495"/>
             <twoDimVertex x="-200.582895" y=" 326.436482"/>
           </shape>
-        </tile10_gdmlfile>
-        <tile11_gdmlfile material="PlasticScint">
+        </tile10>
+        <tile11 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -182,8 +182,8 @@
             <twoDimVertex x="-488.055959" y=" 338.185482"/>
             <twoDimVertex x=" 239.031199" y="-346.196498"/>
           </shape>
-        </tile11_gdmlfile>
-        <tile12_gdmlfile material="PlasticScint">
+        </tile11>
+        <tile12 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -197,8 +197,8 @@
             <twoDimVertex x="-333.086451" y="  86.981442"/>
             <twoDimVertex x=" 183.030736" y="-308.834498"/>
           </shape>
-        </tile12_gdmlfile>
-        <ctile9_gdmlfile material="PlasticScint">
+        </tile12>
+        <ctile9 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -211,8 +211,8 @@
             <twoDimVertex x=" 295.139543" y=" 162.710482"/>
             <twoDimVertex x="  -3.233504" y="-167.969510"/>
           </shape>
-        </ctile9_gdmlfile>
-        <ctile10_gdmlfile material="PlasticScint">
+        </ctile9>
+        <ctile10 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -225,8 +225,8 @@
             <twoDimVertex x="  39.796895" y=" 153.649495"/>
             <twoDimVertex x="  39.796895" y=" 162.699482"/>
           </shape>
-        </ctile10_gdmlfile>
-        <ctile11_gdmlfile material="PlasticScint">
+        </ctile10>
+        <ctile11 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -239,8 +239,8 @@
             <twoDimVertex x=" 304.647959" y=" 165.380482"/>
             <twoDimVertex x=" -46.687490" y="-165.319499"/>
           </shape>
-        </ctile11_gdmlfile>
-        <ctile12_gdmlfile material="PlasticScint">
+        </ctile11>
+        <ctile12 material="PlasticScint">
           <shape type="Xtru">
             <section zOrder="0" zPosition="-3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="1" zPosition=" 3.5" xOffset="0" yOffset="0" scalingFactor="1"/>
@@ -254,7 +254,7 @@
             <twoDimVertex x=" 158.588451" y=" -88.011558"/>
             <twoDimVertex x=" 103.674877" y="-130.125510"/>
           </shape>
-        </ctile12_gdmlfile>
+        </ctile12>
 
   <define>
 

--- a/src/BarrelHCalCalorimeter_geo.cpp
+++ b/src/BarrelHCalCalorimeter_geo.cpp
@@ -26,6 +26,8 @@
 #include "TGDMLParse.h"
 #include "FileLoaderHelper.h"
 
+#include <cmath>
+
 using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::detail;
@@ -105,13 +107,16 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       getAttrOrDefault<std::string>(x_det_csec_gdmlfile, _Unicode(cache), " ");
 
   xml_comp_t x_det_er_gdmlfile = x_det.child("er_gdmlfile");
-  std::string er_gdml_file = getAttrOrDefault<std::string>(x_det_er_gdmlfile, _Unicode(file), " ");
-  ;
   std::string er_gdml_material =
       getAttrOrDefault<std::string>(x_det_er_gdmlfile, _Unicode(material), " ");
-  std::string er_gdml_url = getAttrOrDefault<std::string>(x_det_er_gdmlfile, _Unicode(url), " ");
-  std::string er_gdml_cache =
-      getAttrOrDefault<std::string>(x_det_er_gdmlfile, _Unicode(cache), " ");
+  xml_comp_t x_er_dims = x_det_er_gdmlfile.child(_Unicode(dimensions));
+  double er_rinner     = x_er_dims.attr<double>(_Unicode(rinner)) * mm;
+  double er_router     = x_er_dims.attr<double>(_Unicode(router)) * mm;
+  double er_zhalf      = x_er_dims.attr<double>(_Unicode(zhalf)) * mm;
+  double er_zcenter    = x_er_dims.attr<double>(_Unicode(zcenter)) * mm;
+  int er_nholes        = x_er_dims.attr<int>(_Unicode(nholes));
+  double er_rhole      = x_er_dims.attr<double>(_Unicode(rhole)) * mm;
+  double er_rhole_ctr  = x_er_dims.attr<double>(_Unicode(rhole_ctr)) * mm;
 
   // Loop over the defines section and pick up the tile offsets, ref location and angles
 
@@ -227,27 +232,32 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   Material csector_material = description.material(csec_gdml_material.c_str());
   barrel_csector_vol.setMaterial(csector_material);
 
-  // end ring
-  EnsureFileFromURLExists(er_gdml_url, er_gdml_file, er_gdml_cache);
-  if (!fs::exists(fs::path(er_gdml_file))) {
-    printout(ERROR, "BarrelHCalCalorimeter_geo", "file " + er_gdml_file + " does not exist");
-    printout(ERROR, "BarrelHCalCalorimeter_geo",
-             "use a FileLoader plugin before the field element");
-    std::_Exit(EXIT_FAILURE);
-  }
+  // end ring — steel annulus (Tube) with 32 air-filled bolt-hole daughters
+  //
+  // Using daughter placements instead of a Boolean-subtraction chain lets
+  // Geant4's SmartVoxelHeader voxelise the 32 holes, giving O(log 32)
+  // boundary-crossing tests rather than traversing a depth-32 CSG tree.
+  // A track inside a daughter volume is in the daughter's material (air),
+  // which is geometrically equivalent to a hole in the steel.
+  Volume barrel_er_vol;
+  {
+    Tube er_base("", er_rinner, er_router, er_zhalf);
+    Material er_material = description.material(er_gdml_material.c_str());
+    barrel_er_vol        = Volume("BarrelHCalEndRing", er_base, er_material);
+    barrel_er_vol.setVisAttributes(description, x_det.visStr());
 
-  Volume barrel_er_vol = parser.GDMLReadFile(er_gdml_file.c_str());
-  if (!barrel_er_vol.isValid()) {
-    printout(WARNING, "BarrelHCalCalorimeter", "%s", er_gdml_file.c_str());
-    printout(WARNING, "BarrelHCalCalorimeter", "barrel_er_vol invalid, GDML parser failed!");
-    std::_Exit(EXIT_FAILURE);
+    // Bolt-hole daughters: same half-length as the ring (flush faces — no
+    // overlap needed because the hole solid is a proper daughter, not a
+    // Boolean operand).
+    Tube er_hole("BarrelHCalEndRingHole", 0., er_rhole, er_zhalf);
+    Volume hole_vol("BarrelHCalEndRingHole", er_hole, description.air());
+    hole_vol.setVisAttributes(description, "InvisibleNoDaughters");
+    for (int i = 0; i < er_nholes; ++i) {
+      double phi = i * 2. * M_PI / er_nholes;
+      barrel_er_vol.placeVolume(
+          hole_vol, i, Position(er_rhole_ctr * std::cos(phi), er_rhole_ctr * std::sin(phi), 0.));
+    }
   }
-  barrel_er_vol.import();
-  barrel_er_vol.setVisAttributes(description, x_det.visStr());
-  TessellatedSolid barrel_er_solid = barrel_er_vol.solid();
-  barrel_er_solid->CloseShape(true, true, true); // tesselated solid not closed by import!
-  Material er_material = description.material(er_gdml_material.c_str());
-  barrel_er_vol.setMaterial(er_material);
 
   // Place steel in envelope
 
@@ -273,11 +283,8 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       Transform3D(RotationZ(-sec_rot_angle * dd4hep::deg) * RotationY(180.0 * dd4hep::deg),
                   Translation3D(0, 0, 0)));
 
-  BarrelHCAL.placeVolume(barrel_er_vol, 0,
-                         Transform3D(RotationY(180.0 * dd4hep::deg), Translation3D(0, 0, 0)));
-
-  BarrelHCAL.placeVolume(barrel_er_vol, 1,
-                         Transform3D(RotationY(0.0 * dd4hep::deg), Translation3D(0, 0, 0)));
+  BarrelHCAL.placeVolume(barrel_er_vol, 0, Position(0, 0, -er_zcenter));
+  BarrelHCAL.placeVolume(barrel_er_vol, 1, Position(0, 0, +er_zcenter));
 
   // Loop over the tile solids, create them and add them to the detector volume
 
@@ -304,41 +311,34 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       solid_name = _toString(j - 4, "OuterHCalChimneyTile%02d");
     }
 
-    // tile shape gdml file info
+    // tile shape: read material and Xtru shape from compact XML
     xml_comp_t x_det_tgdmlfile = x_det.child(gdmlname);
-
-    std::string tgdml_file = getAttrOrDefault<std::string>(x_det_tgdmlfile, _Unicode(file), " ");
-    ;
     std::string tgdml_material =
         getAttrOrDefault<std::string>(x_det_tgdmlfile, _Unicode(material), " ");
-    std::string tgdml_url   = getAttrOrDefault<std::string>(x_det_tgdmlfile, _Unicode(url), " ");
-    std::string tgdml_cache = getAttrOrDefault<std::string>(x_det_tgdmlfile, _Unicode(cache), " ");
 
-    EnsureFileFromURLExists(tgdml_url, tgdml_file, tgdml_cache);
-    if (!fs::exists(fs::path(tgdml_file))) {
-      printout(ERROR, "BarrelHCalCalorimeter_geo", "file " + tgdml_file + " does not exist");
-      printout(ERROR, "BarrelHCalCalorimeter_geo",
-               "use a FileLoader plugin before the field element");
-      std::_Exit(EXIT_FAILURE);
+    // Parse <shape type="Xtru"> child: <twoDimVertex> and <section> elements
+    xml_comp_t x_shape = x_det_tgdmlfile.child(_Unicode(shape));
+    std::vector<double> vx, vy, vz, vxoff, vyoff, vscale;
+    for (xml_coll_t v(x_shape, _Unicode(twoDimVertex)); v; ++v) {
+      xml_comp_t vertex = v;
+      vx.push_back(vertex.attr<double>(_Unicode(x)) * mm);
+      vy.push_back(vertex.attr<double>(_Unicode(y)) * mm);
+    }
+    for (xml_coll_t s(x_shape, _Unicode(section)); s; ++s) {
+      xml_comp_t sec = s;
+      vz.push_back(sec.attr<double>(_Unicode(zPosition)) * mm);
+      vxoff.push_back(getAttrOrDefault<double>(sec, _Unicode(xOffset), 0.) * mm);
+      vyoff.push_back(getAttrOrDefault<double>(sec, _Unicode(yOffset), 0.) * mm);
+      vscale.push_back(getAttrOrDefault<double>(sec, _Unicode(scalingFactor), 1.));
     }
 
-    Volume solidVolume = parser.GDMLReadFile(tgdml_file.c_str());
-    if (!solidVolume.isValid()) {
-      printout(WARNING, "BarrelHCalCalorimeter_geo", "%s", tgdml_file.c_str());
-      printout(WARNING, "BarrelHCalCalorimeter_geo", "solidVolume invalid, GDML parser failed!");
-      std::_Exit(EXIT_FAILURE);
-    }
-    solidVolume.import();
-    solidVolume.setVisAttributes(description, x_det.visStr());
-    TessellatedSolid volume_solid = solidVolume.solid();
-    volume_solid->CloseShape(true, true, true); // tesselated solid not closed by import!
+    ExtrudedPolygon tile_solid(vx, vy, vz, vxoff, vyoff, vscale);
     Material tile_material = description.material(tgdml_material.c_str());
-    solidVolume.setMaterial(tile_material);
-
+    Volume solidVolume(solid_name, tile_solid, tile_material);
+    solidVolume.setVisAttributes(description, x_det.visStr());
     solidVolume.setSensitiveDetector(sens);
 
-    // For tiles we build an assembly to get the full array of tiles
-    // Offsets and rotation are to properly orient the tiles in the assembly.
+    // Tile numbers are indexed from centre (eta=0) outward; reindex starting from one end.
 
     if (solid_name.size() > 0) {
 
@@ -348,8 +348,6 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
         std::string stnum = solid_name.substr(solid_name.size() - 2, solid_name.size());
         int tnum          = atoi(stnum.c_str()) - 1;
-
-        // Tile numbers are indexed by the center (eta=0) out, we want them starting zero at one end.
 
         if (type == "OuterHCalTile") {
 

--- a/src/BarrelHCalCalorimeter_geo.cpp
+++ b/src/BarrelHCalCalorimeter_geo.cpp
@@ -240,7 +240,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   // which is geometrically equivalent to a hole in the steel.
   Volume barrel_er_vol;
   {
-    Tube er_base("", er_rinner, er_router, er_zhalf);
+    Tube er_base(er_rinner, er_router, er_zhalf);
     Material er_material = description.material(er_material_name.c_str());
     barrel_er_vol        = Volume("BarrelHCalEndRing", er_base, er_material);
     barrel_er_vol.setVisAttributes(description, x_det.visStr());
@@ -248,7 +248,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
     // Bolt-hole daughters: same half-length as the ring (flush faces — no
     // overlap needed because the hole solid is a proper daughter, not a
     // Boolean operand).
-    Tube er_hole("BarrelHCalEndRingHole", 0., er_rhole, er_zhalf);
+    Tube er_hole(0., er_rhole, er_zhalf);
     Volume hole_vol("BarrelHCalEndRingHole", er_hole, description.air());
     hole_vol.setVisAttributes(description, "InvisibleNoDaughters");
     for (int i = 0; i < er_nholes; ++i) {

--- a/src/BarrelHCalCalorimeter_geo.cpp
+++ b/src/BarrelHCalCalorimeter_geo.cpp
@@ -106,17 +106,16 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   std::string csec_gdml_cache =
       getAttrOrDefault<std::string>(x_det_csec_gdmlfile, _Unicode(cache), " ");
 
-  xml_comp_t x_det_er_gdmlfile = x_det.child("er_gdmlfile");
-  std::string er_gdml_material =
-      getAttrOrDefault<std::string>(x_det_er_gdmlfile, _Unicode(material), " ");
-  xml_comp_t x_er_dims = x_det_er_gdmlfile.child(_Unicode(dimensions));
-  double er_rinner     = x_er_dims.attr<double>(_Unicode(rinner)) * mm;
-  double er_router     = x_er_dims.attr<double>(_Unicode(router)) * mm;
-  double er_zhalf      = x_er_dims.attr<double>(_Unicode(zhalf)) * mm;
-  double er_zcenter    = x_er_dims.attr<double>(_Unicode(zcenter)) * mm;
-  int er_nholes        = x_er_dims.attr<int>(_Unicode(nholes));
-  double er_rhole      = x_er_dims.attr<double>(_Unicode(rhole)) * mm;
-  double er_rhole_ctr  = x_er_dims.attr<double>(_Unicode(rhole_ctr)) * mm;
+  xml_comp_t x_end_ring        = x_det.child("end_ring");
+  std::string er_material_name = getAttrOrDefault<std::string>(x_end_ring, _Unicode(material), " ");
+  xml_comp_t x_er_dims         = x_end_ring.child(_Unicode(dimensions));
+  double er_rinner             = x_er_dims.attr<double>(_Unicode(rinner)) * mm;
+  double er_router             = x_er_dims.attr<double>(_Unicode(router)) * mm;
+  double er_zhalf              = x_er_dims.attr<double>(_Unicode(zhalf)) * mm;
+  double er_zcenter            = x_er_dims.attr<double>(_Unicode(zcenter)) * mm;
+  int er_nholes                = x_er_dims.attr<int>(_Unicode(nholes));
+  double er_rhole              = x_er_dims.attr<double>(_Unicode(rhole)) * mm;
+  double er_rhole_ctr          = x_er_dims.attr<double>(_Unicode(rhole_ctr)) * mm;
 
   // Loop over the defines section and pick up the tile offsets, ref location and angles
 
@@ -242,7 +241,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   Volume barrel_er_vol;
   {
     Tube er_base("", er_rinner, er_router, er_zhalf);
-    Material er_material = description.material(er_gdml_material.c_str());
+    Material er_material = description.material(er_material_name.c_str());
     barrel_er_vol        = Volume("BarrelHCalEndRing", er_base, er_material);
     barrel_er_vol.setVisAttributes(description, x_det.visStr());
 
@@ -300,40 +299,39 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
       // standard tiles
 
-      gdmlname   = _toString(j, "tile%d_gdmlfile");
+      gdmlname   = _toString(j, "tile%d");
       solid_name = _toString(j, "OuterHCalTile%02d");
 
     } else {
 
       // chimney tiles
 
-      gdmlname   = _toString(j - 4, "ctile%d_gdmlfile");
+      gdmlname   = _toString(j - 4, "ctile%d");
       solid_name = _toString(j - 4, "OuterHCalChimneyTile%02d");
     }
 
     // tile shape: read material and Xtru shape from compact XML
-    xml_comp_t x_det_tgdmlfile = x_det.child(gdmlname);
-    std::string tgdml_material =
-        getAttrOrDefault<std::string>(x_det_tgdmlfile, _Unicode(material), " ");
+    xml_comp_t x_tile              = x_det.child(gdmlname);
+    std::string tile_material_name = getAttrOrDefault<std::string>(x_tile, _Unicode(material), " ");
 
     // Parse <shape type="Xtru"> child: <twoDimVertex> and <section> elements
-    xml_comp_t x_shape = x_det_tgdmlfile.child(_Unicode(shape));
+    xml_comp_t x_shape = x_tile.child(_Unicode(shape));
     std::vector<double> vx, vy, vz, vxoff, vyoff, vscale;
     for (xml_coll_t v(x_shape, _Unicode(twoDimVertex)); v; ++v) {
       xml_comp_t vertex = v;
       vx.push_back(vertex.attr<double>(_Unicode(x)) * mm);
       vy.push_back(vertex.attr<double>(_Unicode(y)) * mm);
     }
-    for (xml_coll_t s(x_shape, _Unicode(section)); s; ++s) {
-      xml_comp_t sec = s;
-      vz.push_back(sec.attr<double>(_Unicode(zPosition)) * mm);
-      vxoff.push_back(getAttrOrDefault<double>(sec, _Unicode(xOffset), 0.) * mm);
-      vyoff.push_back(getAttrOrDefault<double>(sec, _Unicode(yOffset), 0.) * mm);
-      vscale.push_back(getAttrOrDefault<double>(sec, _Unicode(scalingFactor), 1.));
+    for (xml_coll_t sec_iter(x_shape, _Unicode(section)); sec_iter; ++sec_iter) {
+      xml_comp_t xtru_sec = sec_iter;
+      vz.push_back(xtru_sec.attr<double>(_Unicode(zPosition)) * mm);
+      vxoff.push_back(getAttrOrDefault<double>(xtru_sec, _Unicode(xOffset), 0.) * mm);
+      vyoff.push_back(getAttrOrDefault<double>(xtru_sec, _Unicode(yOffset), 0.) * mm);
+      vscale.push_back(getAttrOrDefault<double>(xtru_sec, _Unicode(scalingFactor), 1.));
     }
 
     ExtrudedPolygon tile_solid(vx, vy, vz, vxoff, vyoff, vscale);
-    Material tile_material = description.material(tgdml_material.c_str());
+    Material tile_material = description.material(tile_material_name.c_str());
     Volume solidVolume(solid_name, tile_solid, tile_material);
     solidVolume.setVisAttributes(description, x_det.visStr());
     solidVolume.setSensitiveDetector(sens);


### PR DESCRIPTION
## Summary

Replace 16 scintillator-tile tessellations and the barrel end-ring tessellation in the HCal Barrel geometry plugin with equivalent Geant4 primitive solids, and use daughter-volume placements for the end-ring bolt holes so that Geant4's smart voxelisation applies.

All geometry dimensions are now specified in the compact XML file (`compact/hcal/barrel_gdml.xml`) rather than hardcoded in the plugin. No hardcoded data tables remain in the C++ source.

### Motivation

Tessellated solids force the Geant4 navigator to test every triangle facet at each boundary crossing. The tiles contain several hundred to ~1000 triangles each and are placed ≥192 times per event (12 η layers × 16 φ sectors); the end ring had 9844 vertices and 19816 triangles. Replacing them with primitives removes the facet-loop overhead entirely. For the bolt holes an additional optimisation is possible: using daughter-volume placements instead of a Boolean-subtraction chain lets Geant4's `SmartVoxelHeader` voxelise the 32 holes, giving **O(log 32) boundary lookup** instead of traversing a depth-32 CSG tree.

### Changes

#### Scintillator tiles → `ExtrudedPolygon` (G4ExtrudedSolid)

All 16 tile shapes (Tile01–Tile12, CTile09–CTile12) are flat 7 mm slabs with an 8–9 vertex boundary polygon. Each tile element in the compact XML now carries a `<shape type="Xtru">` child with `<twoDimVertex>` and `<section>` sub-elements (following GDML conventions). The plugin reads and constructs an `ExtrudedPolygon` directly from those elements — no GDML file download is required at runtime.

Tile01 retains the non-zero z offset (z: 1.9212–8.9212 mm) that was baked into the original tessellation.

#### End ring → `Tube` mother + 32 air `Tube` daughters

The end ring element in the compact XML now carries a `<dimensions>` child with attributes `rinner`, `router`, `zhalf`, `zcenter`, `nholes`, `rhole`, and `rhole_ctr` (all in mm). The plugin reads these and constructs a steel annulus (`Tube`) with 32 evenly-spaced air-filled bolt-hole daughters.

Rather than building a depth-32 Boolean subtraction chain — which Geant4 cannot voxelise — the holes are represented as **air-filled daughter `Tube` volumes** placed inside the steel annulus mother. A track inside a daughter sees air, which is geometrically equivalent to a hole. Geant4's `SmartVoxelHeader` then voxelises the 32 daughters, reducing per-boundary work from O(32) (CSG tree) to O(log 32).

The two ring copies are placed at z = ±`zcenter` with a simple translation (previously `RotationY(180°)` was used on a shape with z baked in from the tessellation).

#### Compact XML

`file`/`url`/`cache` attributes removed from tile and end-ring elements. Each tile now has a `<shape type="Xtru">` child; the end ring has a `<dimensions>` child. `material` attributes are retained. The sector and chimney-sector GDML files are unchanged.

### Not changed

The steel barrel sector and chimney-sector tessellations (18–21 distinct Z levels, varying XY cross-sections) are left as tessellations pending benchmarking to confirm they are worth the additional implementation effort.