### PR TITLE
Restrict ForwardTOF ACTS layer pattern to sensitive layers

### DIFF
--- a/compact/tracking/tof_endcap.xml
+++ b/compact/tracking/tof_endcap.xml
@@ -695,7 +695,7 @@
   <plugins>
     <plugin name="DD4hep_ParametersPlugin">
       <argument value="ForwardTOF"/>
-      <argument value="layer_pattern: str=ForwardTOF_layer\d"/>
+      <argument value="layer_pattern: str=ForwardTOF_layer[12]"/>
     </plugin>
   </plugins>
 


### PR DESCRIPTION
## Motivation

EICrecon Gen3 blueprint construction can select `ForwardTOF_layer\d` from geometry metadata. In ePIC ForwardTOF, that pattern also matches non-sensitive support/gap layers (`layer3`, `layer5`, `layer6`), which can lead to `LayerBlueprintNode: no surfaces provided` when those empty layers are included.

This patch narrows the exported ForwardTOF layer pattern to the two sensitive layers only.

## Change

- `compact/tracking/tof_endcap.xml`
  - `layer_pattern: str=ForwardTOF_layer\d` → `layer_pattern: str=ForwardTOF_layer[12]`

## Impact

- Keeps ForwardTOF layer discovery aligned with ACTS-convertible sensitive surfaces.
- Avoids pulling non-sensitive ForwardTOF layers into Gen3 layer selection.
- No geometry layout refactor; one-line metadata fix.

## Related

- EICrecon PR: https://github.com/eic/EICrecon/pull/2227
