### PR TITLE
perf(geometry): disambiguate repeated slice volume names

### DIFF
--- a/src/BarrelCalorimeterScFi_geo.cpp
+++ b/src/BarrelCalorimeterScFi_geo.cpp
@@ -129,7 +129,7 @@ static Ref_t create_detector(Detector& desc, xml_h e, SensitiveDetector sens) {
         double s_pos_z = -(l_thickness / 2.);
         for (xml_coll_t si(x_layer, _U(slice)); si; ++si) {
           xml_comp_t x_slice = si;
-          std::string s_name = Form("slice%d", s_num);
+          std::string s_name = l_name + Form("_slice%d", s_num);
           double s_thick     = x_slice.thickness();
           double s_trd_x1    = l_dim_x + (s_pos_z + l_thickness / 2) * tan_hphi;
           double s_trd_x2    = l_dim_x + (s_pos_z + l_thickness / 2 + s_thick) * tan_hphi;

--- a/src/PolyhedraEndcapCalorimeter2_geo.cpp
+++ b/src/PolyhedraEndcapCalorimeter2_geo.cpp
@@ -71,7 +71,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
     double sliceZ = -l_thick / 2;
     for (xml_coll_t xs(x_layer, _U(slice)); xs; ++xs) {
       xml_comp_t x_slice = xs;
-      string s_name      = _toString(s_num, "slice%d");
+      string s_name      = l_name + _toString(s_num, "_slice%d");
       double s_thick     = x_slice.thickness();
       Material s_mat     = description.material(x_slice.materialStr());
       Volume s_vol(s_name, PolyhedraRegular(numsides, rmin, rmax, s_thick), s_mat);


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This disambiguates repeated logical-volume slice names in the two geometry plugins that were producing distinct TGeoVolume objects all named `slice1`, `slice2`, etc. Slice names now include the layer name in `BarrelCalorimeterScFi_geo.cpp` and `PolyhedraEndcapCalorimeter2_geo.cpp`, which makes geometry graph output easier to interpret without changing geometry placement or sharing behavior.

Investigation notes:
- `InsertCalorimeter_geo.cpp` already uses `layer_name + slice%d`, so its slice names were not the source of the ambiguous `slice1` labels.
- In `InsertCalorimeter_geo.cpp`, the beampipe hole radius/position is recomputed from `z_distance_traversed` for every layer, so those slice solids are not shareable across repeated layers.
- The ambiguous `slice1` volumes instead came from other calorimeter plugins with generic `slice%d` names.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

AI usage: GitHub Copilot CLI was used to investigate the geometry naming issue, implement the naming updates, and run a full CMake build check after the change.
