### PR TITLE
ci: add peak RSS memory check to check-geometry-configs

### DIFF
--- a/.github/workflows/check-geometry-configs-geant4.yml
+++ b/.github/workflows/check-geometry-configs-geant4.yml
@@ -1,4 +1,4 @@
-name: Check geometry configs (TGeo)
+name: Check geometry configs (Geant4)
 
 on:
   workflow_call:
@@ -23,13 +23,13 @@ jobs:
         setup: install/bin/thisepic.sh
         run: |
           export DETECTOR_CACHE=/opt/detector/epic-main/share/epic
-          MEMORY_LIMIT_KB=1300000   # 1.3 GB – update this deliberately when geometry grows
+          MEMORY_LIMIT_KB=2350000   # 2.35 GB – update this deliberately when geometry grows
           IFS=, read -a configs <<< "${{inputs.detector_configs}}"
           overall_rc=0
           for config in ${configs[@]} ; do
             echo "::group::${config}" ;
             /usr/bin/time -v -o /tmp/time_${config}.txt \
-              checkGeometry -c ${DETECTOR_PATH}/${config}.xml
+              g4GeometryScan -c ${DETECTOR_PATH}/${config}.xml -d 0,0,1
             rc=$?
             peak_rss_kb=$(grep "Maximum resident set size" /tmp/time_${config}.txt | awk '{print $NF}')
             echo "Peak RSS for ${config}: ${peak_rss_kb} kB (limit: ${MEMORY_LIMIT_KB} kB)"

--- a/.github/workflows/check-geometry-configs.yml
+++ b/.github/workflows/check-geometry-configs.yml
@@ -23,9 +23,21 @@ jobs:
         setup: install/bin/thisepic.sh
         run: |
           export DETECTOR_CACHE=/opt/detector/epic-main/share/epic
+          MEMORY_LIMIT_KB=4000000   # 4 GB – update this deliberately when geometry grows
           IFS=, read -a configs <<< "${{inputs.detector_configs}}"
+          overall_rc=0
           for config in ${configs[@]} ; do
             echo "::group::${config}" ;
-            checkGeometry -c ${DETECTOR_PATH}/${config}.xml ;
+            /usr/bin/time -v -o /tmp/time_${config}.txt \
+              checkGeometry -c ${DETECTOR_PATH}/${config}.xml
+            rc=$?
+            peak_rss_kb=$(grep "Maximum resident set size" /tmp/time_${config}.txt | awk '{print $NF}')
+            echo "Peak RSS for ${config}: ${peak_rss_kb} kB (limit: ${MEMORY_LIMIT_KB} kB)"
+            if [ "${peak_rss_kb}" -gt "${MEMORY_LIMIT_KB}" ]; then
+              echo "::error::Memory limit exceeded for ${config}: ${peak_rss_kb} kB > ${MEMORY_LIMIT_KB} kB"
+              overall_rc=1
+            fi
+            [ $rc -ne 0 ] && overall_rc=$rc
             echo "::endgroup::" ;
           done
+          exit $overall_rc

--- a/.github/workflows/check-geometry-configs.yml
+++ b/.github/workflows/check-geometry-configs.yml
@@ -33,11 +33,11 @@ jobs:
             rc=$?
             peak_rss_kb=$(grep "Maximum resident set size" /tmp/time_${config}.txt | awk '{print $NF}')
             echo "Peak RSS for ${config}: ${peak_rss_kb} kB (limit: ${MEMORY_LIMIT_KB} kB)"
+            echo "::endgroup::"
             if [ "${peak_rss_kb}" -gt "${MEMORY_LIMIT_KB}" ]; then
               echo "::error::Memory limit exceeded for ${config}: ${peak_rss_kb} kB > ${MEMORY_LIMIT_KB} kB"
               overall_rc=1
             fi
             [ $rc -ne 0 ] && overall_rc=$rc
-            echo "::endgroup::" ;
           done
           exit $overall_rc

--- a/.github/workflows/check-geometry-configs.yml
+++ b/.github/workflows/check-geometry-configs.yml
@@ -23,7 +23,7 @@ jobs:
         setup: install/bin/thisepic.sh
         run: |
           export DETECTOR_CACHE=/opt/detector/epic-main/share/epic
-          MEMORY_LIMIT_KB=1200000   # 1.2 GB – update this deliberately when geometry grows
+          MEMORY_LIMIT_KB=1300000   # 1.3 GB – update this deliberately when geometry grows
           IFS=, read -a configs <<< "${{inputs.detector_configs}}"
           overall_rc=0
           for config in ${configs[@]} ; do

--- a/.github/workflows/check-geometry-configs.yml
+++ b/.github/workflows/check-geometry-configs.yml
@@ -23,7 +23,7 @@ jobs:
         setup: install/bin/thisepic.sh
         run: |
           export DETECTOR_CACHE=/opt/detector/epic-main/share/epic
-          MEMORY_LIMIT_KB=4000000   # 4 GB – update this deliberately when geometry grows
+          MEMORY_LIMIT_KB=1200000   # 1.2 GB – update this deliberately when geometry grows
           IFS=, read -a configs <<< "${{inputs.detector_configs}}"
           overall_rc=0
           for config in ${configs[@]} ; do

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -138,6 +138,14 @@ jobs:
     with:
       detector_configs: ${{needs.list-detector-configs.outputs.configs_csv}}
 
+  check-geometry-configs-geant4:
+    needs:
+      - build
+      - list-detector-configs
+    uses: ./.github/workflows/check-geometry-configs-geant4.yml
+    with:
+      detector_configs: "epic_craterlake"
+
   check-tracking-geometry:
     needs: build
     uses: ./.github/workflows/check-tracking-geometry.yml


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

Adds a peak RSS (resident set size) check to the `check-geometry-configs` CI job. Each geometry config is loaded with `checkGeometry` wrapped by `/usr/bin/time -v`; the peak RSS is printed for every config on every run, and the job fails if any config exceeds a hardcoded threshold (`MEMORY_LIMIT_KB`, initially 4 GB).

This prevents silent growth of the geometry memory footprint, analogous to [eic/containers#289](https://github.com/eic/containers/pull/289) which caps compressed container image size. The limit is a hardcoded constant in the workflow file, so increasing it requires a conscious, reviewable PR.

The initial limit of 4 GB is deliberately generous — the first CI run on this PR will reveal actual peak RSS values for all configs, and the limit will be tightened to baseline + ~20% headroom in a follow-up commit.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

Strategy defined by human; implementation by GitHub Copilot CLI, reviewed by human.