### PR TITLE
FileLoader: avoid crashing on filesystem race, flush output buffers on exit

### DIFF
--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -108,10 +108,11 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
               fs::create_symlink(link_target, hash_path);
               success = true;
             } catch (const fs::filesystem_error&) {
-              if (fs::exists(hash_path) && fs::equivalent(hash_path, link_target)) {
+              const bool hash_path_exists = fs::exists(hash_path);
+              if (hash_path_exists && fs::equivalent(hash_path, link_target)) {
                 // Another process created the correct symlink concurrently; that is fine
                 success = true;
-              } else if (fs::exists(hash_path)) {
+              } else if (hash_path_exists) {
                 printout(ERROR, "FileLoader",
                          "symlink " + hash_path.string() +
                              " already exists but points to wrong target");
@@ -218,9 +219,10 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
     // use new path from hash so file link is local
     fs::create_symlink(fs::path(hash), file_path);
   } catch (const fs::filesystem_error&) {
-    if (fs::exists(file_path) && fs::equivalent(file_path, hash_path)) {
+    const bool file_path_exists = fs::exists(file_path);
+    if (file_path_exists && fs::equivalent(file_path, hash_path)) {
       // Another process created the correct symlink concurrently; that is fine
-    } else if (fs::exists(file_path)) {
+    } else if (file_path_exists) {
       printout(ERROR, "FileLoader",
                "symlink " + file_path.string() + " already exists but points to wrong target");
       std::exit(EXIT_FAILURE);

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -60,14 +60,14 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
   std::string hash =
       fmt::format("{:016x}", dd4hep::detail::hash64(url)); // TODO: Use c++20 std::fmt
 
-  // create file parent path, if not exists
+  // create file parent path if not exists
   fs::path parent_path = file_path.parent_path();
-  if (!fs::exists(parent_path)) {
-    if (fs::create_directories(parent_path) == false) {
-      printout(ERROR, "FileLoader", "parent path " + parent_path.string() + " cannot be created");
-      printout(ERROR, "FileLoader", "hint: try running 'mkdir -p " + parent_path.string() + "'");
-      std::exit(EXIT_FAILURE);
-    }
+  try {
+    fs::create_directories(parent_path); // no-op (returns false) if already exists
+  } catch (const fs::filesystem_error&) {
+    printout(ERROR, "FileLoader", "parent path " + parent_path.string() + " cannot be created");
+    printout(ERROR, "FileLoader", "hint: try running 'mkdir -p " + parent_path.string() + "'");
+    std::exit(EXIT_FAILURE);
   }
 
   // if file exists and is symlink to correct hash

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -66,7 +66,7 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
     if (fs::create_directories(parent_path) == false) {
       printout(ERROR, "FileLoader", "parent path " + parent_path.string() + " cannot be created");
       printout(ERROR, "FileLoader", "hint: try running 'mkdir -p " + parent_path.string() + "'");
-      std::_Exit(EXIT_FAILURE);
+      std::exit(EXIT_FAILURE);
     }
   }
 
@@ -108,9 +108,19 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
               fs::create_symlink(link_target, hash_path);
               success = true;
             } catch (const fs::filesystem_error&) {
-              printout(ERROR, "FileLoader",
-                       "unable to link from " + hash_path.string() + " to " + link_target.string());
-              std::_Exit(EXIT_FAILURE);
+              if (fs::exists(hash_path) && fs::equivalent(hash_path, link_target)) {
+                // Another process created the correct symlink concurrently; that is fine
+                success = true;
+              } else if (fs::exists(hash_path)) {
+                printout(ERROR, "FileLoader",
+                         "symlink " + hash_path.string() + " already exists but points to wrong target");
+                std::exit(EXIT_FAILURE);
+              } else {
+                printout(ERROR, "FileLoader",
+                         "unable to link from " + hash_path.string() + " to " + link_target.string());
+                printout(ERROR, "FileLoader", "check permissions and retry");
+                std::exit(EXIT_FAILURE);
+              }
             }
             return true;
           }
@@ -150,7 +160,7 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
       printout(ERROR, "FileLoader", "hint: check the command and try running manually");
       printout(ERROR, "FileLoader",
                "hint: allow insecure connections on some systems with the flag -k");
-      std::_Exit(EXIT_FAILURE);
+      std::exit(EXIT_FAILURE);
     }
   }
 
@@ -176,7 +186,7 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
                    "hint: this may be resolved by removing directory " + parent_path.string());
           printout(ERROR, "FileLoader",
                    "hint: or in that directory removing the file or link " + file_path.string());
