### PR TITLE
perf(DRICH): share CarbonSegment logical volumes within each crown ring

### DIFF
--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -426,14 +426,15 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
       double segmentSpacing      = 2 * M_PI / N;
       double segmentAngularWidth = coronasThickness / rMin_Zminus;
 
-      ConeSegment segmentSolid(crownHeight / 2.0, rMin_Zminus, rMax_Zminus, rMin_Zplus,
-                               rMax_Zplus, 0.0, segmentAngularWidth);
+      ConeSegment segmentSolid(crownHeight / 2.0, rMin_Zminus, rMax_Zminus, rMin_Zplus, rMax_Zplus,
+                               0.0, segmentAngularWidth);
       std::string segName = "CarbonSegment_" + std::to_string(i);
       Volume segVol(segName, segmentSolid, coronasMat);
       segVol.setVisAttributes(coronasVis);
 
       for (int p = 0; p < N; p++) {
-        aerogelVol.placeVolume(segVol, Transform3D(RotationZ(p * segmentSpacing), Position(0., 0., 0.)));
+        aerogelVol.placeVolume(segVol,
+                               Transform3D(RotationZ(p * segmentSpacing), Position(0., 0., 0.)));
       }
     } //crown
   } //trapezoidal

--- a/src/DRICH_geo.cpp
+++ b/src/DRICH_geo.cpp
@@ -414,7 +414,7 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
       aerogelVol.placeVolume(crownVol, Position(0., 0., 0.));
     }
 
-    // Create and place individual segment volumes
+    // Create one segment logical volume per crown ring and place it with azimuthal rotations
     for (int i = 0; i < numCrowns - 1; i++) {
       int N = numSegments[i];
 
@@ -426,18 +426,14 @@ static Ref_t createDetector(Detector& desc, xml::Handle_t handle, SensitiveDetec
       double segmentSpacing      = 2 * M_PI / N;
       double segmentAngularWidth = coronasThickness / rMin_Zminus;
 
+      ConeSegment segmentSolid(crownHeight / 2.0, rMin_Zminus, rMax_Zminus, rMin_Zplus,
+                               rMax_Zplus, 0.0, segmentAngularWidth);
+      std::string segName = "CarbonSegment_" + std::to_string(i);
+      Volume segVol(segName, segmentSolid, coronasMat);
+      segVol.setVisAttributes(coronasVis);
+
       for (int p = 0; p < N; p++) {
-        double phiStart = p * segmentSpacing;
-        double phiEnd   = phiStart + segmentAngularWidth;
-
-        ConeSegment segmentSolid(crownHeight / 2.0, rMin_Zminus, rMax_Zminus, rMin_Zplus,
-                                 rMax_Zplus, phiStart, phiEnd);
-        std::string segName = "CarbonSegment_" + std::to_string(i) + "_" + std::to_string(p);
-        Volume segVol(segName, segmentSolid, coronasMat);
-        segVol.setVisAttributes(coronasVis);
-
-        // Place segment volume directly in aerogel
-        aerogelVol.placeVolume(segVol, Position(0., 0., 0.));
+        aerogelVol.placeVolume(segVol, Transform3D(RotationZ(p * segmentSpacing), Position(0., 0., 0.)));
       }
     } //crown
   } //trapezoidal


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Within each aerogel corona ring, all phi-segments of the CarbonSegment structural support share the
same ConeSegment shape and material. This PR creates one logical volume per ring and places it N
times with azimuthal rotations, reducing ~82 unique TGeoVolume objects to one per crown ring (~5).

Identified via analysis of geometry DOT file from npdet_to_dot.

### What is the urgency of this PR?
- [x] Low

### What kind of change does this PR introduce?
- [x] Optimization (issue #__)

### Please check if any of the following apply
- [x] AI was used in preparing this PR. Please describe usage below.

GitHub Copilot was used to identify the pattern and draft the refactoring.