### PR TITLE
update SVT barrel sensor structure, updated material map

### DIFF
--- a/compact/display_detailed.xml
+++ b/compact/display_detailed.xml
@@ -24,6 +24,7 @@
     <vis name="TrackerGEMModuleVis"  ref="TrackerMPGDVis"   visible="true"  showDaughters="false" />
     <vis name="TrackerMMGASLayerVis" ref="TrackerMPGDVis"   visible="true"  showDaughters="false" />
 
+    <vis name="SVTReadoutVis"         ref="AnlDarkGreen"    visible="true"  showDaughters="true" />
     <vis name="VertexLayerVis"        ref="AnlGray"         visible="true"  showDaughters="false" />
     <vis name="VertexSupportLayerVis" ref="AnlBlue"         visible="true"  showDaughters="false" />
     <vis name="VertexSupportVis"      ref="VertexSupportLayerVis" visible="true"  showDaughters="true" />

--- a/compact/display_geoviewer.xml
+++ b/compact/display_geoviewer.xml
@@ -23,6 +23,7 @@
     <vis name="TrackerGEMModuleVis"  ref="TrackerMPGDVis"   visible="true"  showDaughters="false" />
     <vis name="TrackerMMGASLayerVis" ref="TrackerMPGDVis"   visible="true"  showDaughters="false" />
 
+    <vis name="SVTReadoutVis"         ref="AnlDarkGreen"    visible="true"  showDaughters="true" />
     <vis name="VertexLayerVis"        ref="AnlGold"         visible="true"  showDaughters="false" />
     <vis name="VertexSupportLayerVis" ref="AnlBlue"         visible="true"  showDaughters="false" />
     <vis name="VertexSupportVis"      ref="VertexSupportLayerVis" visible="true"  showDaughters="true" />

--- a/compact/tracking/definitions_craterlake.xml
+++ b/compact/tracking/definitions_craterlake.xml
@@ -215,8 +215,7 @@
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_CACHE:/opt/detector"/>
       <arg value="file:calibrations/materials-map.cbor"/>
-      <arg value="url:https://github.com/eic/epic-data/raw/2df7751706c545ecda5957137695a0859a09a9ee/material-map.cbor"/>
-
+      <arg value="url:https://raw.githubusercontent.com/eic/epic-data/b59d999b8df6ecf4349dbc1bf4f836295d182e05/material-map.cbor"/>
     </plugin>
   </plugins>
 

--- a/compact/tracking/silicon_barrel.xml
+++ b/compact/tracking/silicon_barrel.xml
@@ -9,8 +9,16 @@
          17 April 2026. Sam Henry
     </comment>
 
-    <constant name="SiBarrelSensor_thickness" value="40*um" />
-    <constant name="SiBarrelSensorMod_thickness" value="SiBarrelSensor_thickness*2.7" /> <!-- multiply thickness by 2.7 this increases thickness by 0.00034 -->
+    <constant name="SiBarrelSensorCu_thickness"         value="2.5*um" />
+    <constant name="SiBarrelSensorActiveSi_thickness"   value="14*um" />
+    <constant name="SiBarrelSensorInactiveSi_thickness" value="36*um" />
+    <constant name="SiBarrelSensor_thickness"
+      value="SiBarrelSensorCu_thickness + SiBarrelSensorActiveSi_thickness + SiBarrelSensorInactiveSi_thickness" />
+    <constant name="SiBarrelSensorMod_thickness" value="SiBarrelSensor_thickness" />
+    <comment>
+      The geometry plugin expands each CurvedSi component into the configurable
+      three-layer stack, with Cu always facing away from the stave support.
+    </comment>
     <constant name="SiBarrelSiliconGap_width" value="1*mm" />
 
     <constant name="SiBarrelStave1Service_thickness" value="0.07875*mm" />
@@ -91,9 +99,11 @@
 <constant name="SiBarrelSiliconCurveHalfAngle1" value="asin(0.5*SiBarrelStave1_width / SiBarrelSiliconCurveRadius)" />
 <constant name="SiBarrelSiliconCurveHalfAngle2" value="asin(0.5*SiBarrelStave2_width / SiBarrelSiliconCurveRadius)" />
 <constant name="SiBarrelSiliconGapHalfAngle" value="atan(0.5*SiBarrelSiliconGap_width / SiBarrelSiliconCurveRadius)" />
-<constant name="SiBarrel_ShortThickness" value="0.5*SiBarrelSensorMod_thickness" />
-<constant name="SiBarrel1_LongThickness" value="1.5*SiBarrelSensorMod_thickness + SiBarrelStave1Service_thickness + SiBarrelStave1Frame_thickness +  SiBarrelBrace_thickness + 2*SiBarrelSiliconSpace1 + SiBarrelSiliconCurveHeight1"  />
-<constant name="SiBarrel2_LongThickness" value="1.5*SiBarrelSensorMod_thickness + SiBarrelStave2Service_thickness + SiBarrelStave2Frame_thickness +  SiBarrelBrace_thickness + 2*SiBarrelSiliconSpace2 + SiBarrelSiliconCurveHeight1"  />
+<constant name="SiBarrel_ShortThickness" value="SiBarrelSensorCu_thickness + SiBarrelSensorActiveSi_thickness/2" />
+<constant name="SiBarrel1_SupportDepth" value="SiBarrelStave1Service_thickness + SiBarrelStave1Frame_thickness + SiBarrelBrace_thickness + 2*SiBarrelSiliconSpace1 + SiBarrelSiliconCurveHeight1" />
+<constant name="SiBarrel2_SupportDepth" value="SiBarrelStave2Service_thickness + SiBarrelStave2Frame_thickness + SiBarrelBrace_thickness + 2*SiBarrelSiliconSpace2 + SiBarrelSiliconCurveHeight2" />
+<constant name="SiBarrel1_LongThickness" value="SiBarrelSensorInactiveSi_thickness + SiBarrelSensorActiveSi_thickness/2 + SiBarrelSensorMod_thickness + SiBarrel1_SupportDepth" />
+<constant name="SiBarrel2_LongThickness" value="SiBarrelSensorInactiveSi_thickness + SiBarrelSensorActiveSi_thickness/2 + SiBarrelSensorMod_thickness + SiBarrel2_SupportDepth" />
 
 
   </define>
@@ -114,7 +124,12 @@
         rmax="SiBarrelLayer1_rmax"
         length="SiBarrelLayer1_length" />
       <comment>Silicon Barrel Modules</comment>
-      <module name="Module1" vis="TrackerLayerVis">
+      <module name="Module1" vis="TrackerLayerVis"
+        sensor_stack="true"
+        sensor_cu_thickness="SiBarrelSensorCu_thickness"
+        sensor_active_si_thickness="SiBarrelSensorActiveSi_thickness"
+        sensor_inactive_si_thickness="SiBarrelSensorInactiveSi_thickness"
+        sensor_support_depth="SiBarrel1_SupportDepth">
 
          <module_component name="CurvedSi0C"
              material="Silicon"
@@ -259,7 +274,7 @@
           width="SiBarrelStave1_width"
           length="SiBarrelStave1_length"
           thickness="SiBarrelStave1Service_thickness"
-          vis="TrackerLayerVis">
+          vis="TrackerSupportVis">
           <position x="0" y="0" z="0.5*(SiBarrelBrace_thickness + SiBarrelStave1Service_thickness)" />
           </module_component>
 
@@ -390,7 +405,12 @@
         rmax="SiBarrelLayer2_rmax"
         length="SiBarrelLayer2_length" />
       <comment>Silicon Barrel Modules</comment>
-      <module name="Module1" vis="TrackerLayerVis">
+      <module name="Module1" vis="TrackerLayerVis"
+        sensor_stack="true"
+        sensor_cu_thickness="SiBarrelSensorCu_thickness"
+        sensor_active_si_thickness="SiBarrelSensorActiveSi_thickness"
+        sensor_inactive_si_thickness="SiBarrelSensorInactiveSi_thickness"
+        sensor_support_depth="SiBarrel2_SupportDepth">
 
          <module_component name="CurvedSi0C"
              material="Silicon"
@@ -654,7 +674,7 @@
           width="SiBarrelStave2_width"
           length="SiBarrelStave2_length"
           thickness="SiBarrelStave2Service_thickness"
-          vis="TrackerLayerVis" >
+          vis="TrackerSupportVis" >
           <position x="0" y="0" z="0.5*(SiBarrelBrace_thickness + SiBarrelStave1Service_thickness)" />
         </module_component>
 

--- a/compact/tracking/silicon_disks.xml
+++ b/compact/tracking/silicon_disks.xml
@@ -18,12 +18,7 @@
     <comment> Support/service thicknesses from ATHENA disks for now </comment>
     <constant name="SiTrackerEndcapAl_thickness"    value="0.15*mm"/>
     <constant name="SiTrackerEndcapCF_thickness"    value="0.12*mm"/>
-    <constant name="SiTrackerSensorCu_thickness"         value="2.5*um"/>
-    <constant name="SiTrackerSensorActiveSi_thickness"   value="14*um"/>
-    <constant name="SiTrackerSensorInactiveSi_thickness" value="36*um"/>
-    <constant name="SiTrackerSensor_thickness"
-      value="SiTrackerSensorCu_thickness + SiTrackerSensorActiveSi_thickness + SiTrackerSensorInactiveSi_thickness"/>
-    <comment>The reflected endcap geometry puts the last component toward z=0 on both sides.</comment>
+    <constant name="SiTrackerSensor_thickness"      value="40*um"/>
 
     <comment> Currently parametrized as 36 pie-shaped modules to approximate disk </comment>
     <constant name="SiTrackerEndcapMod_count"       value="36"/>
@@ -78,9 +73,7 @@
         <trd x1="InnerTrackerEndcapPMod1_x1/2" x2="InnerTrackerEndcapPMod1_x2/2" z="InnerTrackerEndcapPMod1_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
+        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
@@ -110,9 +103,7 @@
         <trd x1="InnerTrackerEndcapNMod1_x1/2" x2="InnerTrackerEndcapNMod1_x2/2" z="InnerTrackerEndcapNMod1_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
+        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
@@ -226,9 +217,7 @@
         <trd x1="TrackerEndcapPMod1_x1/2" x2="TrackerEndcapPMod1_x2/2" z="TrackerEndcapPMod1_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
+        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
@@ -258,9 +247,7 @@
         <trd x1="TrackerEndcapNMod1_x1/2" x2="TrackerEndcapNMod1_x2/2" z="TrackerEndcapNMod1_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
+        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
@@ -290,25 +277,19 @@
         <trd x1="TrackerEndcapPMod2_x1/2" x2="TrackerEndcapPMod2_x2/2" z="TrackerEndcapPMod2_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
+        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
       </module>
       <module name="Module3" vis="TrackerModuleVis">
         <trd x1="TrackerEndcapPMod3_x1/2" x2="TrackerEndcapPMod3_x2/2" z="TrackerEndcapPMod3_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
+        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
       </module>
       <module name="Module4" vis="TrackerModuleVis">
         <trd x1="TrackerEndcapPMod4_x1/2" x2="TrackerEndcapPMod4_x2/2" z="TrackerEndcapPMod4_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
+        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
       </module>
       <layer id="2">
         <envelope vis="TrackerLayerVis"
@@ -368,25 +349,19 @@
         <trd x1="TrackerEndcapNMod2_x1/2" x2="TrackerEndcapNMod2_x2/2" z="TrackerEndcapNMod2_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
+        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
       </module>
       <module name="Module3" vis="TrackerModuleVis">
         <trd x1="TrackerEndcapNMod3_x1/2" x2="TrackerEndcapNMod3_x2/2" z="TrackerEndcapNMod3_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
+        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
       </module>
           <module name="Module4" vis="TrackerModuleVis">
         <trd x1="TrackerEndcapNMod4_x1/2" x2="TrackerEndcapNMod4_x2/2" z="TrackerEndcapNMod4_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
-        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
+        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
       </module>
       <layer id="2">
         <envelope vis="TrackerLayerVis"

--- a/compact/tracking/silicon_disks.xml
+++ b/compact/tracking/silicon_disks.xml
@@ -18,7 +18,12 @@
     <comment> Support/service thicknesses from ATHENA disks for now </comment>
     <constant name="SiTrackerEndcapAl_thickness"    value="0.15*mm"/>
     <constant name="SiTrackerEndcapCF_thickness"    value="0.12*mm"/>
-    <constant name="SiTrackerSensor_thickness"      value="40*um"/>
+    <constant name="SiTrackerSensorCu_thickness"         value="2.5*um"/>
+    <constant name="SiTrackerSensorActiveSi_thickness"   value="14*um"/>
+    <constant name="SiTrackerSensorInactiveSi_thickness" value="36*um"/>
+    <constant name="SiTrackerSensor_thickness"
+      value="SiTrackerSensorCu_thickness + SiTrackerSensorActiveSi_thickness + SiTrackerSensorInactiveSi_thickness"/>
+    <comment>The reflected endcap geometry puts the last component toward z=0 on both sides.</comment>
 
     <comment> Currently parametrized as 36 pie-shaped modules to approximate disk </comment>
     <constant name="SiTrackerEndcapMod_count"       value="36"/>
@@ -73,7 +78,9 @@
         <trd x1="InnerTrackerEndcapPMod1_x1/2" x2="InnerTrackerEndcapPMod1_x2/2" z="InnerTrackerEndcapPMod1_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
@@ -103,7 +110,9 @@
         <trd x1="InnerTrackerEndcapNMod1_x1/2" x2="InnerTrackerEndcapNMod1_x2/2" z="InnerTrackerEndcapNMod1_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
@@ -217,7 +226,9 @@
         <trd x1="TrackerEndcapPMod1_x1/2" x2="TrackerEndcapPMod1_x2/2" z="TrackerEndcapPMod1_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
@@ -247,7 +258,9 @@
         <trd x1="TrackerEndcapNMod1_x1/2" x2="TrackerEndcapNMod1_x2/2" z="TrackerEndcapNMod1_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
       </module>
       <layer id="1">
         <envelope vis="TrackerLayerVis"
@@ -277,19 +290,25 @@
         <trd x1="TrackerEndcapPMod2_x1/2" x2="TrackerEndcapPMod2_x2/2" z="TrackerEndcapPMod2_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
       </module>
       <module name="Module3" vis="TrackerModuleVis">
         <trd x1="TrackerEndcapPMod3_x1/2" x2="TrackerEndcapPMod3_x2/2" z="TrackerEndcapPMod3_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
       </module>
       <module name="Module4" vis="TrackerModuleVis">
         <trd x1="TrackerEndcapPMod4_x1/2" x2="TrackerEndcapPMod4_x2/2" z="TrackerEndcapPMod4_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
       </module>
       <layer id="2">
         <envelope vis="TrackerLayerVis"
