### PR TITLE
feat(ci): add 'geantino' to particle matrix

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -557,7 +557,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        particle: [pi, e]
+        particle: [pi, e, geantino]
         detector_config: [epic_craterlake]
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -566,9 +566,12 @@ jobs:
             charge: "-"
           - particle: geantino
             charge: ""
+            sim: ddsim
             extra_args: '--filter.tracker "" --filter.calo ""'
           - particle: chargedgeantino
             charge: ""
+            sim: ddsim
+            extra_args: '--filter.tracker "" --filter.calo ""'
     steps:
     - uses: actions/checkout@v6
     - uses: actions/download-artifact@v8
@@ -583,7 +586,7 @@ jobs:
         setup: install/bin/thisepic.sh
         run: |
           export DETECTOR_CACHE=/opt/detector/epic-main/share/epic
-          npsim --compactFile ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -G --random.seed 1 --random.enableEventSeed --gun.particle "${{ matrix.particle }}${{ matrix.charge }}" --gun.momentumMin "1*GeV" --gun.momentumMax "20*GeV" --gun.distribution "uniform" -N 100 --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -v WARNING ${{ matrix.extra_args }}
+          ${{ matrix.sim || 'npsim' }} --compactFile ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -G --random.seed 1 --random.enableEventSeed --gun.particle "${{ matrix.particle }}${{ matrix.charge }}" --gun.momentumMin "1*GeV" --gun.momentumMax "20*GeV" --gun.distribution "uniform" -N 100 --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -v WARNING ${{ matrix.extra_args }}
     - uses: actions/upload-artifact@v7
       with:
         name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -557,10 +557,15 @@ jobs:
     needs: build
     strategy:
       matrix:
-        particle: [pi-, e-, geantino]
+        particle: [e, pi, geantino]
         detector_config: [epic_craterlake]
         include:
+          - particle: e
+            charge: "-"
+          - particle: pi
+            charge: "-"
           - particle: geantino
+            charge: ""
             extra_args: '--filter.tracker "" --filter.calo ""'
     steps:
     - uses: actions/checkout@v6
@@ -576,7 +581,7 @@ jobs:
         setup: install/bin/thisepic.sh
         run: |
           export DETECTOR_CACHE=/opt/detector/epic-main/share/epic
-          npsim --compactFile ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -G --random.seed 1 --random.enableEventSeed --gun.particle "${{ matrix.particle }}" --gun.momentumMin "1*GeV" --gun.momentumMax "20*GeV" --gun.distribution "uniform" -N 100 --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -v WARNING ${{ matrix.extra_args }}
+          npsim --compactFile ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -G --random.seed 1 --random.enableEventSeed --gun.particle "${{ matrix.particle }}${{ matrix.charge }}" --gun.momentumMin "1*GeV" --gun.momentumMax "20*GeV" --gun.distribution "uniform" -N 100 --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -v WARNING ${{ matrix.extra_args }}
     - uses: actions/upload-artifact@v7
       with:
         name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
@@ -684,7 +689,7 @@ jobs:
     needs: [build, npsim-gun]
     strategy:
       matrix:
-        particle: [pi-, e-]
+        particle: [e, pi]
         detector_config: [epic_craterlake]
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -557,7 +557,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        particle: [e, pi, geantino]
+        particle: [e, pi, geantino, chargedgeantino]
         detector_config: [epic_craterlake]
         include:
           - particle: e
@@ -567,6 +567,8 @@ jobs:
           - particle: geantino
             charge: ""
             extra_args: '--filter.tracker "" --filter.calo ""'
+          - particle: chargedgeantino
+            charge: ""
     steps:
     - uses: actions/checkout@v6
     - uses: actions/download-artifact@v8

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -557,7 +557,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        particle: [pi, e, geantino]
+        particle: [pi-, e-, geantino]
         detector_config: [epic_craterlake]
     steps:
     - uses: actions/checkout@v6
@@ -573,7 +573,7 @@ jobs:
         setup: install/bin/thisepic.sh
         run: |
           export DETECTOR_CACHE=/opt/detector/epic-main/share/epic
-          npsim --compactFile ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -G --random.seed 1 --random.enableEventSeed --gun.particle "${{ matrix.particle }}-" --gun.momentumMin "1*GeV" --gun.momentumMax "20*GeV" --gun.distribution "uniform" -N 100 --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -v WARNING
+          npsim --compactFile ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -G --random.seed 1 --random.enableEventSeed --gun.particle "${{ matrix.particle }}" --gun.momentumMin "1*GeV" --gun.momentumMax "20*GeV" --gun.distribution "uniform" -N 100 --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -v WARNING
     - uses: actions/upload-artifact@v7
       with:
         name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
@@ -681,7 +681,7 @@ jobs:
     needs: [build, npsim-gun]
     strategy:
       matrix:
-        particle: [pi, e]
+        particle: [pi-, e-]
         detector_config: [epic_craterlake]
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -559,6 +559,9 @@ jobs:
       matrix:
         particle: [pi-, e-, geantino]
         detector_config: [epic_craterlake]
+        include:
+          - particle: geantino
+            extra_args: '--filter.tracker "" --filter.calo ""'
     steps:
     - uses: actions/checkout@v6
     - uses: actions/download-artifact@v8
@@ -573,7 +576,7 @@ jobs:
         setup: install/bin/thisepic.sh
         run: |
           export DETECTOR_CACHE=/opt/detector/epic-main/share/epic
-          npsim --compactFile ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -G --random.seed 1 --random.enableEventSeed --gun.particle "${{ matrix.particle }}" --gun.momentumMin "1*GeV" --gun.momentumMax "20*GeV" --gun.distribution "uniform" -N 100 --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -v WARNING
+          npsim --compactFile ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -G --random.seed 1 --random.enableEventSeed --gun.particle "${{ matrix.particle }}" --gun.momentumMin "1*GeV" --gun.momentumMax "20*GeV" --gun.distribution "uniform" -N 100 --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root -v WARNING ${{ matrix.extra_args }}
     - uses: actions/upload-artifact@v7
       with:
         name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This pull request expands the CI simulation particle matrix and fixes artifact naming compatibility.

- CI configuration:
  * Updated `particle` matrix in `.github/workflows/linux-eic-shell.yml` from `[pi-, e-]` to `[e, pi, geantino, chargedgeantino]`, with an explicit `charge` variable (`"-"` for `e`/`pi`, `""` for geantino variants) so that `--gun.particle` receives the correct signed name (e.g. `e-`) while artifact names remain backward-compatible (using the bare particle name without the charge sign).

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

GitHub Copilot was used to implement the `charge` matrix variable approach and update artifact name references.