### PR TITLE
feat: create DIRC region

### DIFF
--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -80,6 +80,7 @@
   </limits>
 
   <regions>
+    <region name="DIRCRegion"/>
   </regions>
 
   <display>
@@ -96,7 +97,7 @@
   </display>
 
   <detectors>
-    <detector id="BarrelDIRC_ID" name="cb_DIRC" type="epic_DIRC" readout="DIRCBarHits" vis="DIRCTube">
+    <detector id="BarrelDIRC_ID" name="cb_DIRC" type="epic_DIRC" readout="DIRCBarHits" vis="DIRCTube" region="DIRCRegion">
       <dimensions rmin="DIRCBar_center - DIRCBar_height/2" rmax="DIRCBar_center + DIRCBar_height/2" length="DIRC_length"/>
       <position x="0" y="0" z="DIRC_offset"/>
       <module name="DIRCBox" repeat="DIRCBox_count" width="DIRCPrism_width + 1*mm" height="DIRCPrism_height*2" length="DIRCBarAssm_length + 550*mm" vis="DIRCBox">

--- a/src/DIRC_geo.cpp
+++ b/src/DIRC_geo.cpp
@@ -79,7 +79,7 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens) {
 
   //---- Entire DIRC assembly
   Assembly det_volume("DIRC");
-  det_volume.setVisAttributes(desc.visAttributes(xml_det.visStr()));
+  det_volume.setAttributes(desc, xml_det.regionStr(), xml_det.limitsStr(), xml_det.visStr());
   Transform3D det_tr(RotationY(0), Position(0.0, 0.0, dirc_pos_z));
   det.setPlacement(
       desc.pickMotherVolume(det).placeVolume(det_volume, det_tr).addPhysVolID("system", det_id));


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds a DIRC region (`DIRCRegion`) for optical photon QE suppression with https://github.com/eic/npsim/pull/75.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: DIRC region)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

This is a dependency for the July campaign and needs roll-out by Monday.