@@ -349,19 +368,25 @@
         <trd x1="TrackerEndcapNMod2_x1/2" x2="TrackerEndcapNMod2_x2/2" z="TrackerEndcapNMod2_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
       </module>
       <module name="Module3" vis="TrackerModuleVis">
         <trd x1="TrackerEndcapNMod3_x1/2" x2="TrackerEndcapNMod3_x2/2" z="TrackerEndcapNMod3_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
       </module>
           <module name="Module4" vis="TrackerModuleVis">
         <trd x1="TrackerEndcapNMod4_x1/2" x2="TrackerEndcapNMod4_x2/2" z="TrackerEndcapNMod4_y/2" />
         <module_component thickness="SiTrackerEndcapCF_thickness" material="CarbonFiber" vis="TrackerSupportVis" />
         <module_component thickness="SiTrackerEndcapAl_thickness" material="Aluminum" vis="TrackerServiceVis" />
-        <module_component thickness="SiTrackerSensor_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorInactiveSi_thickness" material="Silicon" sensitive="false" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorActiveSi_thickness" material="Silicon" sensitive="true" vis="TrackerLayerVis" />
+        <module_component thickness="SiTrackerSensorCu_thickness" material="Copper" sensitive="false" vis="TrackerServiceVis" />
       </module>
       <layer id="2">
         <envelope vis="TrackerLayerVis"

--- a/compact/tracking/vertex_barrel.xml
+++ b/compact/tracking/vertex_barrel.xml
@@ -8,7 +8,7 @@
     <constant name="SiVertexSensorInactiveSi_thickness" value="36*um" />
     <constant name="SiVertexSensor_thickness"
       value="SiVertexSensorCu_thickness + SiVertexSensorActiveSi_thickness + SiVertexSensorInactiveSi_thickness" />
-    <comment>Radial order: inactive Si (substrate), active Si (epitaxial), then Cu (wire bond) at larger R.</comment>
+    <comment>Radial order: inactive Si (substrate), active Si (epitaxial), then Cu (metal layer) at larger R.</comment>
 
     <comment>
       One physical RSU is one module. Its 14 um silicon layer contains two rows
@@ -100,6 +100,7 @@
         twelve 2x6 tile regions are sensitive. Cu is always at larger radius.
       </comment>
       <rsu_layout
+        passive_vis="SVTReadoutVis"
         rows_rphi="RSURows_rphi"
         halves_z="RSUHalves_z"
         tiles_per_z_half="RSUTiles_per_z_half"
@@ -116,23 +117,17 @@
           material="Silicon"
           sensitive="false"
           thickness="SiVertexSensorInactiveSi_thickness"
-          width="RSU_width"
-          length="RSU_length"
           vis="VertexLayerVis" />
         <module_component name="ActiveSi"
           material="Silicon"
           sensitive="true"
           thickness="SiVertexSensorActiveSi_thickness"
-          width="RSU_width"
-          length="RSU_length"
           vis="VertexLayerVis" />
         <module_component name="Cu"
           material="Copper"
           sensitive="false"
           thickness="SiVertexSensorCu_thickness"
-          width="RSU_width"
-          length="RSU_length"
-          vis="VertexLayerVis" />
+          vis="SVTReadoutVis" />
       </module>
 
       <module name="Module1" rmin="VertexBarrelModL1_rmin" width="VertexBarrelStaveL1_width"
@@ -141,23 +136,17 @@
           material="Silicon"
           sensitive="false"
           thickness="SiVertexSensorInactiveSi_thickness"
-          width="RSU_width"
-          length="RSU_length"
           vis="VertexLayerVis" />
         <module_component name="ActiveSi"
           material="Silicon"
           sensitive="true"
           thickness="SiVertexSensorActiveSi_thickness"
-          width="RSU_width"
-          length="RSU_length"
           vis="VertexLayerVis" />
         <module_component name="Cu"
           material="Copper"
           sensitive="false"
           thickness="SiVertexSensorCu_thickness"
-          width="RSU_width"
-          length="RSU_length"
-          vis="VertexLayerVis" />
+          vis="SVTReadoutVis" />
       </module>
 
       <module name="Module2" rmin="VertexBarrelModL2_rmin" width="VertexBarrelStaveL2_width"
@@ -166,23 +155,17 @@
           material="Silicon"
           sensitive="false"
           thickness="SiVertexSensorInactiveSi_thickness"
-          width="RSU_width"
-          length="RSU_length"
           vis="VertexLayerVis" />
         <module_component name="ActiveSi"
           material="Silicon"
           sensitive="true"
           thickness="SiVertexSensorActiveSi_thickness"
-          width="RSU_width"
-          length="RSU_length"
           vis="VertexLayerVis" />
         <module_component name="Cu"
           material="Copper"
           sensitive="false"
           thickness="SiVertexSensorCu_thickness"
-          width="RSU_width"
-          length="RSU_length"
-          vis="VertexLayerVis" />
+          vis="SVTReadoutVis" />
       </module>
 
       <comment>Each layer places complete RSUs around phi and along z.</comment>

--- a/compact/tracking/vertex_barrel.xml
+++ b/compact/tracking/vertex_barrel.xml
@@ -1,5 +1,5 @@
 <!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
-<!-- Copyright (C) 2025 Sylvester Joosten, Whitney Armstrong, Shujie Li -->
+<!-- Copyright (C) 2026 Sylvester Joosten, Whitney Armstrong, Shujie Li -->
 
 <lccdd>
   <define>
@@ -8,68 +8,66 @@
     <constant name="SiVertexSensorInactiveSi_thickness" value="36*um" />
     <constant name="SiVertexSensor_thickness"
       value="SiVertexSensorCu_thickness + SiVertexSensorActiveSi_thickness + SiVertexSensorInactiveSi_thickness" />
-    <comment>Radial order: inactive Si, active Si, then Cu at larger R.</comment>
+    <comment>Radial order: inactive Si (substrate), active Si (epitaxial), then Cu (wire bond) at larger R.</comment>
 
     <comment>
-      1 RSU              = 2x6 tiles with inactive areas == 2x2 sections
-      1 section (module) = 3-tiles along z
-      1 "stave"          = 1 row of 12 RSU
+      One physical RSU is one module. Its 14 um silicon layer contains two rows
+      of six sensitive tiles; the silicon between tiles remains inactive.
     </comment>
 
     <constant name="RSU_width"   value="19.564*mm" />
     <constant name="RSU_length"  value="21.666*mm" />
-    <constant name="RSUSection_rphi" value="RSU_width/2" />
-    <constant name="RSUSection_z" value="RSU_length/2" />
+    <constant name="RSUHalf_rphi" value="RSU_width/2" />
+    <constant name="RSUHalf_z" value="RSU_length/2" />
     <constant name="RSUBackbone_z" value="0.060*mm" />
     <constant name="RSUBiasing_rphi" value="0.060*mm" />
     <constant name="RSUReadout_rphi" value="0.525*mm" />
     <constant name="RSUPower_z" value="0.020*mm" />
-    <constant name="RSUTiles_per_section" value="3" />
+    <constant name="RSURows_rphi" value="2" />
+    <constant name="RSUHalves_z" value="2" />
+    <constant name="RSUTiles_per_z_half" value="3" />
     <constant name="RSUTile_rphi"
-      value="RSUSection_rphi - RSUBiasing_rphi - RSUReadout_rphi" />
+      value="RSUHalf_rphi - RSUBiasing_rphi - RSUReadout_rphi" />
     <constant name="RSUTilePitch_z"
-      value="(RSUSection_z - RSUBackbone_z)/RSUTiles_per_section" />
+      value="(RSUHalf_z - RSUBackbone_z)/RSUTiles_per_z_half" />
     <constant name="RSUTile_z" value="RSUTilePitch_z - RSUPower_z" />
 
-    <constant name="VertexBarrelMod_length"   value="RSUSection_z" />
-    <constant name="VertexBarrelLayer_nz"     value="12*2" />
-    <comment>
-      # of RSU in phi: 12, 16, 40 RSUs = 24, 32, 80 sections
-    </comment>
-    <constant name="VertexBarrelL0_nphi" value="12*2" />
-    <constant name="VertexBarrelL1_nphi" value="16*2" />
-    <constant name="VertexBarrelL2_nphi" value="40*2" />
+    <constant name="VertexBarrelMod_length" value="RSU_length" />
+    <constant name="VertexBarrelLayer_nz" value="12" />
+    <comment>Number of physical RSUs around each barrel layer.</comment>
+    <constant name="VertexBarrelL0_nphi" value="12" />
+    <constant name="VertexBarrelL1_nphi" value="16" />
+    <constant name="VertexBarrelL2_nphi" value="40" />
 
-    <constant name="VertexBarrelStaveL0_width" value="RSUSection_rphi" />
-    <constant name="VertexBarrelStaveL1_width" value="RSUSection_rphi" />
-    <constant name="VertexBarrelStaveL2_width" value="RSUSection_rphi" />
+    <constant name="VertexBarrelStaveL0_width" value="RSU_width" />
+    <constant name="VertexBarrelStaveL1_width" value="RSU_width" />
+    <constant name="VertexBarrelStaveL2_width" value="RSU_width" />
 
     <comment>
-      the radius here include a gap b/w upper and lower half.
-      L0 and L1 values from drawing (see vertex_barrel_support.xml)
+      The layer radii follow the support drawing in vertex_barrel_support.xml.
+      L1 and L2 include a 1 um clearance from the support.
     </comment>
     <constant name="VertexBarrelMod_thickness" value="0.2*mm" />
     <constant name="VertexBarrelModL0_rmin" value="38*mm" />
     <constant name="VertexBarrelModL1_rmin" value="50.3*mm+1*um" />
     <constant name="VertexBarrelModL2_rmin" value="125.2*mm+1*um" />
 
-    <constant name="VertexBarrelMod_vert_off" value="1.0*mm" /> <comment>roughly (38.15*2pi-234.8)/4 </comment>
-    <constant name="VertexBarrelModL0_dphi"   value="VertexBarrelMod_vert_off/VertexBarrelModL0_rmin" />
-    <constant name="VertexBarrelModL1_dphi"   value="VertexBarrelMod_vert_off/VertexBarrelModL1_rmin" />
-    <constant name="VertexBarrelModL2_dphi"   value="VertexBarrelMod_vert_off/VertexBarrelModL2_rmin" />
-
-    <documentation>
-      for the segmentation. Assume sensors are placed at the inner most surface for each layer
-    </documentation>
+    <comment>The segmentation radius is the center of the 14 um active-silicon layer.</comment>
     <constant name="VertexBarrelSegL0_r" value="VertexBarrelModL0_rmin+SiVertexSensorInactiveSi_thickness+SiVertexSensorActiveSi_thickness/2.0" />
     <constant name="VertexBarrelSegL1_r" value="VertexBarrelModL1_rmin+SiVertexSensorInactiveSi_thickness+SiVertexSensorActiveSi_thickness/2.0" />
     <constant name="VertexBarrelSegL2_r" value="VertexBarrelModL2_rmin+SiVertexSensorInactiveSi_thickness+SiVertexSensorActiveSi_thickness/2.0" />
 
-    <constant name="VertexBarrelEnvelope_length"    value="VertexTrackingRegion_length"/> <comment>place holder, not used for now bur required for CI checks</comment>
-    <documentation>
-      - Currently there are 3 sensor layers: Layer 1,2,3 = L0, L1, L2.
-      - assume they are of the same length and aligned.
-    </documentation>
+    <comment>
+      The two barrel half-shell seams need extra azimuthal clearance. Convert
+      the 1 mm clearance to an angle at the active-silicon radius.
+    </comment>
+    <constant name="VertexBarrelMod_vert_off" value="1.0*mm" />
+    <constant name="VertexBarrelModL0_dphi" value="VertexBarrelMod_vert_off/VertexBarrelSegL0_r" />
+    <constant name="VertexBarrelModL1_dphi" value="VertexBarrelMod_vert_off/VertexBarrelSegL1_r" />
+    <constant name="VertexBarrelModL2_dphi" value="VertexBarrelMod_vert_off/VertexBarrelSegL2_r" />
+
+    <constant name="VertexBarrelEnvelope_length" value="VertexTrackingRegion_length"/>
+    <comment>All three sensor layers have the same length and z alignment.</comment>
     <constant name="VertexBarrelLayer_length" value="VertexBarrelMod_length*VertexBarrelLayer_nz" />
     <constant name="VertexBarrelLayer_zoff"   value="0"  />
     <constant name="VertexBarrelLayer_zstart" value="-VertexBarrelLayer_length/2+VertexBarrelLayer_zoff" />
@@ -97,24 +95,14 @@
       insideTrackingVolume="true">
       <type_flags type="DetType_TRACKER + DetType_BARREL" />
       <comment>
-        - Vertex Barrel Modules.
-        - For RSU (1 module = 1 upper/lower section of three tiles):
-            --Use [mod_name]_upper and [mod_name]_lower here, and [mod_name] in corresponding layer
-          to allow the geo plugin find both modules.
-            -- also need to specify type="upper" or "lower" in components.
-        - for other modules and components:
-            no need to specify upper and lower anywhere.
-        - one RSU ("|" = backbone. Length alone z.):
-         | ------readout-------- | -------readout--------
-         | tile*3                | tile*3                      upper module
-         | ------biasing-------- | -------biasing--------
-         | ------biasing-------- | -------biasing--------
-         | tile*3                | tile*3                      lower module
-         | ------readout-------- | -------readout--------
-
+        Each module is one complete RSU. The 36 um inactive Si and 2.5 um Cu
+        cover the full RSU. The 14 um Si also covers the full RSU, but only its
+        twelve 2x6 tile regions are sensitive. Cu is always at larger radius.
       </comment>
       <rsu_layout
-        tiles_per_section="RSUTiles_per_section"
+        rows_rphi="RSURows_rphi"
+        halves_z="RSUHalves_z"
+        tiles_per_z_half="RSUTiles_per_z_half"
         backbone_z="RSUBackbone_z"
         biasing_rphi="RSUBiasing_rphi"
         readout_rphi="RSUReadout_rphi"
@@ -122,154 +110,82 @@
         tile_rphi="RSUTile_rphi"
         tile_pitch_z="RSUTilePitch_z"
         tile_z="RSUTile_z" />
-      <module name="Module0_upper" rmin="VertexBarrelModL0_rmin"  width="VertexBarrelStaveL0_width"
-      length="VertexBarrelMod_length">
-        <module_component name="RSU" type="upper"
+      <module name="Module0" rmin="VertexBarrelModL0_rmin" width="VertexBarrelStaveL0_width"
+        length="VertexBarrelMod_length">
+        <module_component name="InactiveSi"
           material="Silicon"
           sensitive="false"
           thickness="SiVertexSensorInactiveSi_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
+          width="RSU_width"
+          length="RSU_length"
           vis="VertexLayerVis" />
-        <module_component name="RSU" type="upper"
+        <module_component name="ActiveSi"
           material="Silicon"
           sensitive="true"
           thickness="SiVertexSensorActiveSi_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
+          width="RSU_width"
+          length="RSU_length"
           vis="VertexLayerVis" />
