### PR TITLE
DIRC: add bar lateral surface with UNIFIED model micro-facet roughness

### DIFF
--- a/compact/optical_materials.xml
+++ b/compact/optical_materials.xml
@@ -1178,6 +1178,12 @@
     <opticalsurface finish="polished" model="glisur" name="DIRC_MirrorOpticalSurface" type="dielectric_metal" value="0">
       <property name="REFLECTIVITY" ref="REFLECTIVITY_DIRC_mirror"/>
     </opticalsurface>
+    <!-- Bar lateral surface: UNIFIED model with ground finish.
+         sigma_alpha (micro-facet roughness angle, rad) is set in DIRC_geo.cpp
+         via TGeoOpticalSurface::SetSigmaAlpha(), as DD4hep compact XML does not
+         yet support the sigma_alpha attribute for the unified model.
+         A value of 0.02 rad is typical for polished quartz in hpDIRC simulations. -->
+    <opticalsurface finish="ground" model="unified" name="DIRC_BarOpticalSurface" type="dielectric_dielectric" value="1.0"/>
 
     <!-- BEGIN dRICH and pfRICH optical surface properties
       - to generate, follow: https://github.com/eic/drich-dev/blob/main/doc/material_tables.md

--- a/src/DIRC_geo.cpp
+++ b/src/DIRC_geo.cpp
@@ -147,6 +147,16 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens) {
   auto surf    = surfMgr.opticalSurface("DIRC_MirrorOpticalSurface");
   SkinSurface skin(desc, det, Form("dirc_mirror_optical_surface"), surf, mirror_vol);
   skin.isValid();
+  //---- Bar lateral surface: UNIFIED model with micro-facet roughness.
+  //     sigma_alpha = 0.02 rad (polished quartz, typical for hpDIRC simulations).
+  //     This causes photons near the TIR critical angle to scatter at micro-facets
+  //     and refract out of the bar, physically limiting unphysically long paths.
+  //     Note: DD4hep compact XML does not currently support the sigma_alpha
+  //     attribute, so it is set here via TGeoOpticalSurface::SetSigmaAlpha().
+  auto bar_surf = surfMgr.opticalSurface("DIRC_BarOpticalSurface");
+  bar_surf->SetSigmaAlpha(0.02);
+  SkinSurface bar_skin(desc, det, Form("dirc_bar_optical_surface"), bar_surf, bar_vol);
+  bar_skin.isValid();
 
   //---- Define Envelope_box_vol that holds 4*10bars+glue+mirror
   //---- Place Envelope_box_vol inside dirc_module


### PR DESCRIPTION
## Summary

Add an explicit `G4LogicalSkinSurface` on `bar_vol` (the quartz bars) using the UNIFIED optical model with `ground` finish and `sigma_alpha = 0.02 rad`.

## Physics motivation

Currently the bar lateral faces have **no explicit optical surface**, defaulting to perfect `glisur/polished` total internal reflection. This causes an unphysical simulation pathology: optical photons can bounce indefinitely (up to 690 m / 113,000 steps in profiling runs), limited only by the bulk absorption length.

In a real polished quartz bar, surface micro-roughness causes photons near the TIR critical angle to be deflected onto micro-facets at slightly different angles. A fraction of these exceed the critical angle and **refract out of the bar** instead of reflecting. The UNIFIED model with `ground` finish and `sigma_alpha` (Gaussian std-dev of micro-facet normal angle) correctly models this physics.

`sigma_alpha = 0.02 rad` (≈ 1.1°) is the standard value for polished quartz used in hpDIRC simulations (BaBar DIRC, Belle II iTOP papers).

## Implementation note

DD4hep compact XML `<opticalsurface>` does not currently support the `sigma_alpha` attribute for the UNIFIED model (only `value` → `polish` for glisur is parsed in `Compact2Objects.cpp`). The value is therefore set programmatically via `TGeoOpticalSurface::SetSigmaAlpha()`, which `DDG4::Geant4Converter::handleOpticalSurface()` correctly forwards to `G4OpticalSurface::SetSigmaAlpha()`.

## Files changed
- `compact/optical_materials.xml`: add `DIRC_BarOpticalSurface` definition (unified/ground/dielectric_dielectric)
- `src/DIRC_geo.cpp`: load bar surface, set sigma_alpha, apply as SkinSurface on bar_vol