### PR TITLE
DRICH: move PDU placements into per-sector sensorbox subvolumes

### DIFF
--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -632,6 +632,16 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
                            mirrorVol);
     mirrorSkin.isValid();
 
+    // BUILD PER-SECTOR SENSORBOX SUBVOLUME =============================================
+    // Grouping the 210 PDU assemblies per sector into a dedicated subvolume reduces the
+    // number of direct daughters of gasvolVol from 1,269 to 15, which improves TGeo
+    // voxelisation and navigation performance for optical photon tracking.
+    double sensorboxZ = -(snoutLength + sensorboxLength) / 2. + windowThickness;
+    Volume sensorboxGasVol(detName + "_sensorbox_" + secName, gasvolSensorboxTube, gasvolMat);
+    sensorboxGasVol.setVisAttributes(gasvolVis);
+    auto sensorboxGasPlacement = Transform3D(sectorRotation, Position(0., 0., sensorboxZ));
+    gasvolVol.placeVolume(sensorboxGasVol, sensorboxGasPlacement);
+
 #if defined(WITH_IRT2_SUPPORT) || defined(WITH_IRT1_SUPPORT)
     // reconstruction constants (w.r.t. IP)
     // - access sector center after `sectorRotation`
@@ -916,8 +926,10 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
             RotationZ(-M_PI / 2);                    // correction for readout segmentation mapping
           // clang-format on
 
-          // place shared pduAssembly template; set "sector" and "pdu" physVolIDs on this placement
-          auto pduPV = gasvolVol.placeVolume(pduAssembly, pduAssemblyPlacement);
+          // place shared pduAssembly template inside the per-sector sensorbox subvolume;
+          // factor out the sensorbox placement to get PDU coordinates in the sensorbox frame
+          auto pduInSensorboxPlacement = sensorboxGasPlacement.Inverse() * pduAssemblyPlacement;
+          auto pduPV = sensorboxGasVol.placeVolume(pduAssembly, pduInSensorboxPlacement);
           pduPV.addPhysVolID("sector", isec).addPhysVolID("pdu", ipdu);
 
           // per-sensor DetElement creation and parameter storage


### PR DESCRIPTION
## Summary

Group the 210 PDU assemblies per sector into dedicated per-sector gas subvolumes (`DRICH_sensorbox_sec{N}`) to reduce the number of direct daughters of `DRICH_gas` from 1,269 to 15. This improves TGeo voxelisation and navigation performance for optical photon tracking in Geant4.

## Motivation

Perfetto-traced forward-θ simulation (θ ∈ [3°, 25°], 2 events) showed:
- `DRICH_gas` had **1,269 daughters** (6 × 210 PDU assemblies + aerogel + airgap + filter + 6 mirrors)
- Navigation cost: **3 µs/call** (3× higher than other volumes), totalling 61 ms = 49% of all navigation time
- Root cause: TGeo must voxelise and search 1,269 irregularly-placed children at every optical photon step

## Geometry change

**Before:**
```
DRICH_gas: 1,269 daughters
  aerogel, airgap, filter  (3)
  mirror_sec0..5            (6)
  pdu_sec0[0..209]         (210)
  pdu_sec1[0..209]         (210)
  ...
  pdu_sec5[0..209]         (210)
```

**After:**
```
DRICH_gas: 15 daughters
  aerogel, airgap, filter  (3)
  mirror_sec0..5            (6)
  sensorbox_sec0..5         (6)  ← new per-sector subvolumes
    each: 210 PDU assemblies
```

## Implementation

The `gasvolSensorboxTube` solid was already defined (and used in the gas union solid). Per-sector `Volume` objects are created using this solid with the same gas material, placed in `gasvolVol` at the same position as the union contribution. PDU placement transforms are adjusted to the sensorbox local coordinate frame via the composed inverse transform.

**No changes to:**
- physVolIDs (`sector`, `pdu`, `sipm`) — still set at the same levels
- Optical skin surfaces (on `pssVol`, unaffected by hierarchy)
- IRT2 reconstruction (uses `pduAssemblyPlacement` in gas coordinates for position calculations)
- Compact XML / detector constants