-        <module_component name="RSU" type="upper"
+        <module_component name="Cu"
           material="Copper"
           sensitive="false"
           thickness="SiVertexSensorCu_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
-          vis="VertexLayerVis" />
-      </module>
-      <module name="Module0_lower" rmin="VertexBarrelModL0_rmin"  width="VertexBarrelStaveL0_width"
-      length="VertexBarrelMod_length">
-        <module_component name="RSU" type="lower"
-          material="Silicon"
-          sensitive="false"
-          thickness="SiVertexSensorInactiveSi_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
-          vis="VertexLayerVis" />
-        <module_component name="RSU" type="lower"
-          material="Silicon"
-          sensitive="true"
-          thickness="SiVertexSensorActiveSi_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
-          vis="VertexLayerVis" />
-        <module_component name="RSU" type="lower"
-          material="Copper"
-          sensitive="false"
-          thickness="SiVertexSensorCu_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
+          width="RSU_width"
+          length="RSU_length"
           vis="VertexLayerVis" />
       </module>
 
-      <module name="Module1_upper" rmin="VertexBarrelModL1_rmin"  width="VertexBarrelStaveL1_width"
-      length="VertexBarrelMod_length">
-        <module_component name="RSU" type="upper"
+      <module name="Module1" rmin="VertexBarrelModL1_rmin" width="VertexBarrelStaveL1_width"
+        length="VertexBarrelMod_length">
+        <module_component name="InactiveSi"
           material="Silicon"
           sensitive="false"
           thickness="SiVertexSensorInactiveSi_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
+          width="RSU_width"
+          length="RSU_length"
           vis="VertexLayerVis" />
-        <module_component name="RSU" type="upper"
+        <module_component name="ActiveSi"
           material="Silicon"
           sensitive="true"
           thickness="SiVertexSensorActiveSi_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
+          width="RSU_width"
+          length="RSU_length"
           vis="VertexLayerVis" />
-        <module_component name="RSU" type="upper"
+        <module_component name="Cu"
           material="Copper"
           sensitive="false"
           thickness="SiVertexSensorCu_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
-          vis="VertexLayerVis" />
-      </module>
-      <module name="Module1_lower" rmin="VertexBarrelModL1_rmin"  width="VertexBarrelStaveL1_width"
-      length="VertexBarrelMod_length">
-        <module_component name="RSU" type="lower"
-          material="Silicon"
-          sensitive="false"
-          thickness="SiVertexSensorInactiveSi_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
-          vis="VertexLayerVis" />
-        <module_component name="RSU" type="lower"
-          material="Silicon"
-          sensitive="true"
-          thickness="SiVertexSensorActiveSi_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
-          vis="VertexLayerVis" />
-        <module_component name="RSU" type="lower"
-          material="Copper"
-          sensitive="false"
-          thickness="SiVertexSensorCu_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
+          width="RSU_width"
+          length="RSU_length"
           vis="VertexLayerVis" />
       </module>
 
-      <module name="Module2_upper" rmin="VertexBarrelModL2_rmin"  width="VertexBarrelStaveL2_width"
-      length="VertexBarrelMod_length">
-        <module_component name="RSU" type="upper"
+      <module name="Module2" rmin="VertexBarrelModL2_rmin" width="VertexBarrelStaveL2_width"
+        length="VertexBarrelMod_length">
+        <module_component name="InactiveSi"
           material="Silicon"
           sensitive="false"
           thickness="SiVertexSensorInactiveSi_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
+          width="RSU_width"
+          length="RSU_length"
           vis="VertexLayerVis" />
-        <module_component name="RSU" type="upper"
+        <module_component name="ActiveSi"
           material="Silicon"
           sensitive="true"
           thickness="SiVertexSensorActiveSi_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
+          width="RSU_width"
+          length="RSU_length"
           vis="VertexLayerVis" />
-        <module_component name="RSU" type="upper"
+        <module_component name="Cu"
           material="Copper"
           sensitive="false"
           thickness="SiVertexSensorCu_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
-          vis="VertexLayerVis" />
-      </module>
-      <module name="Module2_lower" rmin="VertexBarrelModL2_rmin"  width="VertexBarrelStaveL2_width"
-      length="VertexBarrelMod_length">
-        <module_component name="RSU" type="lower"
-          material="Silicon"
-          sensitive="false"
-          thickness="SiVertexSensorInactiveSi_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
-          vis="VertexLayerVis" />
-        <module_component name="RSU" type="lower"
-          material="Silicon"
-          sensitive="true"
-          thickness="SiVertexSensorActiveSi_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
-          vis="VertexLayerVis" />
-        <module_component name="RSU" type="lower"
-          material="Copper"
-          sensitive="false"
-          thickness="SiVertexSensorCu_thickness"
-          width="RSUSection_rphi"
-          length="RSUSection_z"
+          width="RSU_width"
+          length="RSU_length"
           vis="VertexLayerVis" />
       </module>
 
-      <comment> Layers composed of many arrayed modules </comment>
+      <comment>Each layer places complete RSUs around phi and along z.</comment>
       <comment> L0 </comment>
       <layer module="Module0" id="0" vis="VertexLayerVis">
         <barrel_envelope
@@ -280,12 +196,7 @@
           bins1="100" />
         <layer_material surface="outer" binning="binPhi,binZ" bins0="VertexBarrelL0_nphi"
           bins1="100" />
-        <comment>
-          phi0 : Starting phi of first module at the first/second halve.
-          nphi : Number of modules in phi.
-          z0 : Z position of first module's center.
-          nz : Number of modules to place in z.
-        </comment>
+        <comment>`phi0` leaves clearance at the half-shell seams; `z0` is the first RSU center.</comment>
         <rphi_layout nphi="VertexBarrelL0_nphi" phi0="VertexBarrelModL0_dphi" dr="0.0 * mm" />
         <z_layout z0="VertexBarrelLayer_z0" nz="VertexBarrelLayer_nz" />
       </layer>
@@ -341,7 +252,7 @@
           grid_size_phi="0.02*mm/VertexBarrelSegL2_r" grid_size_z="0.02*mm"
           radius="VertexBarrelSegL2_r" />
       </segmentation>
-      <id>system:8,layer:4,module:12,sensor:2,phi:32:-16,z:-16</id>
+      <id>system:8,layer:4,module:12,sensor:4,phi:32:-16,z:-16</id>
     </readout>
   </readouts>
 

--- a/compact/tracking/vertex_barrel.xml
+++ b/compact/tracking/vertex_barrel.xml
@@ -3,7 +3,12 @@
 
 <lccdd>
   <define>
-    <constant name="SiVertexSensor_thickness" value="40*um" />
+    <constant name="SiVertexSensorCu_thickness"         value="2.5*um" />
+    <constant name="SiVertexSensorActiveSi_thickness"   value="14*um" />
+    <constant name="SiVertexSensorInactiveSi_thickness" value="36*um" />
+    <constant name="SiVertexSensor_thickness"
+      value="SiVertexSensorCu_thickness + SiVertexSensorActiveSi_thickness + SiVertexSensorInactiveSi_thickness" />
+    <comment>Radial order: inactive Si, active Si, then Cu at larger R.</comment>
 
     <comment>
       1 RSU              = 2x6 tiles with inactive areas == 2x2 sections
@@ -49,9 +54,9 @@
     <documentation>
       for the segmentation. Assume sensors are placed at the inner most surface for each layer
     </documentation>
-    <constant name="VertexBarrelSegL0_r" value="VertexBarrelModL0_rmin+SiVertexSensor_thickness/2.0" />
-    <constant name="VertexBarrelSegL1_r" value="VertexBarrelModL1_rmin+SiVertexSensor_thickness/2.0" />
-    <constant name="VertexBarrelSegL2_r" value="VertexBarrelModL2_rmin+SiVertexSensor_thickness/2.0" />
+    <constant name="VertexBarrelSegL0_r" value="VertexBarrelModL0_rmin+SiVertexSensorInactiveSi_thickness+SiVertexSensorActiveSi_thickness/2.0" />
+    <constant name="VertexBarrelSegL1_r" value="VertexBarrelModL1_rmin+SiVertexSensorInactiveSi_thickness+SiVertexSensorActiveSi_thickness/2.0" />
+    <constant name="VertexBarrelSegL2_r" value="VertexBarrelModL2_rmin+SiVertexSensorInactiveSi_thickness+SiVertexSensorActiveSi_thickness/2.0" />
 
     <constant name="VertexBarrelEnvelope_length"    value="VertexTrackingRegion_length"/> <comment>place holder, not used for now bur required for CI checks</comment>
     <documentation>
@@ -105,8 +110,22 @@
       length="VertexBarrelMod_length">
         <module_component name="RSU" type="upper"
           material="Silicon"
+          sensitive="false"
+          thickness="SiVertexSensorInactiveSi_thickness"
+          width="Section_width"
+          length="Section_length"
+          vis="VertexLayerVis" />
+        <module_component name="RSU" type="upper"
+          material="Silicon"
           sensitive="true"
-          thickness="SiVertexSensor_thickness"
+          thickness="SiVertexSensorActiveSi_thickness"
+          width="Section_width"
+          length="Section_length"
+          vis="VertexLayerVis" />
+        <module_component name="RSU" type="upper"
+          material="Copper"
+          sensitive="false"
+          thickness="SiVertexSensorCu_thickness"
           width="Section_width"
           length="Section_length"
           vis="VertexLayerVis" />
@@ -115,8 +134,22 @@
       length="VertexBarrelMod_length">
         <module_component name="RSU" type="lower"
           material="Silicon"
+          sensitive="false"
+          thickness="SiVertexSensorInactiveSi_thickness"
+          width="Section_width"
+          length="Section_length"
+          vis="VertexLayerVis" />
+        <module_component name="RSU" type="lower"
+          material="Silicon"
           sensitive="true"
-          thickness="SiVertexSensor_thickness"
+          thickness="SiVertexSensorActiveSi_thickness"
+          width="Section_width"
+          length="Section_length"
+          vis="VertexLayerVis" />
+        <module_component name="RSU" type="lower"
+          material="Copper"
+          sensitive="false"
+          thickness="SiVertexSensorCu_thickness"
           width="Section_width"
           length="Section_length"
           vis="VertexLayerVis" />
@@ -126,8 +159,22 @@
       length="VertexBarrelMod_length">
         <module_component name="RSU" type="upper"
           material="Silicon"
+          sensitive="false"
+          thickness="SiVertexSensorInactiveSi_thickness"
+          width="Section_width"
+          length="Section_length"
+          vis="VertexLayerVis" />
+        <module_component name="RSU" type="upper"
+          material="Silicon"
           sensitive="true"
-          thickness="SiVertexSensor_thickness"
+          thickness="SiVertexSensorActiveSi_thickness"
+          width="Section_width"
+          length="Section_length"
+          vis="VertexLayerVis" />
+        <module_component name="RSU" type="upper"
+          material="Copper"
+          sensitive="false"
+          thickness="SiVertexSensorCu_thickness"
           width="Section_width"
           length="Section_length"
           vis="VertexLayerVis" />
@@ -136,8 +183,22 @@
       length="VertexBarrelMod_length">
         <module_component name="RSU" type="lower"
           material="Silicon"
+          sensitive="false"
+          thickness="SiVertexSensorInactiveSi_thickness"
+          width="Section_width"
+          length="Section_length"
+          vis="VertexLayerVis" />
+        <module_component name="RSU" type="lower"
+          material="Silicon"
           sensitive="true"
-          thickness="SiVertexSensor_thickness"
+          thickness="SiVertexSensorActiveSi_thickness"
+          width="Section_width"
+          length="Section_length"
+          vis="VertexLayerVis" />
+        <module_component name="RSU" type="lower"
+          material="Copper"
+          sensitive="false"
+          thickness="SiVertexSensorCu_thickness"
           width="Section_width"
           length="Section_length"
           vis="VertexLayerVis" />
@@ -147,8 +208,22 @@
       length="VertexBarrelMod_length">
         <module_component name="RSU" type="upper"
           material="Silicon"
+          sensitive="false"
+          thickness="SiVertexSensorInactiveSi_thickness"
+          width="Section_width"
+          length="Section_length"
+          vis="VertexLayerVis" />
+        <module_component name="RSU" type="upper"
+          material="Silicon"
           sensitive="true"
-          thickness="SiVertexSensor_thickness"
+          thickness="SiVertexSensorActiveSi_thickness"
+          width="Section_width"
+          length="Section_length"
+          vis="VertexLayerVis" />
+        <module_component name="RSU" type="upper"
+          material="Copper"
+          sensitive="false"
+          thickness="SiVertexSensorCu_thickness"
           width="Section_width"
           length="Section_length"
           vis="VertexLayerVis" />
@@ -157,8 +232,22 @@
       length="VertexBarrelMod_length">
         <module_component name="RSU" type="lower"
           material="Silicon"
+          sensitive="false"
+          thickness="SiVertexSensorInactiveSi_thickness"
+          width="Section_width"
+          length="Section_length"
+          vis="VertexLayerVis" />
+        <module_component name="RSU" type="lower"
+          material="Silicon"
           sensitive="true"
-          thickness="SiVertexSensor_thickness"
+          thickness="SiVertexSensorActiveSi_thickness"
+          width="Section_width"
+          length="Section_length"
+          vis="VertexLayerVis" />
+        <module_component name="RSU" type="lower"
+          material="Copper"
+          sensitive="false"
+          thickness="SiVertexSensorCu_thickness"
           width="Section_width"
           length="Section_length"
           vis="VertexLayerVis" />

--- a/compact/tracking/vertex_barrel.xml
+++ b/compact/tracking/vertex_barrel.xml
@@ -18,13 +18,20 @@
 
     <constant name="RSU_width"   value="19.564*mm" />
     <constant name="RSU_length"  value="21.666*mm" />
-    <constant name="Periphery_width" value="0.398*mm"/>
-    <constant name="bias_width" value="0.06*mm"/>
-    <constant name="backbone_width" value="0.09*mm"/>
-    <constant name="Section_width"  value="RSU_width/2-bias_width-Periphery_width"/>
-    <constant name="Section_length" value="RSU_length/2-backbone_width"/>
+    <constant name="RSUSection_rphi" value="RSU_width/2" />
+    <constant name="RSUSection_z" value="RSU_length/2" />
+    <constant name="RSUBackbone_z" value="0.060*mm" />
+    <constant name="RSUBiasing_rphi" value="0.060*mm" />
+    <constant name="RSUReadout_rphi" value="0.525*mm" />
+    <constant name="RSUPower_z" value="0.020*mm" />
+    <constant name="RSUTiles_per_section" value="3" />
+    <constant name="RSUTile_rphi"
+      value="RSUSection_rphi - RSUBiasing_rphi - RSUReadout_rphi" />
+    <constant name="RSUTilePitch_z"
+      value="(RSUSection_z - RSUBackbone_z)/RSUTiles_per_section" />
+    <constant name="RSUTile_z" value="RSUTilePitch_z - RSUPower_z" />
 
