### PR TITLE
fix: require workflow_conclusion 'completed' for previous artifact

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -599,7 +599,7 @@ jobs:
         branch: ${{ github.event.pull_request.base.ref || github.ref_name }}
         path: ref/
         name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
-        workflow_conclusion: ""
+        workflow_conclusion: "completed"
         if_no_artifact_found: warn
     - name: Compare to previous artifacts
       uses: eic/run-cvmfs-osg-eic-shell@main
@@ -668,7 +668,7 @@ jobs:
         branch: ${{ github.event.pull_request.base.ref || github.ref_name }}
         path: ref/
         name: sim_dis_${{matrix.beam}}_minQ2=${{matrix.minq2}}_${{ matrix.detector_config }}.edm4hep.root
-        workflow_conclusion: ""
+        workflow_conclusion: "completed"
         if_no_artifact_found: warn
     - name: Compare to previous artifacts
       uses: eic/run-cvmfs-osg-eic-shell@main
@@ -728,7 +728,7 @@ jobs:
         branch: ${{ github.event.pull_request.base.ref || github.ref_name }}
         path: ref/
         name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
-        workflow_conclusion: ""
+        workflow_conclusion: "completed"
         if_no_artifact_found: warn
     - name: Compare to previous artifacts
       uses: eic/run-cvmfs-osg-eic-shell@main
@@ -794,7 +794,7 @@ jobs:
         branch: ${{ github.event.pull_request.base.ref || github.ref_name }}
         path: ref/
         name: rec_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4eic.root
-        workflow_conclusion: ""
+        workflow_conclusion: "completed"
         if_no_artifact_found: warn
     - name: Compare to previous artifacts
       uses: eic/run-cvmfs-osg-eic-shell@main


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This pull request makes a minor update to the GitHub Actions workflow configuration. The change ensures that artifact downloads only occur if the referenced workflow has fully completed, improving the reliability of dependent steps.

Workflow configuration improvement:
- In .github/workflows/linux-eic-shell.yml, set the workflow_conclusion parameter to "completed" for artifact download steps, instead of an empty string, in both relevant jobs.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: avoid trying to pull artifacts from workflows that are still running)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
