### PR TITLE
feat: add EcalBarrelScFiLayerRegion in dedicated region

### DIFF
--- a/compact/ecal/bic/bic.xml
+++ b/compact/ecal/bic/bic.xml
@@ -118,6 +118,7 @@
 
   <regions>
     <region name="EcalBarrelRegion"/>
+    <region name="EcalBarrelScFiLayerRegion"/>
   </regions>
 
   <display>
@@ -335,6 +336,7 @@
       <sectors vis="EcalBarrelSectorVis"/>
 
       <layer repeat="EcalBarrelImagingLayers_num-1" vis="EcalBarrelLayerVis"
+             region="EcalBarrelScFiLayerRegion"
              space_between="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween"
              space_before="EcalBarrel_FrontSupportThickness + EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween/2.">
         <slice material="SciFiPb_PbGlue_Edge" thickness="EcalBarrel_RadiatorEdgeThickness" vis="EcalBarrelSliceVis"/>
@@ -354,6 +356,7 @@
       </layer>
 
       <layer repeat="1" vis="EcalBarrelLayerVis"
+             region="EcalBarrelScFiLayerRegion"
              space_before="EcalBarrel_ImagingLayerThickness + EcalBarrel_SpaceBetween">
         <slice material="SciFiPb_PbGlue_Edge" thickness="EcalBarrel_RadiatorEdgeThickness" vis="EcalBarrelSliceVis"/>
         <slice material="SciFiPb_PbGlue" thickness="EcalBarrel_RadiatorThickness" vis="EcalBarrelFiberLayerVis">
@@ -370,7 +373,8 @@
         </slice>
       </layer>
 
-      <layer repeat="EcalBarrel_FiberBulkLayers_num-2" vis="EcalBarelLayerVis">
+      <layer repeat="EcalBarrel_FiberBulkLayers_num-2" vis="EcalBarelLayerVis"
+             region="EcalBarrelScFiLayerRegion">
         <slice material="SciFiPb_PbGlue"
           thickness="EcalBarrel_RadiatorThickness"
           vis="EcalBarrelFiberLayerVis">
@@ -387,7 +391,8 @@
         </slice>
       </layer>
 
-      <layer repeat="1" vis="EcalBarrelLayerVis">
+      <layer repeat="1" vis="EcalBarrelLayerVis"
+             region="EcalBarrelScFiLayerRegion">
         <slice material="SciFiPb_PbGlue" thickness="EcalBarrel_RadiatorThickness" vis="EcalBarrelFiberLayerVis">
           <fiber material="SciFiPb_Scintillator"
             sensitive="yes"


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds a dedicated region for the EcalBarrelScFi layers with the Pb/ScFi layups. This allows for optimizing with Woodcock tracking in G4HepEm without jumping over the interspersed imaging layers.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: new region for Woodcock tracking)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