-    <constant name="VertexBarrelMod_length"   value="RSU_length/2" />
+    <constant name="VertexBarrelMod_length"   value="RSUSection_z" />
     <constant name="VertexBarrelLayer_nz"     value="12*2" />
     <comment>
       # of RSU in phi: 12, 16, 40 RSUs = 24, 32, 80 sections
@@ -33,9 +40,9 @@
     <constant name="VertexBarrelL1_nphi" value="16*2" />
     <constant name="VertexBarrelL2_nphi" value="40*2" />
 
-    <constant name="VertexBarrelStaveL0_width" value="RSU_width/2" />
-    <constant name="VertexBarrelStaveL1_width" value="RSU_width/2" />
-    <constant name="VertexBarrelStaveL2_width" value="RSU_width/2" />
+    <constant name="VertexBarrelStaveL0_width" value="RSUSection_rphi" />
+    <constant name="VertexBarrelStaveL1_width" value="RSUSection_rphi" />
+    <constant name="VertexBarrelStaveL2_width" value="RSUSection_rphi" />
 
     <comment>
       the radius here include a gap b/w upper and lower half.
@@ -106,28 +113,37 @@
          | ------readout-------- | -------readout--------
 
       </comment>
+      <rsu_layout
+        tiles_per_section="RSUTiles_per_section"
+        backbone_z="RSUBackbone_z"
+        biasing_rphi="RSUBiasing_rphi"
+        readout_rphi="RSUReadout_rphi"
+        power_z="RSUPower_z"
+        tile_rphi="RSUTile_rphi"
+        tile_pitch_z="RSUTilePitch_z"
+        tile_z="RSUTile_z" />
       <module name="Module0_upper" rmin="VertexBarrelModL0_rmin"  width="VertexBarrelStaveL0_width"
       length="VertexBarrelMod_length">
         <module_component name="RSU" type="upper"
           material="Silicon"
           sensitive="false"
           thickness="SiVertexSensorInactiveSi_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
         <module_component name="RSU" type="upper"
           material="Silicon"
           sensitive="true"
           thickness="SiVertexSensorActiveSi_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
         <module_component name="RSU" type="upper"
           material="Copper"
           sensitive="false"
           thickness="SiVertexSensorCu_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
       </module>
       <module name="Module0_lower" rmin="VertexBarrelModL0_rmin"  width="VertexBarrelStaveL0_width"
@@ -136,22 +152,22 @@
           material="Silicon"
           sensitive="false"
           thickness="SiVertexSensorInactiveSi_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
         <module_component name="RSU" type="lower"
           material="Silicon"
           sensitive="true"
           thickness="SiVertexSensorActiveSi_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
         <module_component name="RSU" type="lower"
           material="Copper"
           sensitive="false"
           thickness="SiVertexSensorCu_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
       </module>
 
@@ -161,22 +177,22 @@
           material="Silicon"
           sensitive="false"
           thickness="SiVertexSensorInactiveSi_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
         <module_component name="RSU" type="upper"
           material="Silicon"
           sensitive="true"
           thickness="SiVertexSensorActiveSi_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
         <module_component name="RSU" type="upper"
           material="Copper"
           sensitive="false"
           thickness="SiVertexSensorCu_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
       </module>
       <module name="Module1_lower" rmin="VertexBarrelModL1_rmin"  width="VertexBarrelStaveL1_width"
@@ -185,22 +201,22 @@
           material="Silicon"
           sensitive="false"
           thickness="SiVertexSensorInactiveSi_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
         <module_component name="RSU" type="lower"
           material="Silicon"
           sensitive="true"
           thickness="SiVertexSensorActiveSi_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
         <module_component name="RSU" type="lower"
           material="Copper"
           sensitive="false"
           thickness="SiVertexSensorCu_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
       </module>
 
@@ -210,22 +226,22 @@
           material="Silicon"
           sensitive="false"
           thickness="SiVertexSensorInactiveSi_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
         <module_component name="RSU" type="upper"
           material="Silicon"
           sensitive="true"
           thickness="SiVertexSensorActiveSi_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
         <module_component name="RSU" type="upper"
           material="Copper"
           sensitive="false"
           thickness="SiVertexSensorCu_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
       </module>
       <module name="Module2_lower" rmin="VertexBarrelModL2_rmin"  width="VertexBarrelStaveL2_width"
@@ -234,22 +250,22 @@
           material="Silicon"
           sensitive="false"
           thickness="SiVertexSensorInactiveSi_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
         <module_component name="RSU" type="lower"
           material="Silicon"
           sensitive="true"
           thickness="SiVertexSensorActiveSi_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
         <module_component name="RSU" type="lower"
           material="Copper"
           sensitive="false"
           thickness="SiVertexSensorCu_thickness"
-          width="Section_width"
-          length="Section_length"
+          width="RSUSection_rphi"
+          length="RSUSection_z"
           vis="VertexLayerVis" />
       </module>
 