-          std::_Exit(EXIT_FAILURE);
+          std::exit(EXIT_FAILURE);
         }
       }
     } else {
@@ -184,7 +194,7 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
       if (fs::remove(file_path) == false) {
         // failure mode; cannot remove dead symlink
         printout(ERROR, "FileLoader", "unable to remove symlink " + file_path.string());
-        std::_Exit(EXIT_FAILURE);
+        std::exit(EXIT_FAILURE);
       }
     }
   } else {
@@ -196,7 +206,7 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
                "we tried to create a symlink " + file_path.string() + " to the actual resource, " +
                    "but a file already exists there and we will not remove it automatically");
       printout(ERROR, "FileLoader", "hint: backup the file, remove it manually, and retry");
-      std::_Exit(EXIT_FAILURE);
+      std::exit(EXIT_FAILURE);
     }
   }
   // file_path now does not exist
@@ -206,10 +216,18 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
     // use new path from hash so file link is local
     fs::create_symlink(fs::path(hash), file_path);
   } catch (const fs::filesystem_error&) {
-    printout(ERROR, "FileLoader",
-             "unable to link from " + file_path.string() + " to " + hash_path.string());
-    printout(ERROR, "FileLoader", "check permissions and retry");
-    std::_Exit(EXIT_FAILURE);
+    if (fs::exists(file_path) && fs::equivalent(file_path, hash_path)) {
+      // Another process created the correct symlink concurrently; that is fine
+    } else if (fs::exists(file_path)) {
+      printout(ERROR, "FileLoader",
+               "symlink " + file_path.string() + " already exists but points to wrong target");
+      std::exit(EXIT_FAILURE);
+    } else {
+      printout(ERROR, "FileLoader",
+               "unable to link from " + file_path.string() + " to " + hash_path.string());
+      printout(ERROR, "FileLoader", "check permissions and retry");
+      std::exit(EXIT_FAILURE);
+    }
   }
 
   // final check of the file size
@@ -221,6 +239,6 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
              "hint: check whether the file " + fs::canonical(file_path).string() +
                  " has any content");
     printout(ERROR, "FileLoader", "hint: check whether the URL " + url + " has any content");
-    std::_Exit(EXIT_FAILURE);
+    std::exit(EXIT_FAILURE);
   }
 }

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -113,11 +113,13 @@ inline void EnsureFileFromURLExists(std::string url, std::string file, std::stri
                 success = true;
               } else if (fs::exists(hash_path)) {
                 printout(ERROR, "FileLoader",
-                         "symlink " + hash_path.string() + " already exists but points to wrong target");
+                         "symlink " + hash_path.string() +
+                             " already exists but points to wrong target");
                 std::exit(EXIT_FAILURE);
               } else {
                 printout(ERROR, "FileLoader",
-                         "unable to link from " + hash_path.string() + " to " + link_target.string());
+                         "unable to link from " + hash_path.string() + " to " +
+                             link_target.string());
                 printout(ERROR, "FileLoader", "check permissions and retry");
                 std::exit(EXIT_FAILURE);
               }


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Resolves: https://github.com/eic/detector_benchmarks/issues/257

There were two issues:
1. std::_Exit does not call destructors, but also does not flush buffers, so error messages are lost
2. there is a race when multiple applications try to initialize geometries in the same directory (in benchmarks it must be triggered by a subtle bug in gitlab yamls or snakemake rules)

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.
  claude