### PR TITLE
feat: impose time and track length limit for optical photons in DIRC

### DIFF
--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -77,16 +77,14 @@
   </materials>
 
   <limits>
-    <limitset name="DIRCRegionLimits">
+    <limitset name="DIRCLimits">
       <limit name="time_max" particles="opticalphoton" value="150.0" unit="ns"/>
       <limit name="track_length_max" particles="opticalphoton" value="30000.0" unit="mm"/>
     </limitset>
   </limits>
 
   <regions>
-    <region name="DIRCRegion">
-      <limitsetref name="DIRCRegionLimits"/>
-    </region>
+    <region name="DIRCRegion"/>
   </regions>
 
   <display>
@@ -103,7 +101,7 @@
   </display>
 
   <detectors>
-    <detector id="BarrelDIRC_ID" name="cb_DIRC" type="epic_DIRC" readout="DIRCBarHits" vis="DIRCTube" region="DIRCRegion">
+    <detector id="BarrelDIRC_ID" name="cb_DIRC" type="epic_DIRC" readout="DIRCBarHits" vis="DIRCTube" region="DIRCRegion" limits="DIRCLimits">
       <dimensions rmin="DIRCBar_center - DIRCBar_height/2" rmax="DIRCBar_center + DIRCBar_height/2" length="DIRC_length"/>
       <position x="0" y="0" z="DIRC_offset"/>
       <module name="DIRCBox" repeat="DIRCBox_count" width="DIRCPrism_width + 1*mm" height="DIRCPrism_height*2" length="DIRCBarAssm_length + 550*mm" vis="DIRCBox">

--- a/compact/pid/dirc.xml
+++ b/compact/pid/dirc.xml
@@ -77,10 +77,16 @@
   </materials>
 
   <limits>
+    <limitset name="DIRCRegionLimits">
+      <limit name="time_max" particles="opticalphoton" value="150.0" unit="ns"/>
+      <limit name="track_length_max" particles="opticalphoton" value="30000.0" unit="mm"/>
+    </limitset>
   </limits>
 
   <regions>
-    <region name="DIRCRegion"/>
+    <region name="DIRCRegion">
+      <limitsetref name="DIRCRegionLimits"/>
+    </region>
   </regions>
 
   <display>


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Based on discussions with the DIRC DSC, this solution is preferred over #1113.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: cut out long lived optical photons)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

This is intended for July campaign inclusion.