--- a/src/BarrelTrackerWithCurves_geo.cpp
+++ b/src/BarrelTrackerWithCurves_geo.cpp
@@ -151,8 +151,7 @@ static Ref_t create_BarrelTrackerWithCurves(Detector& description, xml_h e,
         getAttrOrDefault<double>(x_mod, _Unicode(sensor_active_si_thickness), 0.0);
     const double inactive_si_thickness =
         getAttrOrDefault<double>(x_mod, _Unicode(sensor_inactive_si_thickness), 0.0);
-    const double sensor_thickness =
-        copper_thickness + active_si_thickness + inactive_si_thickness;
+    const double sensor_thickness = copper_thickness + active_si_thickness + inactive_si_thickness;
 
     if (sensor_stack &&
         (copper_thickness <= 0 || active_si_thickness <= 0 || inactive_si_thickness <= 0)) {
@@ -241,8 +240,9 @@ static Ref_t create_BarrelTrackerWithCurves(Detector& description, xml_h e,
           double c_phi0 =
               x_comp.phi0(); // start and stop angle of segment in rad - zero is centre of stave
           double c_phi1 = x_comp.phi1();
-          double c_Nseg = x_comp.nsegments(); //  number of flat segments used to approximate cylinder
-          double dphi   = (c_phi1 - c_phi0) / (double)c_Nseg;
+          double c_Nseg =
+              x_comp.nsegments(); //  number of flat segments used to approximate cylinder
+          double dphi = (c_phi1 - c_phi0) / (double)c_Nseg;
           vector<double> Xp, Zp;
           double phiP = c_phi0;
 
@@ -257,8 +257,7 @@ static Ref_t create_BarrelTrackerWithCurves(Detector& description, xml_h e,
                                    (Zp[i + 1] - Zp[i]) * (Zp[i + 1] - Zp[i]));
             double midX     = 0.5 * (Xp[i] + Xp[i + 1]);
             double midZ     = 0.5 * (Zp[i] + Zp[i + 1]);
-            Box seg_box((segwidth / 2) *
-                            ((c_rmin - layer_thicknesses[layer] / 2) / c_rmin),
+            Box seg_box((segwidth / 2) * ((c_rmin - layer_thicknesses[layer] / 2) / c_rmin),
                         x_comp.length() / 2, layer_thicknesses[layer] / 2);
             string seg_nam = c_nam;
             if (build_sensor_stack)

--- a/src/BarrelTrackerWithCurves_geo.cpp
+++ b/src/BarrelTrackerWithCurves_geo.cpp
@@ -144,6 +144,21 @@ static Ref_t create_BarrelTrackerWithCurves(Detector& description, xml_h e,
       throw runtime_error("Logics error in building modules.");
     }
 
+    const bool sensor_stack = getAttrOrDefault<bool>(x_mod, _Unicode(sensor_stack), false);
+    const double copper_thickness =
+        getAttrOrDefault<double>(x_mod, _Unicode(sensor_cu_thickness), 0.0);
+    const double active_si_thickness =
+        getAttrOrDefault<double>(x_mod, _Unicode(sensor_active_si_thickness), 0.0);
+    const double inactive_si_thickness =
+        getAttrOrDefault<double>(x_mod, _Unicode(sensor_inactive_si_thickness), 0.0);
+    const double sensor_thickness =
+        copper_thickness + active_si_thickness + inactive_si_thickness;
+
+    if (sensor_stack &&
+        (copper_thickness <= 0 || active_si_thickness <= 0 || inactive_si_thickness <= 0)) {
+      throw runtime_error("CurvedTrackerBarrel: sensor stack thicknesses must be positive");
+    }
+
     int ncomponents        = 0;
     int sensor_number      = 1;
     double total_thickness = 0;
@@ -198,77 +213,106 @@ static Ref_t create_BarrelTrackerWithCurves(Detector& description, xml_h e,
 
       Volume c_vol;
       if (x_comp.nameStr().find("Curved") != std::string::npos) {
-        double c_rmin = x_comp.radius(); // radius of curvature in cm
-        double c_phi0 =
-            x_comp.phi0(); // start and stop angle of segment in rad - zero is centre of stave
-        double c_phi1 = x_comp.phi1();
-        double c_Nseg = x_comp.nsegments(); //  number of flat segments used to approximate cylinder
-        double dphi   = (c_phi1 - c_phi0) / (double)c_Nseg;
-        vector<double> Xp, Zp;
-        double phiP = c_phi0;
+        const bool build_sensor_stack =
+            sensor_stack && x_comp.nameStr().find("CurvedSi") != std::string::npos;
+        vector<string> layer_names       = {"Sensor"};
+        vector<string> layer_materials   = {x_comp.materialStr()};
+        vector<double> layer_thicknesses = {x_comp.thickness()};
+        vector<double> layer_offsets     = {0.0};
+        vector<bool> layer_sensitivities = {x_comp.isSensitive()};
 
-        for (int i = 0; i < c_Nseg + 1; ++i) {
-          Xp.push_back(c_rmin * sin(phiP));
-          Zp.push_back(c_rmin * cos(phiP));
-          phiP += dphi;
-        }
-        phiP = c_phi0 + dphi / 2;
-        for (int i = 0; i < c_Nseg; ++i) {
-          double segwidth = sqrt((Xp[i + 1] - Xp[i]) * (Xp[i + 1] - Xp[i]) +
-                                 (Zp[i + 1] - Zp[i]) * (Zp[i + 1] - Zp[i]));
-          double midX     = 0.5 * (Xp[i] + Xp[i + 1]);
-          double midZ     = 0.5 * (Zp[i] + Zp[i + 1]);
-          Box seg_box((segwidth / 2) * ((c_rmin - x_comp.thickness() / 2) / c_rmin),
-                      x_comp.length() / 2, x_comp.thickness() / 2);
-          string seg_nam = c_nam + "." + _toString(i);
-          Volume seg_vol(seg_nam, seg_box, description.material(x_comp.materialStr()));
-
-          if (x_pos && x_rot) {
-            Position c_pos(midX + x_pos.x(0), x_pos.y(0), midZ + x_pos.z(0));
-            RotationZYX c_rot(x_rot.z(0), phiP + x_rot.y(0), x_rot.x(0));
-            pv = m_vol.placeVolume(seg_vol, Transform3D(c_rot, c_pos));
-          } else if (x_rot) {
-            Position c_pos(midX, 0, midZ);
-            pv = m_vol.placeVolume(
-                seg_vol,
-                Transform3D(RotationZYX(x_rot.z(0), x_rot.y(0) + phiP, x_rot.x(0)), c_pos));
-          } else if (x_pos) {
-            RotationZYX c_rot(0, phiP, 0);
-            Position c_pos(midX + x_pos.x(0), x_pos.y(0), x_pos.z(0) + midZ);
-            pv = m_vol.placeVolume(seg_vol, Transform3D(c_rot, c_pos));
-          } else {
-            RotationZYX c_rot(0, phiP, 0);
-            Position c_pos(midX, 0, midZ);
-            pv = m_vol.placeVolume(seg_vol, Transform3D(c_rot, c_pos));
+        if (build_sensor_stack) {
+          if (fabs(x_comp.thickness() - sensor_thickness) > 1e-9 * mm) {
+            throw runtime_error("CurvedTrackerBarrel: component and sensor-stack thickness differ");
           }
-          phiP += dphi;
-          seg_vol.setRegion(description, x_comp.regionStr());
-          seg_vol.setLimitSet(description, x_comp.limitsStr());
-          seg_vol.setVisAttributes(description, x_comp.visStr());
-          if (x_comp.isSensitive()) {
-            pv.addPhysVolID("sensor", sensor_number++);
-            seg_vol.setSensitiveDetector(sens);
-            sensitives[m_nam].push_back(pv);
-            //        module_thicknesses[m_nam] = {x_comp.innerthickness(),x_comp.outerthickness()};
+          layer_names       = {"InactiveSi", "ActiveSi", "Copper"};
+          layer_materials   = {"Silicon", "Silicon", "Copper"};
+          layer_thicknesses = {inactive_si_thickness, active_si_thickness, copper_thickness};
+          // Increasing curvature radius is away from the stave support for both sensor surfaces.
+          layer_offsets       = {inactive_si_thickness / 2.0 - sensor_thickness / 2.0,
+                                 inactive_si_thickness + active_si_thickness / 2.0 -
+                                     sensor_thickness / 2.0,
+                                 sensor_thickness / 2.0 - copper_thickness / 2.0};
+          layer_sensitivities = {false, x_comp.isSensitive(), false};
+        }
 
-            // -------- create a measurement plane for the tracking surface attched to the sensitive volume -----
-            Vector3D u(-1., 0., 0.);
-            Vector3D v(0., -1., 0.);
-            Vector3D n(0., 0., 1.);
-            //    Vector3D o( 0. , 0. , 0. ) ;
+        for (size_t layer = 0; layer < layer_names.size(); ++layer) {
+          double c_rmin = x_comp.radius() + layer_offsets[layer]; // radius of curvature in cm
+          double c_phi0 =
+              x_comp.phi0(); // start and stop angle of segment in rad - zero is centre of stave
+          double c_phi1 = x_comp.phi1();
+          double c_Nseg = x_comp.nsegments(); //  number of flat segments used to approximate cylinder
+          double dphi   = (c_phi1 - c_phi0) / (double)c_Nseg;
+          vector<double> Xp, Zp;
+          double phiP = c_phi0;
 
-            // compute the inner and outer thicknesses that need to be assigned to the tracking surface
-            // depending on wether the support is above or below the sensor
-            double inner_thickness =
-                getAttrOrDefault<double>(x_comp, _Unicode(innerthickness), 0.5 * mm);
-            double outer_thickness =
-                getAttrOrDefault<double>(x_comp, _Unicode(outerthickness), 0.5 * mm);
-            SurfaceType type(SurfaceType::Sensitive);
+          for (int i = 0; i < c_Nseg + 1; ++i) {
+            Xp.push_back(c_rmin * sin(phiP));
+            Zp.push_back(c_rmin * cos(phiP));
+            phiP += dphi;
+          }
+          phiP = c_phi0 + dphi / 2;
+          for (int i = 0; i < c_Nseg; ++i) {
+            double segwidth = sqrt((Xp[i + 1] - Xp[i]) * (Xp[i + 1] - Xp[i]) +
+                                   (Zp[i + 1] - Zp[i]) * (Zp[i + 1] - Zp[i]));
+            double midX     = 0.5 * (Xp[i] + Xp[i + 1]);
+            double midZ     = 0.5 * (Zp[i] + Zp[i + 1]);
+            Box seg_box((segwidth / 2) *
+                            ((c_rmin - layer_thicknesses[layer] / 2) / c_rmin),
+                        x_comp.length() / 2, layer_thicknesses[layer] / 2);
+            string seg_nam = c_nam;
+            if (build_sensor_stack)
+              seg_nam += "_" + layer_names[layer];
+            seg_nam += "." + _toString(i);
+            Volume seg_vol(seg_nam, seg_box, description.material(layer_materials[layer]));
 
-            VolPlane surf(seg_vol, type, inner_thickness, outer_thickness, u, v, n); //,o ) ;
-            volplane_surfaces[m_nam].push_back(surf);
+            if (x_pos && x_rot) {
+              Position c_pos(midX + x_pos.x(0), x_pos.y(0), midZ + x_pos.z(0));
+              RotationZYX c_rot(x_rot.z(0), phiP + x_rot.y(0), x_rot.x(0));
+              pv = m_vol.placeVolume(seg_vol, Transform3D(c_rot, c_pos));
+            } else if (x_rot) {
+              Position c_pos(midX, 0, midZ);
+              pv = m_vol.placeVolume(
+                  seg_vol,
+                  Transform3D(RotationZYX(x_rot.z(0), x_rot.y(0) + phiP, x_rot.x(0)), c_pos));
+            } else if (x_pos) {
+              RotationZYX c_rot(0, phiP, 0);
+              Position c_pos(midX + x_pos.x(0), x_pos.y(0), x_pos.z(0) + midZ);
+              pv = m_vol.placeVolume(seg_vol, Transform3D(c_rot, c_pos));
+            } else {
+              RotationZYX c_rot(0, phiP, 0);
+              Position c_pos(midX, 0, midZ);
+              pv = m_vol.placeVolume(seg_vol, Transform3D(c_rot, c_pos));
+            }
+            phiP += dphi;
+            seg_vol.setRegion(description, x_comp.regionStr());
+            seg_vol.setLimitSet(description, x_comp.limitsStr());
+            seg_vol.setVisAttributes(description, x_comp.visStr());
+            if (layer_sensitivities[layer]) {
+              pv.addPhysVolID("sensor", sensor_number++);
+              seg_vol.setSensitiveDetector(sens);
+              sensitives[m_nam].push_back(pv);
+              //        module_thicknesses[m_nam] = {x_comp.innerthickness(),x_comp.outerthickness()};
 
-            //--------------------------------------------
+              // -------- create a measurement plane for the tracking surface attched to the sensitive volume -----
+              Vector3D u(-1., 0., 0.);
+              Vector3D v(0., -1., 0.);
+              Vector3D n(0., 0., 1.);
+              //    Vector3D o( 0. , 0. , 0. ) ;
+
+              // compute the inner and outer thicknesses that need to be assigned to the tracking surface
+              // depending on wether the support is above or below the sensor
+              double inner_thickness =
+                  getAttrOrDefault<double>(x_comp, _Unicode(innerthickness), 0.5 * mm);
+              double outer_thickness =
+                  getAttrOrDefault<double>(x_comp, _Unicode(outerthickness), 0.5 * mm);
+              SurfaceType type(SurfaceType::Sensitive);
+
+              VolPlane surf(seg_vol, type, inner_thickness, outer_thickness, u, v, n); //,o ) ;
+              volplane_surfaces[m_nam].push_back(surf);
+
+              //--------------------------------------------
+            }
           }
         }
         // thickness of curved layer is height of curve

--- a/src/CurvedBarrelTracker_geo.cpp
+++ b/src/CurvedBarrelTracker_geo.cpp
@@ -68,6 +68,7 @@ static Ref_t create_CurvedBarrelTracker(Detector& description, xml_h e, Sensitiv
   double rsu_tile_rphi     = x_rsu_layout.attr<double>(_Unicode(tile_rphi));
   double rsu_tile_pitch_z  = x_rsu_layout.attr<double>(_Unicode(tile_pitch_z));
   double rsu_tile_z        = x_rsu_layout.attr<double>(_Unicode(tile_z));
+  string rsu_passive_vis   = x_rsu_layout.attr<string>(_Unicode(passive_vis));
   int rsu_tiles            = rsu_rows_rphi * rsu_halves_z * rsu_tiles_per_z_half;
 
   // The formulas below describe this specific EIC-LAS RSU. Four sensor-ID bits
@@ -176,9 +177,9 @@ static Ref_t create_CurvedBarrelTracker(Detector& description, xml_h e, Sensitiv
         throw runtime_error("Partial full-RSU material layer.");
       }
 
+      Material component_material = description.material(x_comp.materialStr());
       Tube component_solid(component_rmin, component_rmax, module_length / 2.0, 0, module_dphi);
-      Volume component_volume(component_name, component_solid,
-                              description.material(x_comp.materialStr()));
+      Volume component_volume(component_name, component_solid, component_material);
       component_volume.setRegion(description, x_comp.regionStr());
       component_volume.setLimitSet(description, x_comp.limitsStr());
 
@@ -191,13 +192,13 @@ static Ref_t create_CurvedBarrelTracker(Detector& description, xml_h e, Sensitiv
 
       // Pattern for several sensitive areas in one module:
       // 1. Place one nonsensitive mother volume for the complete material layer.
-      // 2. Place one daughter volume inside it for each sensitive area.
-      // 3. Mark only the daughters sensitive and give each a sensor ID and surface.
+      // 2. Partition it into visible passive daughters and sensitive tile daughters.
+      // 3. Mark only the tiles sensitive and give each a sensor ID and surface.
       //
       // A daughter replaces the mother's material in its own region. Using the
       // same material therefore keeps one continuous silicon layer, while the
-      // parts of the mother outside the daughters form the inactive gaps. The
-      // daughters must be fully contained and must not overlap one another.
+      // passive daughters make the backbone, readout, bias, and power gaps
+      // visible. All daughters must be fully contained and mutually disjoint.
       // Here, sensitive="true" in the XML selects this component for tiling; it
       // does not make the full 14 um mother sensitive.
       component_volume.setVisAttributes(description.invisible());
@@ -205,7 +206,42 @@ static Ref_t create_CurvedBarrelTracker(Detector& description, xml_h e, Sensitiv
 
       double inner_thickness = thickness_so_far + component_thickness / 2.0;
       double outer_thickness = total_thickness - inner_thickness;
+      int passive_count      = 0;
       int sensor_id          = 1;
+
+      auto place_passive_piece = [&](const string& piece_name, double rphi_start, double rphi_width,
+                                     double z_start, double z_length) {
+        double phi_start = rphi_start / reference_radius;
+        double phi_end   = (rphi_start + rphi_width) / reference_radius;
+        Tube piece_solid(component_rmin, component_rmax, z_length / 2.0, phi_start, phi_end);
+        Volume piece_volume(module_name + "_" + piece_name, piece_solid, component_material);
+        piece_volume.setRegion(description, x_comp.regionStr());
+        piece_volume.setLimitSet(description, x_comp.limitsStr());
+        piece_volume.setVisAttributes(description, rsu_passive_vis);
+        component_volume.placeVolume(piece_volume, Position(0, 0, z_start + z_length / 2.0));
+        ++passive_count;
+      };
+
+      // Each z half starts with a full-width backbone. Outside the backbone,
+      // four passive r-phi bands surround the two tile rows.
+      for (int half_z_id = 0; half_z_id < rsu_halves_z; ++half_z_id) {
+        double half_z_start       = -half_z + half_z_id * half_z;
+        double after_backbone_z   = half_z_start + rsu_backbone_z;
+        double after_backbone_len = half_z - rsu_backbone_z;
+        string half_suffix        = _toString(half_z_id, "_h%d");
+
+        place_passive_piece("backbone" + half_suffix, 0, module_width, half_z_start,
+                            rsu_backbone_z);
+        place_passive_piece("readout_low" + half_suffix, 0, rsu_readout_rphi, after_backbone_z,
+                            after_backbone_len);
+        place_passive_piece("bias_low" + half_suffix, rsu_readout_rphi + rsu_tile_rphi,
+                            rsu_biasing_rphi, after_backbone_z, after_backbone_len);
+        place_passive_piece("bias_high" + half_suffix, half_rphi, rsu_biasing_rphi,
+                            after_backbone_z, after_backbone_len);
+        place_passive_piece("readout_high" + half_suffix,
+                            half_rphi + rsu_biasing_rphi + rsu_tile_rphi, rsu_readout_rphi,
+                            after_backbone_z, after_backbone_len);
+      }
 
       for (int row_id = 0; row_id < rsu_rows_rphi; ++row_id) {
         // From low to high r-phi: readout, tiles, two central bias bands,
@@ -221,10 +257,15 @@ static Ref_t create_CurvedBarrelTracker(Detector& description, xml_h e, Sensitiv
             double tile_phi_start = tile_rphi_start / reference_radius;
             double tile_phi_end   = (tile_rphi_start + rsu_tile_rphi) / reference_radius;
             string tile_name      = module_name + _toString(sensor_id, "_tile%02d");
+            string power_name = "power" + _toString(row_id, "_r%d") + _toString(half_z_id, "_h%d") +
+                                _toString(tile_id, "_t%d");
+
+            place_passive_piece(power_name, tile_rphi_start, rsu_tile_rphi,
+                                tile_z_start + rsu_tile_z, rsu_power_z);
 
             Tube tile_solid(component_rmin, component_rmax, rsu_tile_z / 2.0, tile_phi_start,
                             tile_phi_end);
-            Volume tile_volume(tile_name, tile_solid, description.material(x_comp.materialStr()));
+            Volume tile_volume(tile_name, tile_solid, component_material);
             tile_volume.setRegion(description, x_comp.regionStr());
             tile_volume.setLimitSet(description, x_comp.limitsStr());
             tile_volume.setVisAttributes(description, x_comp.visStr());
@@ -243,6 +284,11 @@ static Ref_t create_CurvedBarrelTracker(Detector& description, xml_h e, Sensitiv
                                             v, n);
           }
         }
+      }
+
+      int expected_passive_count = rsu_halves_z * (5 + rsu_rows_rphi * rsu_tiles_per_z_half);
+      if (passive_count != expected_passive_count) {
+        throw runtime_error("Incomplete passive vertex-barrel RSU partition.");
       }
 
       thickness_so_far += component_thickness;

--- a/src/CurvedBarrelTracker_geo.cpp
+++ b/src/CurvedBarrelTracker_geo.cpp
@@ -1,17 +1,11 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 - 2025 Whitney Armstrong, Jonathan Witte, Shujie Li
 
-/** Curved Barrel tracker
- * - Derived from "BarrelTrackerWithFrame_geo.cpp".
+/** Curved silicon vertex barrel.
  *
- * - Designed to process "vertex_barrel.xml":
- *       - When the upper and lower modules are provided, builds the four-section
- *         EIC-LAS RSU with three sensitive tiles and inactive gaps per section
- *
- *
- * \code
- * \endcode
- *
+ * One module is one physical RSU. Each RSU contains a full inactive-silicon
+ * layer, a full 14 um silicon layer, and a full copper layer. Twelve silicon
+ * daughters inside the 14 um layer mark the regions that record hits.
  *
  * @author Whitney Armstrong, Jonathan Witte, Shujie Li
  */
@@ -21,338 +15,334 @@
 #include "DD4hep/Shapes.h"
 #include "DDRec/DetectorData.h"
 #include "DDRec/Surface.h"
-#include "XML/Layering.h"
 #include "XML/Utilities.h"
-#include <algorithm>
-#include <array>
-#include <cmath>
 #include "DD4hepDetectorHelper.h"
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::rec;
 using namespace dd4hep::detail;
 
-static Ref_t create_CurvedBarrelTracker(Detector& description, xml_h e, SensitiveDetector sens) {
+namespace {
 
+using Placements = vector<PlacedVolume>;
+
+// A prototype is built once per layer radius and reused at every phi-z position.
+struct ModulePrototype {
+  Volume volume;
+  PlacedVolume active_layer;
+  Placements tiles;
+  vector<VolPlane> surfaces;
+  double length{0.0};
+};
+
+} // namespace
+
+static Ref_t create_CurvedBarrelTracker(Detector& description, xml_h e, SensitiveDetector sens) {
   xml_det_t x_det = e;
   Material air    = description.air();
   int det_id      = x_det.id();
   string det_name = x_det.nameStr();
   DetElement sdet(det_name, det_id);
 
-  typedef vector<PlacedVolume> Placements;
-  map<string, Volume> volumes;
-  map<string, Placements> sensitives;
-  map<string, std::vector<VolPlane>> volplane_surfaces;
-  map<string, std::vector<double>> module_length;
-
-  PlacedVolume pv;
-
-  // Set detector type flag
   dd4hep::xml::setDetectorTypeFlag(x_det, sdet);
-  auto& params = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(sdet);
+  auto& params = DD4hepDetectorHelper::ensureExtension<VariantParameters>(sdet);
 
-  // The XML describes one quarter-RSU section. Upper/lower module prototypes mirror
-  // the r-phi ordering, while consecutive z placements provide the other two sections.
-  xml_comp_t x_rsu_layout   = x_det.child(_Unicode(rsu_layout));
-  int rsu_tiles_per_section = x_rsu_layout.attr<int>(_Unicode(tiles_per_section));
-  double rsu_backbone_z     = x_rsu_layout.attr<double>(_Unicode(backbone_z));
-  double rsu_biasing_rphi   = x_rsu_layout.attr<double>(_Unicode(biasing_rphi));
-  double rsu_readout_rphi   = x_rsu_layout.attr<double>(_Unicode(readout_rphi));
-  double rsu_power_z        = x_rsu_layout.attr<double>(_Unicode(power_z));
-  double rsu_tile_rphi      = x_rsu_layout.attr<double>(_Unicode(tile_rphi));
-  double rsu_tile_pitch_z   = x_rsu_layout.attr<double>(_Unicode(tile_pitch_z));
-  double rsu_tile_z         = x_rsu_layout.attr<double>(_Unicode(tile_z));
+  // These are measured gaps in the full 2-by-6 tile layout.
+  xml_comp_t x_rsu_layout  = x_det.child(_Unicode(rsu_layout));
+  int rsu_rows_rphi        = x_rsu_layout.attr<int>(_Unicode(rows_rphi));
+  int rsu_halves_z         = x_rsu_layout.attr<int>(_Unicode(halves_z));
+  int rsu_tiles_per_z_half = x_rsu_layout.attr<int>(_Unicode(tiles_per_z_half));
+  double rsu_backbone_z    = x_rsu_layout.attr<double>(_Unicode(backbone_z));
+  double rsu_biasing_rphi  = x_rsu_layout.attr<double>(_Unicode(biasing_rphi));
+  double rsu_readout_rphi  = x_rsu_layout.attr<double>(_Unicode(readout_rphi));
+  double rsu_power_z       = x_rsu_layout.attr<double>(_Unicode(power_z));
+  double rsu_tile_rphi     = x_rsu_layout.attr<double>(_Unicode(tile_rphi));
+  double rsu_tile_pitch_z  = x_rsu_layout.attr<double>(_Unicode(tile_pitch_z));
+  double rsu_tile_z        = x_rsu_layout.attr<double>(_Unicode(tile_z));
+  int rsu_tiles            = rsu_rows_rphi * rsu_halves_z * rsu_tiles_per_z_half;
 
-  // VertexBarrelHits allocates two bits to the sensor field, with zero reserved.
-  if (rsu_tiles_per_section < 1 || rsu_tiles_per_section > 3 || rsu_backbone_z <= 0 ||
-      rsu_biasing_rphi <= 0 || rsu_readout_rphi <= 0 || rsu_power_z <= 0 || rsu_tile_rphi <= 0 ||
-      rsu_tile_pitch_z <= 0 || rsu_tile_z <= 0) {
-    printout(ERROR, "CurvedBarrelTracker", "Invalid RSU layout dimensions or tile count.");
+  // The formulas below describe this specific EIC-LAS RSU. Four sensor-ID bits
+  // allow values 1 through 12; zero is left unused.
+  if (rsu_rows_rphi != 2 || rsu_halves_z != 2 || rsu_tiles_per_z_half != 3 || rsu_tiles != 12 ||
+      rsu_backbone_z <= 0 || rsu_biasing_rphi <= 0 || rsu_readout_rphi <= 0 || rsu_power_z <= 0 ||
+      rsu_tile_rphi <= 0 || rsu_tile_pitch_z <= 0 || rsu_tile_z <= 0) {
+    printout(ERROR, "CurvedBarrelTracker", "Invalid RSU tile count or gap dimensions.");
     throw runtime_error("Invalid RSU layout in vertex_barrel.xml.");
   }
 
-  // Add the volume boundary material if configured
   for (xml_coll_t bmat(x_det, _Unicode(boundary_material)); bmat; ++bmat) {
-    xml_comp_t x_boundary_material = bmat;
-    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(x_boundary_material, params,
-                                                    "boundary_material");
+    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(xml_comp_t(bmat), params, "boundary_material");
   }
 
   Assembly assembly(det_name);
-
+  assembly.setVisAttributes(description.invisible());
   sens.setType("tracker");
 
-  // loop over the modules
+  map<string, ModulePrototype> modules;
+
+  // Build one complete RSU prototype for each layer radius.
   for (xml_coll_t mi(x_det, _U(module)); mi; ++mi) {
-    xml_comp_t x_mod = mi;
-    string m_nam     = x_mod.nameStr();
-    double m_rmin    = x_mod.rmin();
-    double m_length  = x_mod.length();
-    double m_width   = x_mod.width();
-    module_length[m_nam].push_back(m_length);
+    xml_comp_t x_mod     = mi;
+    string module_name   = x_mod.nameStr();
+    double module_rmin   = x_mod.rmin();
+    double module_width  = x_mod.width();
+    double module_length = x_mod.length();
 
-    if (volumes.find(m_nam) != volumes.end()) {
+    if (modules.count(module_name) != 0) {
+      printout(ERROR, "CurvedBarrelTracker", "Module '%s' is defined more than once.",
+               module_name.c_str());
+      throw runtime_error("Duplicate vertex-barrel module name.");
+    }
+
+    // Find the active layer before building any solids. Its middle radius is
+    // the common angular reference for all three material layers.
+    double total_thickness  = 0.0;
+    double active_offset    = 0.0;
+    double active_thickness = 0.0;
+    int active_components   = 0;
+    int component_count     = 0;
+    for (xml_coll_t ci(x_mod, _U(module_component)); ci; ++ci) {
+      xml_comp_t x_comp = ci;
+      if (x_comp.thickness() <= 0) {
+        throw runtime_error("Vertex-barrel component thickness must be positive.");
+      }
+      if (x_comp.isSensitive()) {
+        active_offset    = total_thickness;
+        active_thickness = x_comp.thickness();
+        ++active_components;
+      }
+      total_thickness += x_comp.thickness();
+      ++component_count;
+    }
+
+    if (component_count != 3 || active_components != 1 || module_width <= 0 || module_length <= 0 ||
+        total_thickness <= 0) {
       printout(ERROR, "CurvedBarrelTracker",
-               string((string("Module with named ") + m_nam + string(" already exists."))).c_str());
-      throw runtime_error("Logics error in building modules.");
+               "Module '%s' needs three material layers and one active layer.",
+               module_name.c_str());
+      throw runtime_error("Invalid vertex-barrel material stack.");
     }
-    int ncomponents        = 0;
-    int sensor_number      = 1;
-    double total_thickness = 0;
 
-    // Compute module total thickness from components
-    xml_coll_t ci(x_mod, _U(module_component));
-    for (ci.reset(), total_thickness = 0.0; ci; ++ci) {
-      total_thickness += xml_comp_t(ci).thickness();
+    double reference_radius = module_rmin + active_offset + active_thickness / 2.0;
+    double module_dphi      = module_width / reference_radius;
+    double half_rphi        = module_width / 2.0;
+    double half_z           = module_length / 2.0;
+    double length_tolerance = 1.0e-12 * max(module_width, module_length);
+
+    // These equations check that the tile rows and columns fit exactly inside
+    // the rectangular RSU. The small differences are the inactive gaps.
+    if (abs(2.0 * (rsu_readout_rphi + rsu_tile_rphi + rsu_biasing_rphi) - module_width) >
+            length_tolerance ||
+        abs(2.0 * (rsu_backbone_z + rsu_tiles_per_z_half * rsu_tile_pitch_z) - module_length) >
+            length_tolerance ||
+        abs(rsu_tile_z + rsu_power_z - rsu_tile_pitch_z) > length_tolerance) {
+      printout(ERROR, "CurvedBarrelTracker",
+               "Module '%s' RSU dimensions do not add up to one rectangle.", module_name.c_str());
+      throw runtime_error("Invalid full-RSU dimensions.");
     }
-    // the module assembly volume
-    Assembly m_vol(m_nam);
-    volumes[m_nam] = m_vol;
-    m_vol.setVisAttributes(description.visAttributes(x_mod.visStr()));
+
+    Tube module_solid(module_rmin, module_rmin + total_thickness, module_length / 2.0, 0,
+                      module_dphi);
+    Volume module_volume(module_name, module_solid, air);
+    module_volume.setVisAttributes(description.invisible());
+
+    ModulePrototype prototype;
+    prototype.volume = module_volume;
+    prototype.length = module_length;
 
     double thickness_so_far = 0.0;
-    for (xml_coll_t mci(x_mod, _U(module_component)); mci; ++mci, ++ncomponents) {
-      xml_comp_t x_comp  = mci;
-      const string c_nam = x_comp.nameStr(); // _toString(ncomponents, "component%d");
-      const string c_mat = x_comp.materialStr();
-      double c_thickness = x_comp.thickness();
-      double c_width     = getAttrOrDefault(x_comp, _U(width), m_width);
-      double c_length    = getAttrOrDefault(x_comp, _U(length), m_length);
-      double c_rmin      = m_rmin + thickness_so_far;
-      double c_dphi      = c_width / c_rmin;
+    for (xml_coll_t ci(x_mod, _U(module_component)); ci; ++ci) {
+      xml_comp_t x_comp          = ci;
+      string component_name      = module_name + "_" + x_comp.nameStr();
+      double component_thickness = x_comp.thickness();
+      double component_width     = getAttrOrDefault(x_comp, _U(width), module_width);
+      double component_length    = getAttrOrDefault(x_comp, _U(length), module_length);
+      double component_rmin      = module_rmin + thickness_so_far;
+      double component_rmax      = component_rmin + component_thickness;
 
-      auto attach_sensitive = [&](Volume& component_volume, PlacedVolume& component_pv) {
-        component_pv.addPhysVolID("sensor", sensor_number++);
-        component_volume.setSensitiveDetector(sens);
-        sensitives[m_nam].push_back(component_pv);
-        // -------- create a measurement plane for the tracking surface attched to the sensitive volume -----
-        Vector3D u(-1., 0., 0.);
-        Vector3D v(0., -1., 0.);
-        Vector3D n(0., 0., 1.);
-        // compute the inner and outer thicknesses that need to be assigned to the tracking surface
-        // depending on wether the support is above or below the sensor
-        double inner_thickness = thickness_so_far + c_thickness / 2.0;
-        double outer_thickness = total_thickness - inner_thickness;
+      if (abs(component_width - module_width) > length_tolerance ||
+          abs(component_length - module_length) > length_tolerance) {
+        printout(ERROR, "CurvedBarrelTracker",
+                 "Module '%s' material layers must cover the complete RSU.", module_name.c_str());
+        throw runtime_error("Partial full-RSU material layer.");
+      }
 
-        SurfaceType type(SurfaceType::Sensitive);
-        VolPlane surf(component_volume, type, inner_thickness, outer_thickness, u, v, n);
-        volplane_surfaces[m_nam].push_back(surf);
-      };
+      Tube component_solid(component_rmin, component_rmax, module_length / 2.0, 0, module_dphi);
+      Volume component_volume(component_name, component_solid,
+                              description.material(x_comp.materialStr()));
+      component_volume.setRegion(description, x_comp.regionStr());
+      component_volume.setLimitSet(description, x_comp.limitsStr());
 
-      if (c_nam == "RSU") {
-        const string c_type = x_comp.typeStr();
-        if (c_type != "upper" && c_type != "lower") {
-          printout(ERROR, "CurvedBarrelTracker",
-                   string((string("Module ") + m_nam + string(": invalid RSU component type [") +
-                           c_type + string("], should be upper or lower")))
-                       .c_str());
-          throw runtime_error("Logics error in building modules.");
-        }
-
-        const double partition_area =
-            c_width * rsu_backbone_z +
-            (rsu_biasing_rphi + rsu_readout_rphi) * (c_length - rsu_backbone_z) +
-            rsu_tile_rphi * rsu_tiles_per_section * (rsu_tile_z + rsu_power_z);
-        const double length_tolerance = 1.0e-12 * std::max(c_width, c_length);
-        const double area_tolerance   = 1.0e-12 * c_width * c_length;
-        if (std::abs(rsu_biasing_rphi + rsu_tile_rphi + rsu_readout_rphi - c_width) >
-                length_tolerance ||
-            std::abs(rsu_backbone_z + rsu_tiles_per_section * rsu_tile_pitch_z - c_length) >
-                length_tolerance ||
-            std::abs(rsu_tile_z + rsu_power_z - rsu_tile_pitch_z) > length_tolerance ||
-            std::abs(partition_area - c_width * c_length) > area_tolerance) {
-          printout(ERROR, "CurvedBarrelTracker",
-                   string((string("Module ") + m_nam +
-                           string(": RSU pieces do not form a positive rectangular section.")))
-                       .c_str());
-          throw runtime_error("Invalid RSU section geometry.");
-        }
-
-        const string component_base = m_nam + _toString(ncomponents, "_component%d_") + c_type;
-        auto place_rsu_piece = [&](const string& piece_name, double rphi_start, double rphi_width,
-                                   double z_start, double z_width, const string& vis,
-                                   bool sensitive) {
-          Tube piece_solid(c_rmin, c_rmin + c_thickness, z_width / 2.0, rphi_start / c_rmin,
-                           (rphi_start + rphi_width) / c_rmin);
-          Volume piece_volume(component_base + "_" + piece_name, piece_solid,
-                              description.material(c_mat));
-          piece_volume.setRegion(description, x_comp.regionStr());
-          piece_volume.setLimitSet(description, x_comp.limitsStr());
-          piece_volume.setVisAttributes(description, vis);
-          PlacedVolume piece_pv = m_vol.placeVolume(
-              piece_volume, Position(0, 0, -c_length / 2.0 + z_start + z_width / 2.0));
-          if (sensitive) {
-            attach_sensitive(piece_volume, piece_pv);
-          }
-        };
-
-        if (x_comp.isSensitive()) {
-          // The backbone owns the two passive-band corner areas, so all pieces are disjoint.
-          place_rsu_piece("backbone", 0, c_width, 0, rsu_backbone_z, "SVTReadoutVis", false);
-
-          const double first_passive_rphi = c_type == "upper" ? rsu_biasing_rphi : rsu_readout_rphi;
-          const double second_passive_rphi =
-              c_type == "upper" ? rsu_readout_rphi : rsu_biasing_rphi;
-          const string first_passive_name  = c_type == "upper" ? "biasing" : "readout";
-          const string second_passive_name = c_type == "upper" ? "readout" : "biasing";
-          const double z_after_backbone    = c_length - rsu_backbone_z;
-          place_rsu_piece(first_passive_name, 0, first_passive_rphi, rsu_backbone_z,
-                          z_after_backbone, "SVTReadoutVis", false);
-          place_rsu_piece(second_passive_name, first_passive_rphi + rsu_tile_rphi,
-                          second_passive_rphi, rsu_backbone_z, z_after_backbone, "SVTReadoutVis",
-                          false);
-
-          for (int tile = 0; tile < rsu_tiles_per_section; ++tile) {
-            const double tile_z_start = rsu_backbone_z + tile * rsu_tile_pitch_z;
-            place_rsu_piece(_toString(tile + 1, "tile%d"), first_passive_rphi, rsu_tile_rphi,
-                            tile_z_start, rsu_tile_z, x_comp.visStr(), true);
-            place_rsu_piece(_toString(tile + 1, "power_gap%d"), first_passive_rphi, rsu_tile_rphi,
-                            tile_z_start + rsu_tile_z, rsu_power_z, "SVTReadoutVis", false);
-          }
-        } else {
-          // Inactive silicon and copper remain continuous across the complete section.
-          place_rsu_piece("full", 0, c_width, 0, c_length, x_comp.visStr(), false);
-        }
-
-        thickness_so_far += c_thickness;
+      if (!x_comp.isSensitive()) {
+        component_volume.setVisAttributes(description, x_comp.visStr());
+        module_volume.placeVolume(component_volume);
+        thickness_so_far += component_thickness;
         continue;
       }
 
-      // Regular components retain the original single-volume behavior.
-      Tube c_tube(c_rmin, c_rmin + c_thickness, c_length / 2, 0, c_dphi);
-      Volume c_vol(c_nam, c_tube, description.material(c_mat));
-      pv = m_vol.placeVolume(c_vol, Position(0, 0, 0));
-      c_vol.setRegion(description, x_comp.regionStr());
-      c_vol.setLimitSet(description, x_comp.limitsStr());
-      c_vol.setVisAttributes(description, x_comp.visStr());
-      if (x_comp.isSensitive()) {
-        attach_sensitive(c_vol, pv);
+      // Pattern for several sensitive areas in one module:
+      // 1. Place one nonsensitive mother volume for the complete material layer.
+      // 2. Place one daughter volume inside it for each sensitive area.
+      // 3. Mark only the daughters sensitive and give each a sensor ID and surface.
+      //
+      // A daughter replaces the mother's material in its own region. Using the
+      // same material therefore keeps one continuous silicon layer, while the
+      // parts of the mother outside the daughters form the inactive gaps. The
+      // daughters must be fully contained and must not overlap one another.
+      // Here, sensitive="true" in the XML selects this component for tiling; it
+      // does not make the full 14 um mother sensitive.
+      component_volume.setVisAttributes(description.invisible());
+      prototype.active_layer = module_volume.placeVolume(component_volume);
+
+      double inner_thickness = thickness_so_far + component_thickness / 2.0;
+      double outer_thickness = total_thickness - inner_thickness;
+      int sensor_id          = 1;
+
+      for (int row_id = 0; row_id < rsu_rows_rphi; ++row_id) {
+        // From low to high r-phi: readout, tiles, two central bias bands,
+        // tiles, readout. This is symmetric about the RSU center.
+        double tile_rphi_start = row_id == 0 ? rsu_readout_rphi : half_rphi + rsu_biasing_rphi;
+
+        for (int half_z_id = 0; half_z_id < rsu_halves_z; ++half_z_id) {
+          double half_z_start = -half_z + half_z_id * half_z;
+
+          for (int tile_id = 0; tile_id < rsu_tiles_per_z_half; ++tile_id, ++sensor_id) {
+            double tile_z_start   = half_z_start + rsu_backbone_z + tile_id * rsu_tile_pitch_z;
+            double tile_z_center  = tile_z_start + rsu_tile_z / 2.0;
+            double tile_phi_start = tile_rphi_start / reference_radius;
+            double tile_phi_end   = (tile_rphi_start + rsu_tile_rphi) / reference_radius;
+            string tile_name      = module_name + _toString(sensor_id, "_tile%02d");
+
+            Tube tile_solid(component_rmin, component_rmax, rsu_tile_z / 2.0, tile_phi_start,
+                            tile_phi_end);
+            Volume tile_volume(tile_name, tile_solid, description.material(x_comp.materialStr()));
+            tile_volume.setRegion(description, x_comp.regionStr());
+            tile_volume.setLimitSet(description, x_comp.limitsStr());
+            tile_volume.setVisAttributes(description, x_comp.visStr());
+            tile_volume.setSensitiveDetector(sens);
+
+            PlacedVolume tile_pv =
+                component_volume.placeVolume(tile_volume, Position(0, 0, tile_z_center));
+            tile_pv.addPhysVolID("sensor", sensor_id);
+            prototype.tiles.push_back(tile_pv);
+
+            Vector3D u(-1., 0., 0.);
+            Vector3D v(0., -1., 0.);
+            Vector3D n(0., 0., 1.);
+            SurfaceType type(SurfaceType::Sensitive);
+            prototype.surfaces.emplace_back(tile_volume, type, inner_thickness, outer_thickness, u,
+                                            v, n);
+          }
+        }
       }
-      thickness_so_far += c_thickness;
+
+      thickness_so_far += component_thickness;
     }
+
+    if (!prototype.active_layer.isValid() || prototype.tiles.size() != 12 ||
+        prototype.surfaces.size() != prototype.tiles.size()) {
+      printout(ERROR, "CurvedBarrelTracker", "Module '%s' did not produce twelve tiles.",
+               module_name.c_str());
+      throw runtime_error("Incomplete vertex-barrel RSU prototype.");
+    }
+
+    modules.emplace(module_name, std::move(prototype));
   }
 
-  // now build the layers by alternating upper and lower modules.
-  // each layer has a gap b/w the upper and lower half (see phi0 and phi1)
+  // Place complete RSUs in each layer. The larger phi clearance appears only
+  // at the two half-shell seams, never inside a physical RSU.
   for (xml_coll_t li(x_det, _U(layer)); li; ++li) {
     xml_comp_t x_layer  = li;
     xml_comp_t x_barrel = x_layer.child(_U(barrel_envelope));
     xml_comp_t x_layout = x_layer.child(_U(rphi_layout));
-    xml_comp_t z_layout = x_layer.child(_U(z_layout)); // Get the <z_layout> element.
-    int lay_id          = x_layer.id();
-    string m_nam        = x_layer.moduleStr();
-    string lay_nam      = det_name + _toString(x_layer.id(), "_layer%d");
-    Tube lay_tub(x_barrel.inner_r(), x_barrel.outer_r(), x_barrel.z_length() / 2.0);
+    xml_comp_t z_layout = x_layer.child(_U(z_layout));
+    int layer_id        = x_layer.id();
+    string module_name  = x_layer.moduleStr();
+    string layer_name   = det_name + _toString(layer_id, "_layer%d");
 
-    Volume lay_vol(lay_nam, lay_tub, air); // Create the layer envelope volume.
-    Position lay_pos(0, 0, getAttrOrDefault(x_barrel, _U(z0), 0.));
-    lay_vol.setVisAttributes(description.visAttributes(x_layer.visStr()));
-
-    int l_nphi      = x_layout.nphi(); // Number of modules in phi.
-    double phi0     = x_layout.phi0(); // Starting phi of first module.
-    int nphi[2]     = {int((l_nphi + 1) / 2),
-                       int(l_nphi / 2)}; // number of modules in uppper and lower modules.
-    double phi_incr = (M_PI * 2 - phi0 * 2) / l_nphi; // Phi increment for one module.
-    double z0       = z_layout.z0();                  // Z position of first module in phi.
-    double nz       = z_layout.nz();                  // Number of modules to place in z.
-
-    Volume module_env[2];
-    Placements sensVols[2];
-    string m_nams[2] = {m_nam + "_upper", m_nam + "_lower"};
-    // if both upper and lower modules are provided (for RSU tiles)
-    if ((volumes.find(m_nams[0]) != volumes.end()) && (volumes.find(m_nams[1]) != volumes.end())) {
-      if (nphi[0] != nphi[1]) {
-        printout(ERROR, "CurvedBarrelTracker",
-                 string((string("Layer ") + lay_nam +
-                         string(": nphi must be even number to allow upper and lower modules"))
-                            .c_str()));
-        throw runtime_error("Logics error in building modules.");
-      }
-      module_env[0] = volumes[m_nams[0]];
-      module_env[1] = volumes[m_nams[1]];
-      sensVols[0]   = sensitives[m_nams[0]];
-      sensVols[1]   = sensitives[m_nams[1]];
+    auto module_iter = modules.find(module_name);
+    if (module_iter == modules.end()) {
+      printout(ERROR, "CurvedBarrelTracker", "Layer '%s' uses unknown module '%s'.",
+               layer_name.c_str(), module_name.c_str());
+      throw runtime_error("Unknown vertex-barrel module.");
     }
-    // for other regular modules
-    else if (volumes.find(m_nam) != volumes.end()) {
-      module_env[0] = volumes[m_nam];
-      module_env[1] = volumes[m_nam];
-      sensVols[0]   = sensitives[m_nam];
-      sensVols[1]   = sensitives[m_nam];
-      m_nams[0]     = m_nam;
-      m_nams[1]     = m_nam;
-    }
-    DetElement lay_elt(sdet, lay_nam, lay_id);
+    ModulePrototype& prototype = module_iter->second;
 
-    // the local coordinate systems of modules in dd4hep and acts differ
-    // see http://acts.web.cern.ch/ACTS/latest/doc/group__DD4hepPlugins.html
-    auto& layerParams =
-        DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(lay_elt);
+    Tube layer_solid(x_barrel.inner_r(), x_barrel.outer_r(), x_barrel.z_length() / 2.0);
+    Volume layer_volume(layer_name, layer_solid, air);
+    layer_volume.setVisAttributes(description.visAttributes(x_layer.visStr()));
+    DetElement layer_element(sdet, layer_name, layer_id);
 
+    auto& layer_params = DD4hepDetectorHelper::ensureExtension<VariantParameters>(layer_element);
     for (xml_coll_t lmat(x_layer, _Unicode(layer_material)); lmat; ++lmat) {
-      xml_comp_t x_layer_material = lmat;
-      DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(x_layer_material, layerParams,
+      DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(xml_comp_t(lmat), layer_params,
                                                       "layer_material");
     }
 
-    // Z increment for module placement along Z axis.
-    // Adjust for z0 at center of module rather than
-    // the end of cylindrical envelope.
-    // double z_incr = nz > 1 ? (2.0 * abs(z0)) / (nz - 1) : 0.0;
-    // Starting z for module placement along Z axis.
-    int module = 1;
-    // Loop over the number of modules in phi.
-    for (int kk = 0; kk < 2; kk++) {
-      int iphi      = nphi[kk];
-      double z_incr = module_length[m_nams[kk]][0];
-      for (int ii = 0; ii < iphi; ii++) {
-        double dphi = phi0;
-        if (ii > (iphi / 2) - 1)
-          dphi = 2 * phi0;
-        // Loop over the number of modules in z.
-        double module_z = z0;
-        for (int j = 0; j < nz; j++, module_z += z_incr) {
-          string module_name = _toString(module, "module%d");
-          DetElement mod_elt(lay_elt, module_name, module);
-          Transform3D tr(
-              RotationZYX(dphi + phi_incr * kk + phi_incr * ii * 2, 0, 0),
-              Position(0, 0, module_z)); // altering upper and lower module to fill every other row
-          pv = lay_vol.placeVolume(module_env[kk], tr);
-          pv.addPhysVolID("module", module);
-          mod_elt.setPlacement(pv);
-          for (size_t ic = 0; ic < sensVols[kk].size(); ++ic) {
-            PlacedVolume sens_pv = sensVols[kk][ic];
-            DetElement comp_de(mod_elt, std::string("de_") + sens_pv.volume().name(), module);
-            comp_de.setPlacement(sens_pv);
-            auto& comp_de_params =
-                DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(comp_de);
-            comp_de_params.set<string>("axis_definitions", "XYZ");
-            // note from Wouter: Region allows setting specific physics in regions of space. Limits similar but with production limits. Currently unused in simulations. But we'd sort of tried to make sure we don't prevent ourselves from using it entirely.
-            // comp_de.setAttributes(description, sens_pv.volume(), x_layer.regionStr(), x_layer.limitsStr(),
-            //                       xml_det_t(xmleles[m_nam]).visStr());
-            //
-            volSurfaceList(comp_de)->push_back(volplane_surfaces[m_nams[kk]][ic]);
-          }
+    int nphi        = x_layout.nphi();
+    int nz          = z_layout.nz();
+    double phi0     = x_layout.phi0();
+    double phi_step = (2.0 * M_PI - 2.0 * phi0) / nphi;
+    double first_z  = z_layout.z0();
+    if (nphi <= 0 || nphi % 2 != 0 || nz <= 0) {
+      throw runtime_error("Vertex-barrel nphi must be positive and even; nz must be positive.");
+    }
 
-          /// Increase counters etc.
-          module++;
+    int module_id = 1;
+    for (int iphi = 0; iphi < nphi; ++iphi) {
+      double seam_offset = iphi < nphi / 2 ? phi0 : 2.0 * phi0;
+      double module_phi  = seam_offset + iphi * phi_step;
+      double module_z    = first_z;
+
+      for (int iz = 0; iz < nz; ++iz, module_z += prototype.length, ++module_id) {
+        string placed_name = _toString(module_id, "module%d");
+        DetElement module_element(layer_element, placed_name, module_id);
+        Transform3D transform(RotationZYX(module_phi, 0, 0), Position(0, 0, module_z));
+        PlacedVolume module_pv = layer_volume.placeVolume(prototype.volume, transform);
+        module_pv.addPhysVolID("module", module_id);
+        module_element.setPlacement(module_pv);
+
+        // The DetElement tree must match the physical-volume tree:
+        // module -> active mother -> sensitive tile. This lets DD4hep combine
+        // the layer, module, and sensor IDs, and gives ACTS the tile's correct
+        // world transform. Attach each VolPlane to its tile DetElement, not to
+        // the common active mother.
+        DetElement active_element(module_element, "active_si", 0);
+        active_element.setPlacement(prototype.active_layer);
+        for (size_t tile_index = 0; tile_index < prototype.tiles.size(); ++tile_index) {
+          int sensor_id        = static_cast<int>(tile_index) + 1;
+          PlacedVolume tile_pv = prototype.tiles[tile_index];
+          DetElement tile_element(active_element, tile_pv.volume().name(), sensor_id);
+          tile_element.setPlacement(tile_pv);
+          auto& tile_params =
+              DD4hepDetectorHelper::ensureExtension<VariantParameters>(tile_element);
+          tile_params.set<string>("axis_definitions", "XYZ");
+          volSurfaceList(tile_element)->push_back(prototype.surfaces[tile_index]);
         }
       }
     }
-    // Create the PhysicalVolume for the layer.
-    pv = assembly.placeVolume(lay_vol, lay_pos); // Place layer in mother
-    pv.addPhysVolID("layer", lay_id);            // Set the layer ID.
-    lay_elt.setAttributes(description, lay_vol, x_layer.regionStr(), x_layer.limitsStr(),
-                          x_layer.visStr());
-    lay_elt.setPlacement(pv);
+
+    Position layer_position(0, 0, getAttrOrDefault(x_barrel, _U(z0), 0.));
+    PlacedVolume layer_pv = assembly.placeVolume(layer_volume, layer_position);
+    layer_pv.addPhysVolID("layer", layer_id);
+    layer_element.setAttributes(description, layer_volume, x_layer.regionStr(), x_layer.limitsStr(),
+                                x_layer.visStr());
+    layer_element.setPlacement(layer_pv);
   }
+
   sdet.setAttributes(description, assembly, x_det.regionStr(), x_det.limitsStr(), x_det.visStr());
-  assembly.setVisAttributes(description.invisible());
-  pv = description.pickMotherVolume(sdet).placeVolume(assembly);
-  pv.addPhysVolID("system", det_id); // Set the subdetector system ID.
-  sdet.setPlacement(pv);
+  PlacedVolume detector_pv = description.pickMotherVolume(sdet).placeVolume(assembly);
+  detector_pv.addPhysVolID("system", det_id);
+  sdet.setPlacement(detector_pv);
   return sdet;
 }
 

--- a/src/CurvedBarrelTracker_geo.cpp
+++ b/src/CurvedBarrelTracker_geo.cpp
@@ -5,8 +5,8 @@
  * - Derived from "BarrelTrackerWithFrame_geo.cpp".
  *
  * - Designed to process "vertex_barrel.xml":
- *       - When the upper and lower modules are provided, will use the
- *         Build-in EIC-LAS RSU structure with four sections and inactive areas
+ *       - When the upper and lower modules are provided, builds the four-section
+ *         EIC-LAS RSU with three sensitive tiles and inactive gaps per section
  *
  *
  * \code
@@ -23,7 +23,9 @@
 #include "DDRec/Surface.h"
 #include "XML/Layering.h"
 #include "XML/Utilities.h"
+#include <algorithm>
 #include <array>
+#include <cmath>
 #include "DD4hepDetectorHelper.h"
 
 using namespace std;
@@ -45,11 +47,31 @@ static Ref_t create_CurvedBarrelTracker(Detector& description, xml_h e, Sensitiv
   map<string, std::vector<VolPlane>> volplane_surfaces;
   map<string, std::vector<double>> module_length;
 
-  PlacedVolume pv, pv_frame;
+  PlacedVolume pv;
 
   // Set detector type flag
   dd4hep::xml::setDetectorTypeFlag(x_det, sdet);
   auto& params = DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(sdet);
+
+  // The XML describes one quarter-RSU section. Upper/lower module prototypes mirror
+  // the r-phi ordering, while consecutive z placements provide the other two sections.
+  xml_comp_t x_rsu_layout   = x_det.child(_Unicode(rsu_layout));
+  int rsu_tiles_per_section = x_rsu_layout.attr<int>(_Unicode(tiles_per_section));
+  double rsu_backbone_z     = x_rsu_layout.attr<double>(_Unicode(backbone_z));
+  double rsu_biasing_rphi   = x_rsu_layout.attr<double>(_Unicode(biasing_rphi));
+  double rsu_readout_rphi   = x_rsu_layout.attr<double>(_Unicode(readout_rphi));
+  double rsu_power_z        = x_rsu_layout.attr<double>(_Unicode(power_z));
+  double rsu_tile_rphi      = x_rsu_layout.attr<double>(_Unicode(tile_rphi));
+  double rsu_tile_pitch_z   = x_rsu_layout.attr<double>(_Unicode(tile_pitch_z));
+  double rsu_tile_z         = x_rsu_layout.attr<double>(_Unicode(tile_z));
+
+  // VertexBarrelHits allocates two bits to the sensor field, with zero reserved.
+  if (rsu_tiles_per_section < 1 || rsu_tiles_per_section > 3 || rsu_backbone_z <= 0 ||
+      rsu_biasing_rphi <= 0 || rsu_readout_rphi <= 0 || rsu_power_z <= 0 || rsu_tile_rphi <= 0 ||
+      rsu_tile_pitch_z <= 0 || rsu_tile_z <= 0) {
+    printout(ERROR, "CurvedBarrelTracker", "Invalid RSU layout dimensions or tile count.");
+    throw runtime_error("Invalid RSU layout in vertex_barrel.xml.");
+  }
 
   // Add the volume boundary material if configured
   for (xml_coll_t bmat(x_det, _Unicode(boundary_material)); bmat; ++bmat) {
@@ -92,7 +114,6 @@ static Ref_t create_CurvedBarrelTracker(Detector& description, xml_h e, Sensitiv
 
     double thickness_so_far = 0.0;
     for (xml_coll_t mci(x_mod, _U(module_component)); mci; ++mci, ++ncomponents) {
-      Volume c_vol;
       xml_comp_t x_comp  = mci;
       const string c_nam = x_comp.nameStr(); // _toString(ncomponents, "component%d");
       const string c_mat = x_comp.materialStr();
@@ -102,87 +123,10 @@ static Ref_t create_CurvedBarrelTracker(Detector& description, xml_h e, Sensitiv
       double c_rmin      = m_rmin + thickness_so_far;
       double c_dphi      = c_width / c_rmin;
 
-      if (c_nam == "RSU") { // for RSU, create ONE upper or lower 3-tile sections.
-        // **** hard-coded RSU design with 12 tiles, plus backbones, readout pads, biasing
-        // Having issue including multiple sensitive surfaces in one Tube module (worked with box).
-        // Therefore use type "upper" and "lower" to create two mirrored tile sections. (left right is identical)
-        //
-        // "|" = backbone. Length alone z.
-        //
-        // | ------readout-------- | -------readout--------
-        // | tilex3                | tilex3
-        // | ------biasing-------- | -------biasing--------
-        // | ------biasing-------- | -------biasing--------
-        // | tilex3                | tilex3
-        // | ------readout-------- | -------readout--------
-        const string frame_vis        = "SVTReadoutVis";
-        const string c_type           = x_comp.typeStr();
-        const double BiasingWidth     = 0.06 * mm; // need to x2 for two sets
-        const double ReadoutPadsWidth = m_width - BiasingWidth - c_width;
-        const double BackboneLength   = m_length - c_length; //0.06*mm;
-
-        double px = 0, py = 0, pz = 0;
-        double c_z0 = -m_length / 2;
-        double c_z1 = c_z0 + BackboneLength;
-        double c_z2 = m_length / 2;
-        pz          = (c_z1 + c_z2) / 2; // section central z
-
-        double c_phi0 = 0;
-        double c_phi1, c_phi2;
-        double c_phi3 = m_width / m_rmin;
-        string c_nam1, c_nam2;
-        if (c_type == "upper") {
-          c_phi1 = BiasingWidth / c_rmin;
-          c_phi2 = c_phi1 + c_dphi;
-          c_nam1 = "biasing";
-          c_nam2 = "readout";
-        } else if (c_type == "lower") {
-          c_phi1 = ReadoutPadsWidth / c_rmin;
-          c_phi2 = c_phi1 + c_dphi;
-          c_nam1 = "readout";
-          c_nam2 = "biasing";
-        } else {
-          printout(ERROR, "CurvedBarrelTracker",
-                   string((string("Module ") + m_nam + string(": invalid RSU component type [") +
-                           c_type + string("], should be upper or lower")))
-                       .c_str());
-          throw runtime_error("Logics error in building modules.");
-        }
-
-        // *** inactive areas
-        // biasing and readout (horizontal)
-        Tube f_tube1(c_rmin, c_rmin + c_thickness, c_length / 2, c_phi0, c_phi1);
-        Volume f_vol1(c_nam1, f_tube1, description.material(c_mat));
-        pv_frame = m_vol.placeVolume(f_vol1, Position(px, py, pz));
-        f_vol1.setVisAttributes(description, frame_vis);
-
-        Tube f_tube2(c_rmin, c_rmin + c_thickness, c_length / 2, c_phi2, c_phi3);
-        Volume f_vol2(c_nam2, f_tube2, description.material(c_mat));
-        pv_frame = m_vol.placeVolume(f_vol2, Position(px, py, pz));
-        f_vol2.setVisAttributes(description, frame_vis);
-
-        // backbone (vertical)
-        Tube f_tube3(c_rmin, c_rmin + c_thickness, BackboneLength / 2, c_phi0, c_phi3);
-        Volume f_vol3("backbone", f_tube3, description.material(c_mat));
-        pv_frame = m_vol.placeVolume(f_vol3, Position(px, py, (c_z0 + c_z1) / 2));
-        f_vol3.setVisAttributes(description, frame_vis);
-
-        // *** sensitive tile
-        Tube c_tube(c_rmin, c_rmin + c_thickness, c_length / 2, c_phi1, c_phi2);
-        c_vol = Volume(c_nam + "_" + c_type, c_tube, description.material(c_mat));
-        pv    = m_vol.placeVolume(c_vol, Position(px, py, pz));
-      } else { // for regular component, no difference b/w upper/lower
-        Tube c_tube(c_rmin, c_rmin + c_thickness, c_length / 2, 0, c_dphi);
-        c_vol = Volume(c_nam, c_tube, description.material(c_mat));
-        pv    = m_vol.placeVolume(c_vol, Position(0, 0, 0));
-      }
-      c_vol.setRegion(description, x_comp.regionStr());
-      c_vol.setLimitSet(description, x_comp.limitsStr());
-      c_vol.setVisAttributes(description, x_comp.visStr());
-      if (x_comp.isSensitive()) {
-        pv.addPhysVolID("sensor", sensor_number++);
-        c_vol.setSensitiveDetector(sens);
-        sensitives[m_nam].push_back(pv);
+      auto attach_sensitive = [&](Volume& component_volume, PlacedVolume& component_pv) {
+        component_pv.addPhysVolID("sensor", sensor_number++);
+        component_volume.setSensitiveDetector(sens);
+        sensitives[m_nam].push_back(component_pv);
         // -------- create a measurement plane for the tracking surface attched to the sensitive volume -----
         Vector3D u(-1., 0., 0.);
         Vector3D v(0., -1., 0.);
@@ -193,8 +137,98 @@ static Ref_t create_CurvedBarrelTracker(Detector& description, xml_h e, Sensitiv
         double outer_thickness = total_thickness - inner_thickness;
 
         SurfaceType type(SurfaceType::Sensitive);
-        VolPlane surf(c_vol, type, inner_thickness, outer_thickness, u, v, n); //,o ) ;
+        VolPlane surf(component_volume, type, inner_thickness, outer_thickness, u, v, n);
         volplane_surfaces[m_nam].push_back(surf);
+      };
+
+      if (c_nam == "RSU") {
+        const string c_type = x_comp.typeStr();
+        if (c_type != "upper" && c_type != "lower") {
+          printout(ERROR, "CurvedBarrelTracker",
+                   string((string("Module ") + m_nam + string(": invalid RSU component type [") +
+                           c_type + string("], should be upper or lower")))
+                       .c_str());
+          throw runtime_error("Logics error in building modules.");
+        }
+
+        const double partition_area =
+            c_width * rsu_backbone_z +
+            (rsu_biasing_rphi + rsu_readout_rphi) * (c_length - rsu_backbone_z) +
+            rsu_tile_rphi * rsu_tiles_per_section * (rsu_tile_z + rsu_power_z);
+        const double length_tolerance = 1.0e-12 * std::max(c_width, c_length);
+        const double area_tolerance   = 1.0e-12 * c_width * c_length;
+        if (std::abs(rsu_biasing_rphi + rsu_tile_rphi + rsu_readout_rphi - c_width) >
+                length_tolerance ||
+            std::abs(rsu_backbone_z + rsu_tiles_per_section * rsu_tile_pitch_z - c_length) >
+                length_tolerance ||
+            std::abs(rsu_tile_z + rsu_power_z - rsu_tile_pitch_z) > length_tolerance ||
+            std::abs(partition_area - c_width * c_length) > area_tolerance) {
+          printout(ERROR, "CurvedBarrelTracker",
+                   string((string("Module ") + m_nam +
+                           string(": RSU pieces do not form a positive rectangular section.")))
+                       .c_str());
+          throw runtime_error("Invalid RSU section geometry.");
+        }
+
+        const string component_base = m_nam + _toString(ncomponents, "_component%d_") + c_type;
+        auto place_rsu_piece = [&](const string& piece_name, double rphi_start, double rphi_width,
+                                   double z_start, double z_width, const string& vis,
+                                   bool sensitive) {
+          Tube piece_solid(c_rmin, c_rmin + c_thickness, z_width / 2.0, rphi_start / c_rmin,
+                           (rphi_start + rphi_width) / c_rmin);
+          Volume piece_volume(component_base + "_" + piece_name, piece_solid,
+                              description.material(c_mat));
+          piece_volume.setRegion(description, x_comp.regionStr());
+          piece_volume.setLimitSet(description, x_comp.limitsStr());
+          piece_volume.setVisAttributes(description, vis);
+          PlacedVolume piece_pv = m_vol.placeVolume(
+              piece_volume, Position(0, 0, -c_length / 2.0 + z_start + z_width / 2.0));
+          if (sensitive) {
+            attach_sensitive(piece_volume, piece_pv);
+          }
+        };
+
+        if (x_comp.isSensitive()) {
+          // The backbone owns the two passive-band corner areas, so all pieces are disjoint.
+          place_rsu_piece("backbone", 0, c_width, 0, rsu_backbone_z, "SVTReadoutVis", false);
+
+          const double first_passive_rphi = c_type == "upper" ? rsu_biasing_rphi : rsu_readout_rphi;
+          const double second_passive_rphi =
+              c_type == "upper" ? rsu_readout_rphi : rsu_biasing_rphi;
+          const string first_passive_name  = c_type == "upper" ? "biasing" : "readout";
+          const string second_passive_name = c_type == "upper" ? "readout" : "biasing";
+          const double z_after_backbone    = c_length - rsu_backbone_z;
+          place_rsu_piece(first_passive_name, 0, first_passive_rphi, rsu_backbone_z,
+                          z_after_backbone, "SVTReadoutVis", false);
+          place_rsu_piece(second_passive_name, first_passive_rphi + rsu_tile_rphi,
+                          second_passive_rphi, rsu_backbone_z, z_after_backbone, "SVTReadoutVis",
+                          false);
+
+          for (int tile = 0; tile < rsu_tiles_per_section; ++tile) {
+            const double tile_z_start = rsu_backbone_z + tile * rsu_tile_pitch_z;
+            place_rsu_piece(_toString(tile + 1, "tile%d"), first_passive_rphi, rsu_tile_rphi,
+                            tile_z_start, rsu_tile_z, x_comp.visStr(), true);
+            place_rsu_piece(_toString(tile + 1, "power_gap%d"), first_passive_rphi, rsu_tile_rphi,
+                            tile_z_start + rsu_tile_z, rsu_power_z, "SVTReadoutVis", false);
+          }
+        } else {
+          // Inactive silicon and copper remain continuous across the complete section.
+          place_rsu_piece("full", 0, c_width, 0, c_length, x_comp.visStr(), false);
+        }
+
+        thickness_so_far += c_thickness;
+        continue;
+      }
+
+      // Regular components retain the original single-volume behavior.
+      Tube c_tube(c_rmin, c_rmin + c_thickness, c_length / 2, 0, c_dphi);
+      Volume c_vol(c_nam, c_tube, description.material(c_mat));
+      pv = m_vol.placeVolume(c_vol, Position(0, 0, 0));
+      c_vol.setRegion(description, x_comp.regionStr());
+      c_vol.setLimitSet(description, x_comp.limitsStr());
+      c_vol.setVisAttributes(description, x_comp.visStr());
+      if (x_comp.isSensitive()) {
+        attach_sensitive(c_vol, pv);
       }
       thickness_so_far += c_thickness;
     }


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Improve the SVT sensor description. 
Reference: page 14 in Zhenyu's [presentation](https://indico.bnl.gov/event/33460/#6-svt-rates-next-steps-on-sens)

Change Barrel sensor structure from 1 layer of 40um active silicon to: 46um inactive Si (substrate) + 14um active Si (epitaxial) + 2.5um Cu (wire bonding)
IB: Cu always face larger R. Also added 12 tiles per RSU structure.
OB: Cu faces outer side of the stave and alternating in Z. 

Disks: change on-hold until the module layout finalized https://github.com/eic/epic/pull/1073


### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x ] AI was used in preparing this PR. Please describe usage below.
I used codex to assist coding.