### PR TITLE
segement mpgd endcap into quads

### DIFF
--- a/compact/materials.xml
+++ b/compact/materials.xml
@@ -579,4 +579,20 @@
     <composite n="6"  ref="O"/>
     <composite n="2"  ref="N"/>
   </material>
+  <material name="Fiberglass">
+    <D type="density" value="1.85" unit="g / cm3"/>
+    <composite n="0.30" ref="Si"/>
+    <composite n="0.50" ref="O"/>
+    <composite n="0.10" ref="Ca"/>
+    <composite n="0.05" ref="Al"/>
+    <composite n="0.05" ref="B"/>
+ </material>
+ <material name="Honeycomb">
+    <D type="density" value="0.048" unit="g / cm3"/>
+    <composite n="0.54" ref="C"/>
+    <composite n="0.04" ref="H"/>
+    <composite n="0.22" ref="O"/>
+    <composite n="0.20" ref="N"/>
+ </material>
+
 </materials>

--- a/compact/tracking/definitions_craterlake.xml
+++ b/compact/tracking/definitions_craterlake.xml
@@ -107,25 +107,15 @@
     <constant name="TrackerEndcapNDisk4_rmax"        value="TrackerEndcapPDisk4_rmax" />
 
     <comment> Main parameters for MPGD endcap disks, offset here is the distance between disks </comment>
-    <constant name="ForwardMPGD_z1"             value="1285.0*mm-24*mm"/>
-    <constant name="ForwardMPGDMod_offset"        value="118.0*mm"/>
-    <constant name="ForwardMPGD_z2"             value="ForwardMPGD_z1 + ForwardMPGDMod_offset"/>
-    <constant name="ForwardMPGDMod1_rmin"         value="90*mm" />
-    <constant name="ForwardMPGDMod2_rmin"         value="90*mm"/>
-    <constant name="ForwardMPGDMod1_rmax"         value="428*mm" />
-    <constant name="ForwardMPGDMod2_rmax"         value="428*mm" />
-    <constant name="ForwardMPGDMod1_Rmax"         value="460*mm" />
-    <constant name="ForwardMPGDMod2_Rmax"         value="460*mm" />
+    <constant name="ForwardMPGD_z1"             value="1285.0*mm"/>
+    <constant name="ForwardMPGD_z2"             value="1350*mm"/>
+    <constant name="ForwardMPGDMod_rmin"         value="90*mm" />
+    <constant name="ForwardMPGDMod_rmax"         value="450*mm" />
 
-    <constant name="BackwardMPGD_z1"             value="1075.0*mm-12*mm"/>
-    <constant name="BackwardMPGDMod_offset"        value="118.0*mm"/>
-    <constant name="BackwardMPGD_z2"             value="BackwardMPGD_z1 + BackwardMPGDMod_offset"/>
-    <constant name="BackwardMPGDMod1_rmin"         value="50.0*mm" />
-    <constant name="BackwardMPGDMod2_rmin"         value="50.0*mm" />
-    <constant name="BackwardMPGDMod1_rmax"         value="432.0*mm" />
-    <constant name="BackwardMPGDMod2_rmax"         value="432.0*mm" />
-    <constant name="BackwardMPGDMod1_Rmax"         value="460.0*mm" />
-    <constant name="BackwardMPGDMod2_Rmax"         value="460.0*mm" />
+    <constant name="BackwardMPGD_z1"             value="1075.0*mm"/>
+    <constant name="BackwardMPGD_z2"             value="1189.0*mm"/>
+    <constant name="BackwardMPGDMod_rmin"         value="50.0*mm" />
+    <constant name="BackwardMPGDMod_rmax"         value="450.0*mm" />
 
   </define>
   <comment> See compact/definitions.xml for reserved detector id

--- a/compact/tracking/definitions_craterlake.xml
+++ b/compact/tracking/definitions_craterlake.xml
@@ -87,7 +87,7 @@
     <constant name="TrackerEndcapPDisk3_rmax"        value="TrackerEndcapDisk_rmax * .98" />
     <constant name="TrackerEndcapPDisk4_zmin"        value="120.0*cm" />
     <constant name="TrackerEndcapPDisk4_rmin"        value="45.72*mm + Beampipe_bakeout_buffer + 12.70*mm" />
-   <constant name="TrackerEndcapPDisk4_rmax"        value="TrackerEndcapDisk_rmax * .98" />
+    <constant name="TrackerEndcapPDisk4_rmax"        value="TrackerEndcapDisk_rmax * .98" />
 
     <comment> Main parameters for the negative silicon disks (will be reflected, so positive z-values here)</comment>
     <constant name="InnerTrackerEndcapN_zmin"        value="InnerTrackerEndcapP_zmin" />
@@ -113,7 +113,7 @@
     <constant name="ForwardMPGDMod_rmax"         value="450*mm" />
 
     <constant name="BackwardMPGD_z1"             value="1075.0*mm"/>
-    <constant name="BackwardMPGD_z2"             value="1189.0*mm"/>
+    <constant name="BackwardMPGD_z2"             value="1188.5*mm"/>
     <constant name="BackwardMPGDMod_rmin"         value="50.0*mm" />
     <constant name="BackwardMPGDMod_rmax"         value="450.0*mm" />
 
@@ -209,7 +209,7 @@
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_CACHE:/opt/detector"/>
       <arg value="file:calibrations/materials-map.cbor"/>
-      <arg value="url:https://raw.githubusercontent.com/eic/epic-data/700fa7f92568311408137b2002b513346b66277d/material-map.cbor"/>
+       <arg value="url:https://raw.githubusercontent.com/eic/epic-data/700fa7f92568311408137b2002b513346b66277d/material-map.cbor"/>
     </plugin>
   </plugins>
 

--- a/compact/tracking/definitions_craterlake.xml
+++ b/compact/tracking/definitions_craterlake.xml
@@ -87,7 +87,7 @@
     <constant name="TrackerEndcapPDisk3_rmax"        value="TrackerEndcapDisk_rmax * .98" />
     <constant name="TrackerEndcapPDisk4_zmin"        value="120.0*cm" />
     <constant name="TrackerEndcapPDisk4_rmin"        value="45.72*mm + Beampipe_bakeout_buffer + 12.70*mm" />
-    <constant name="TrackerEndcapPDisk4_rmax"        value="TrackerEndcapDisk_rmax * .98" />
+   <constant name="TrackerEndcapPDisk4_rmax"        value="TrackerEndcapDisk_rmax * .98" />
 
     <comment> Main parameters for the negative silicon disks (will be reflected, so positive z-values here)</comment>
     <constant name="InnerTrackerEndcapN_zmin"        value="InnerTrackerEndcapP_zmin" />
@@ -107,21 +107,25 @@
     <constant name="TrackerEndcapNDisk4_rmax"        value="TrackerEndcapPDisk4_rmax" />
 
     <comment> Main parameters for MPGD endcap disks, offset here is the distance between disks </comment>
-    <constant name="ForwardMPGD_zmin"             value="1285.0*mm"/>
-    <constant name="ForwardMPGDMod_offset"        value="125.0*mm"/>
-    <constant name="ForwardMPGDMod1_rmin"         value="70.0*mm" />
-    <constant name="ForwardMPGDMod2_rmin"         value="70.0*mm"/>
-    <comment> rmax = active area radius </comment>
-    <constant name="ForwardMPGDMod1_rmax"         value="420*mm" />
-    <constant name="ForwardMPGDMod2_rmax"         value="420*mm" />
+    <constant name="ForwardMPGD_z1"             value="1285.0*mm-24*mm"/>
+    <constant name="ForwardMPGDMod_offset"        value="118.0*mm"/>
+    <constant name="ForwardMPGD_z2"             value="ForwardMPGD_z1 + ForwardMPGDMod_offset"/>
+    <constant name="ForwardMPGDMod1_rmin"         value="90*mm" />
+    <constant name="ForwardMPGDMod2_rmin"         value="90*mm"/>
+    <constant name="ForwardMPGDMod1_rmax"         value="428*mm" />
+    <constant name="ForwardMPGDMod2_rmax"         value="428*mm" />
+    <constant name="ForwardMPGDMod1_Rmax"         value="460*mm" />
+    <constant name="ForwardMPGDMod2_Rmax"         value="460*mm" />
 
-    <constant name="BackwardMPGD_zmin"             value="1075.0*mm"/>
-    <constant name="BackwardMPGDMod_offset"        value="125.0*mm"/>
+    <constant name="BackwardMPGD_z1"             value="1075.0*mm-12*mm"/>
+    <constant name="BackwardMPGDMod_offset"        value="118.0*mm"/>
+    <constant name="BackwardMPGD_z2"             value="BackwardMPGD_z1 + BackwardMPGDMod_offset"/>
     <constant name="BackwardMPGDMod1_rmin"         value="50.0*mm" />
     <constant name="BackwardMPGDMod2_rmin"         value="50.0*mm" />
-    <comment> rmax = active area radius </comment>
-    <constant name="BackwardMPGDMod1_rmax"         value="420.0*mm" />
-    <constant name="BackwardMPGDMod2_rmax"         value="420.0*mm" />
+    <constant name="BackwardMPGDMod1_rmax"         value="432.0*mm" />
+    <constant name="BackwardMPGDMod2_rmax"         value="432.0*mm" />
+    <constant name="BackwardMPGDMod1_Rmax"         value="460.0*mm" />
+    <constant name="BackwardMPGDMod2_Rmax"         value="460.0*mm" />
 
   </define>
   <comment> See compact/definitions.xml for reserved detector id
@@ -215,7 +219,7 @@
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_CACHE:/opt/detector"/>
       <arg value="file:calibrations/materials-map.cbor"/>
-      <arg value="url:https://raw.githubusercontent.com/eic/epic-data/b59d999b8df6ecf4349dbc1bf4f836295d182e05/material-map.cbor"/>
+      <arg value="url:https://github.com/eic/epic-data/raw/2df7751706c545ecda5957137695a0859a09a9ee/material-map.cbor"/>
     </plugin>
   </plugins>
 

--- a/compact/tracking/mpgd_backward_endcap.xml
+++ b/compact/tracking/mpgd_backward_endcap.xml
@@ -1,153 +1,118 @@
 <!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
-<!-- Copyright (C) 2022 Nicolas Schmidt -->
-
+<!-- Backward MPGD using epic_MPGDQuadrantEndcapTracker. -->
 <lccdd>
   <define>
-    <comment>
-      --------------------------
-      Backward MPGD Parameters
-      --------------------------
-    </comment>
-    <comment> Backward MPGD position </comment>
-    <constant name="BackwardMPGD_nlayers"             value="2"/>
-    <constant name="BackwardMPGD_AllowedSpace"        value="2.5*cm"/>
+    <constant name="BackwardMPGDQuad_modules_nlayers" value="2" />
+    <constant name="BackwardMPGDQuad_modules_per_quadrant" value="12" />
+    <constant name="BackwardMPGDQuad_angle" value="360*degree/(4*BackwardMPGDQuad_modules_per_quadrant)" />
+    <constant name="BackwardMPGDQuad_z1" value="BackwardMPGD_z1" />
+    <constant name="BackwardMPGDQuad_z2" value="BackwardMPGD_z2" />
+    <constant name="BackwardMPGDQuad_stagger" value="16*mm" />
+    <constant name="BackwardMPGDQuad_inner_radius" value="50*mm" />
+    <constant name="BackwardMPGDQuad_outer_radius" value="500*mm" />
+    <constant name="BackwardMPGDQuad_active_outer_radius" value="468*mm"/>
+    <constant name="BackwardMPGDQuad_overlap_half_width" value="12.5*mm" />
+    <constant name="BackwardMPGDQuad_overlap_radius" value="(BackwardMPGDQuad_inner_radius + BackwardMPGDQuad_outer_radius)/2" />
 
-    <comment> Parameters for the endcap MPGDs </comment>
-    <constant name="BackwardMPGDEndcapMod_count"             value="48" />
-    <constant name="BackwardMPGDEndcapMod_dz"                value="0" />
-    <constant name="BackwardMPGDEndcapMod_overlap"           value="0" />
+    <constant name="BackwardMPGDQuad_cathode_cu" value="5*um" />
+    <constant name="BackwardMPGDQuad_cathode_kapton" value="50*um" />
+    <constant name="BackwardMPGDQuad_skin" value="100*um" />
+    <constant name="BackwardMPGDQuad_gem_kapton" value="50*um" />
+    <constant name="BackwardMPGDQuad_gem_cu" value="5*um" />
+    <constant name="BackwardMPGDQuad_honeycomb" value="3*mm" />
+    <constant name="BackwardMPGDQuad_drift_gas" value="6*mm" />
+    <constant name="BackwardMPGDQuad_transfer_gas" value="3*mm" />
+    <constant name="BackwardMPGDQuad_pcb" value="135*um" />
+    <constant name="BackwardMPGDQuad_anode_kapton" value="50*um" />
+    <constant name="BackwardMPGDQuad_anode_cu" value="5*um" />
 
-    <comment> Layer definitions around the sensor for the endcap MPGDs </comment>
-    <constant name="BackwardMPGDDriftGap_thickness"           value="3.0*mm" />
-    <constant name="BackwardMPGDWindow_thickness"             value="50*um"/>
-    <constant name="BackwardMPGDWindowGap_thickness"          value="2*mm"/>
-    <constant name="BackwardMPGDFoilCu_thickness"             value="5*um"/>
-    <constant name="BackwardMPGDReadOutElectrode_thickness"   value="10*um"/>
-    <constant name="BackwardMPGDFoilKapton_thickness"         value="50*um"/>
-    <constant name="BackwardMPGDReadOutNomex_thickness"       value="50*um"/>
-    <constant name="BackwardMPGDReadOutKapton_thickness"      value="50*um"/>
-    <constant name="BackwardMPGDPCB_thickness"                value="1.5*mm"/>
+    <constant name="BackwardMPGDQuad_thickness"
+      value="2*BackwardMPGDQuad_cathode_cu + 2*BackwardMPGDQuad_cathode_kapton + 2*BackwardMPGDQuad_skin + BackwardMPGDQuad_gem_kapton + 3*BackwardMPGDQuad_gem_cu + 2*BackwardMPGDQuad_honeycomb + BackwardMPGDQuad_drift_gas + BackwardMPGDQuad_transfer_gas + BackwardMPGDQuad_pcb + BackwardMPGDQuad_anode_kapton + BackwardMPGDQuad_anode_cu" />
+    <constant name="BackwardMPGDQuad_layer_length" value="BackwardMPGDQuad_thickness + 2*BackwardMPGDQuad_stagger" />
+
+    <!-- Trapezoid dimensions use the local Y axis as the detector thickness. -->
+    <constant name="BackwardMPGDQuad_inner_width" value="2*BackwardMPGDQuad_inner_radius*tan(BackwardMPGDQuad_angle/2)" />
+    <constant name="BackwardMPGDQuad_outer_width" value="2*BackwardMPGDQuad_outer_radius*sin(BackwardMPGDQuad_angle/2)" />
+    <constant name="BackwardMPGDQuad_length" value="BackwardMPGDQuad_outer_radius*cos(BackwardMPGDQuad_angle/2)-BackwardMPGDQuad_inner_radius" />
   </define>
 
-  <comment>
-    Actual detector implementation.
-  </comment>
-  <define>
-    <constant name="BackwardMPGDEndcapMod_angle"         value="360.0*degree/BackwardMPGDEndcapMod_count*(1.0 + BackwardMPGDEndcapMod_overlap)" />
-    <comment> 1 um padding to not have layer and module touch (ACTS requirement) </comment>
-    <constant name="BackwardMPGDLayerPad"                    value="0*um"/>
-    <comment> Detector thickness </comment>
-    <constant name="BackwardMPGDCathode_thickness" value="BackwardMPGDFoilKapton_thickness + BackwardMPGDFoilCu_thickness"/>
-    <constant name="BackwardMPGDRWell_thickness"   value="BackwardMPGDFoilKapton_thickness + BackwardMPGDFoilCu_thickness"/>
-    <constant name="BackwardMPGDReadOut_thickness"  value="BackwardMPGDReadOutNomex_thickness + BackwardMPGDReadOutElectrode_thickness + BackwardMPGDReadOutKapton_thickness "/>
-    <comment>@TODO: have space for 3 frames (2mm + 2mm + 3mm) need to add frame material </comment>
-    <constant name="BackwardMPGDFrame_thickness"   value="2*BackwardMPGDWindowGap_thickness + BackwardMPGDDriftGap_thickness"/>
-    <constant name="BackwardMPGDEndcapMod_thickness"  value="BackwardMPGDCathode_thickness + BackwardMPGDRWell_thickness + BackwardMPGDReadOut_thickness + BackwardMPGDFrame_thickness"/>
-    <constant name="BackwardMPGDEndcapLayer_thickness"   value="BackwardMPGDEndcapMod_thickness + 2 * BackwardMPGDEndcapMod_dz + BackwardMPGDLayerPad" />
+  <detectors>
+    <detector id="TrackerEndcapN_4_ID" name="BackwardMPGD" type="epic_MPGDQuadrantEndcapTracker"
+              actsType="endcap" readout="BackwardMPGDEndcapHits" vis="MPGDVis" reflect="true">
+      <type_flags type="DetType_TRACKER + DetType_ENDCAP" />
 
-    <constant name="BackwardMPGDMod1_zmin"         value="BackwardMPGD_zmin" />
-    <constant name="BackwardMPGDMod2_zmin"         value="BackwardMPGD_zmin + BackwardMPGDMod_offset" />
-    <constant name="BackwardMPGDLayer1_rmin"       value="BackwardMPGDMod1_rmin - BackwardMPGDLayerPad" />
-    <constant name="BackwardMPGDLayer2_rmin"       value="BackwardMPGDMod2_rmin - BackwardMPGDLayerPad" />
-    <constant name="BackwardMPGDLayer1_rmax"       value="BackwardMPGDMod1_rmax + BackwardMPGDLayerPad" />
-    <constant name="BackwardMPGDLayer2_rmax"       value="BackwardMPGDMod2_rmax + BackwardMPGDLayerPad" />
-    <constant name="BackwardMPGDLayer1_zmin"       value="BackwardMPGDMod1_zmin - BackwardMPGDLayerPad" />
-    <constant name="BackwardMPGDLayer2_zmin"       value="BackwardMPGDMod2_zmin + BackwardMPGDLayerPad" />
+      <module name="BackwardMPGDQuadModule1" vis="MPGDModuleVis">
+        <trd x1="BackwardMPGDQuad_inner_width/2" x2="BackwardMPGDQuad_outer_width/2" z="BackwardMPGDQuad_length/2" />
+	<overlap x="BackwardMPGDQuad_overlap_half_width" z="(BackwardMPGDQuad_active_outer_radius-BackwardMPGDQuad_inner_radius)/2" />
+        <module_component thickness="BackwardMPGDQuad_cathode_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_cathode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_skin" material="Fiberglass" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_cathode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_gem_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_gem_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_gem_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_gem_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_honeycomb" material="Honeycomb" sensitive="false" vis="MPGDVis" />
+        <module_component name="drift_gas" thickness="BackwardMPGDQuad_drift_gas" material="Ar90IsoButane" sensitive="true" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_transfer_gas" material="Ar90IsoButane" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_honeycomb" material="Honeycomb" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_pcb" material="Fr4" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_skin" material="Fiberglass" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_anode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_anode_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+      </module>
 
-    <constant name="BackwardMPGDMod1_x1"           value="2 * BackwardMPGDMod1_rmin * tan(BackwardMPGDEndcapMod_angle/2)" />
-    <constant name="BackwardMPGDMod1_x2"           value="2 * BackwardMPGDMod1_rmax * sin(BackwardMPGDEndcapMod_angle/2)" />
-    <constant name="BackwardMPGDMod1_y"            value="BackwardMPGDMod1_rmax * cos(BackwardMPGDEndcapMod_angle/2) - BackwardMPGDMod1_rmin" />
-    <constant name="BackwardMPGDMod2_x1"           value="2 * BackwardMPGDMod2_rmin * tan(BackwardMPGDEndcapMod_angle/2)" />
-    <constant name="BackwardMPGDMod2_x2"           value="2 * BackwardMPGDMod2_rmax * sin(BackwardMPGDEndcapMod_angle/2)" />
-    <constant name="BackwardMPGDMod2_y"            value="BackwardMPGDMod2_rmax * cos(BackwardMPGDEndcapMod_angle/2) - BackwardMPGDMod2_rmin" />
-  </define>
+      <module name="BackwardMPGDQuadModule2" vis="MPGDModuleVis">
+        <trd x1="BackwardMPGDQuad_inner_width/2" x2="BackwardMPGDQuad_outer_width/2" z="BackwardMPGDQuad_length/2" />
+        <overlap x="BackwardMPGDQuad_overlap_half_width" z="(BackwardMPGDQuad_active_outer_radius-BackwardMPGDQuad_inner_radius)/2" />
+        <module_component thickness="BackwardMPGDQuad_anode_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_anode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_skin" material="Fiberglass" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_pcb" material="Fr4" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_honeycomb" material="Honeycomb" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_transfer_gas" material="Ar90IsoButane" sensitive="false" vis="MPGDVis" />
+        <module_component name="drift_gas" thickness="BackwardMPGDQuad_drift_gas" material="Ar90IsoButane" sensitive="true" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_honeycomb" material="Honeycomb" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_gem_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_gem_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_gem_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_gem_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_cathode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_skin" material="Fiberglass" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_cathode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="BackwardMPGDQuad_cathode_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+      </module>
 
-    <detectors>
-      <detector
-        id="TrackerEndcapN_4_ID"
-        name="BackwardMPGD"
-        type="epic_TrapEndcapTracker"
-        actsType="endcap"
-        readout="BackwardMPGDEndcapHits"
-        vis="MPGDVis"
-        reflect="true">
-        <type_flags type="DetType_TRACKER + DetType_ENDCAP"/>
-        <module name="BackwardModule1" vis="MPGDModuleVis">
-          <trd x1="BackwardMPGDMod1_x1/2.0" x2="BackwardMPGDMod1_x2/2.0" z="BackwardMPGDMod1_y/2"/>
-          <comment> Window and drift region </comment>
-          <module_component name="DriftGap"           thickness="BackwardMPGDDriftGap_thickness" material="Ar90IsoButane" sensitive="true" vis="MPGDVis"/>
-          <module_component name="WindowGasGap"       thickness="BackwardMPGDWindowGap_thickness" material="Ar90IsoButane" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Window"             thickness="BackwardMPGDWindow_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <comment> HV Cathode </comment>
-          <module_component name="Cathode Kapton"     thickness="BackwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Cathode Cu"         thickness="BackwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <comment> Amplification foil (urwell) </comment>
-          <module_component name="RWell Cu"           thickness="BackwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="RWell Kapton"       thickness="BackwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <comment> Readout/Backboard </comment>
-          <module_component name="Readout Nomex"      thickness="BackwardMPGDReadOutNomex_thickness" material="Nomex" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout Electrodes" thickness="BackwardMPGDReadOutElectrode_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout Kapton"     thickness="BackwardMPGDReadOutKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout PCB"        thickness="BackwardMPGDPCB_thickness" material="Fr4" sensitive="false" vis="MPGDVis"/>
-        </module>
+      <layer id="1">
+        <envelope vis="MPGDLayerVis" rmin="BackwardMPGDQuad_inner_radius" rmax="BackwardMPGDQuad_outer_radius + BackwardMPGDQuad_overlap_half_width" length="BackwardMPGDQuad_layer_length" zstart="BackwardMPGDQuad_z1" />
+        <layer_material surface="inner" binning="binPhi,binR" bins0="4*BackwardMPGDQuad_modules_per_quadrant" bins1="50" />
+        <layer_material surface="outer" binning="binPhi,binR" bins0="4*BackwardMPGDQuad_modules_per_quadrant" bins1="50" />
+        <ring r="BackwardMPGDQuad_inner_radius + BackwardMPGDQuad_length/2" zstart="0" dz="0" dz_offset="BackwardMPGDQuad_stagger" phi0="BackwardMPGDQuad_angle/2" modules_per_quadrant="BackwardMPGDQuad_modules_per_quadrant" module="BackwardMPGDQuadModule1">
+          <overlap quadrant="0" x="-BackwardMPGDQuad_overlap_radius" y="BackwardMPGDQuad_overlap_half_width" rotation="-90*degree" />
+          <overlap quadrant="1" x="-BackwardMPGDQuad_overlap_half_width" y="-BackwardMPGDQuad_overlap_radius" rotation="180*degree" />
+          <overlap quadrant="2" x="BackwardMPGDQuad_overlap_radius" y="-BackwardMPGDQuad_overlap_half_width" rotation="90*degree" />
+          <overlap quadrant="3" x="BackwardMPGDQuad_overlap_half_width" y="BackwardMPGDQuad_overlap_radius" rotation="0*degree" />
+        </ring>
+      </layer>
 
-        <module name="BackwardModule2" vis="MPGDModuleVis">
-          <trd x1="BackwardMPGDMod2_x1/2.0" x2="BackwardMPGDMod2_x2/2.0" z="BackwardMPGDMod2_y/2"/>
-          <comment> Window and drift region </comment>
-          <module_component name="DriftGap"           thickness="BackwardMPGDDriftGap_thickness" material="Ar90IsoButane" sensitive="true" vis="MPGDVis"/>
-          <module_component name="WindowGasGap"       thickness="BackwardMPGDWindowGap_thickness" material="Ar90IsoButane" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Window"             thickness="BackwardMPGDWindow_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <comment> HV Cathode </comment>
-          <module_component name="Cathode Kapton"     thickness="BackwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Cathode Cu"         thickness="BackwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <comment> Amplification foil (urwell) </comment>
-          <module_component name="RWell Cu"           thickness="BackwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="RWell Kapton"       thickness="BackwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <comment> Readout/Backboard </comment>
-          <module_component name="Readout Nomex"      thickness="BackwardMPGDReadOutNomex_thickness" material="Nomex" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout Electrodes" thickness="BackwardMPGDReadOutElectrode_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout Kapton"     thickness="BackwardMPGDReadOutKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout PCB"        thickness="BackwardMPGDPCB_thickness" material="Fr4" sensitive="false" vis="MPGDVis"/>
-        </module>
-
-        <layer id="0">
-          <envelope  vis="MPGDLayerVis"
-            rmin="BackwardMPGDLayer1_rmin"
-            rmax="BackwardMPGDLayer1_rmax"
-            length="BackwardMPGDEndcapLayer_thickness"
-            zstart="BackwardMPGDLayer1_zmin" />
-          <layer_material surface="inner" binning="binPhi,binR" bins0="BackwardMPGDEndcapMod_count" bins1="50"/>
-          <layer_material surface="outer" binning="binPhi,binR" bins0="BackwardMPGDEndcapMod_count" bins1="50"/>
-          <ring
-            r="BackwardMPGDMod1_rmin + BackwardMPGDMod1_y/2.0"
-            zstart="0"
-            nmodules="BackwardMPGDEndcapMod_count"
-            dz="BackwardMPGDEndcapMod_dz"
-            module="BackwardModule1" />
-        </layer>
-
-        <layer id="1">
-          <envelope  vis="MPGDLayerVis"
-            rmin="BackwardMPGDLayer2_rmin"
-            rmax="BackwardMPGDLayer2_rmax"
-            length="BackwardMPGDEndcapLayer_thickness"
-            zstart="BackwardMPGDLayer2_zmin" />
-        <layer_material surface="inner" binning="binPhi,binR" bins0="BackwardMPGDEndcapMod_count" bins1="50"/>
-        <layer_material surface="outer" binning="binPhi,binR" bins0="BackwardMPGDEndcapMod_count" bins1="50"/>
-          <ring
-            r="BackwardMPGDMod2_rmin + BackwardMPGDMod2_y/2.0"
-            zstart="0"
-            nmodules="BackwardMPGDEndcapMod_count"
-            dz="BackwardMPGDEndcapMod_dz"
-            module="BackwardModule2" />
-        </layer>
-      </detector>
+      <layer id="2">
+        <envelope vis="MPGDLayerVis" rmin="BackwardMPGDQuad_inner_radius" rmax="BackwardMPGDQuad_outer_radius + BackwardMPGDQuad_overlap_half_width" length="BackwardMPGDQuad_layer_length" zstart="BackwardMPGDQuad_z2" />
+        <layer_material surface="inner" binning="binPhi,binR" bins0="4*BackwardMPGDQuad_modules_per_quadrant" bins1="50" />
+        <layer_material surface="outer" binning="binPhi,binR" bins0="4*BackwardMPGDQuad_modules_per_quadrant" bins1="50" />
+        <ring r="BackwardMPGDQuad_inner_radius + BackwardMPGDQuad_length/2" zstart="0" dz="0" dz_offset="BackwardMPGDQuad_stagger" phi0="BackwardMPGDQuad_angle/2" modules_per_quadrant="BackwardMPGDQuad_modules_per_quadrant" module="BackwardMPGDQuadModule2">
+          <overlap quadrant="0" x="-BackwardMPGDQuad_overlap_radius" y="BackwardMPGDQuad_overlap_half_width" rotation="-90*degree" />
+          <overlap quadrant="1" x="-BackwardMPGDQuad_overlap_half_width" y="-BackwardMPGDQuad_overlap_radius" rotation="180*degree" />
+          <overlap quadrant="2" x="BackwardMPGDQuad_overlap_radius" y="-BackwardMPGDQuad_overlap_half_width" rotation="90*degree" />
+          <overlap quadrant="3" x="BackwardMPGDQuad_overlap_half_width" y="BackwardMPGDQuad_overlap_radius" rotation="0*degree" />
+        </ring>
+      </layer>
+    </detector>
   </detectors>
 
   <plugins>
     <plugin name="DD4hep_ParametersPlugin">
-      <argument value="BackwardMPGD"/>
-      <argument value="layer_pattern: str=BackwardMPGD_layer\d_N"/>
+      <argument value="BackwardMPGD" />
+      <argument value="layer_pattern: str=BackwardMPGD_layer\d_N" />
     </plugin>
   </plugins>
 
@@ -157,5 +122,4 @@
       <id>system:8,layer:2,module:6,sensor:16,x:32:-16,z:-16</id>
     </readout>
   </readouts>
-
 </lccdd>

--- a/compact/tracking/mpgd_backward_endcap.xml
+++ b/compact/tracking/mpgd_backward_endcap.xml
@@ -8,9 +8,9 @@
     <constant name="BackwardMPGDQuad_z1" value="BackwardMPGD_z1" />
     <constant name="BackwardMPGDQuad_z2" value="BackwardMPGD_z2" />
     <constant name="BackwardMPGDQuad_stagger" value="16*mm" />
-    <constant name="BackwardMPGDQuad_inner_radius" value="50*mm" />
-    <constant name="BackwardMPGDQuad_outer_radius" value="500*mm" />
-    <constant name="BackwardMPGDQuad_active_outer_radius" value="468*mm"/>
+    <constant name="BackwardMPGDQuad_inner_radius" value="BackwardMPGDMod_rmin" />
+    <constant name="BackwardMPGDQuad_outer_radius" value="BackwardMPGDMod_rmax" />
+    <constant name="BackwardMPGDQuad_active_outer_radius" value="420*mm"/>
     <constant name="BackwardMPGDQuad_overlap_half_width" value="12.5*mm" />
     <constant name="BackwardMPGDQuad_overlap_radius" value="(BackwardMPGDQuad_inner_radius + BackwardMPGDQuad_outer_radius)/2" />
 
@@ -43,7 +43,7 @@
 
       <module name="BackwardMPGDQuadModule1" vis="MPGDModuleVis">
         <trd x1="BackwardMPGDQuad_inner_width/2" x2="BackwardMPGDQuad_outer_width/2" z="BackwardMPGDQuad_length/2" />
-        <overlap x="BackwardMPGDQuad_overlap_half_width" z="(BackwardMPGDQuad_active_outer_radius-BackwardMPGDQuad_inner_radius)/2" />
+	<overlap x="BackwardMPGDQuad_overlap_half_width" z="(BackwardMPGDQuad_active_outer_radius-BackwardMPGDQuad_inner_radius)/2" />
         <module_component thickness="BackwardMPGDQuad_cathode_cu" material="Copper" sensitive="false" vis="MPGDVis" />
         <module_component thickness="BackwardMPGDQuad_cathode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
         <module_component thickness="BackwardMPGDQuad_skin" material="Fiberglass" sensitive="false" vis="MPGDVis" />

--- a/compact/tracking/mpgd_backward_endcap.xml
+++ b/compact/tracking/mpgd_backward_endcap.xml
@@ -43,7 +43,7 @@
 
       <module name="BackwardMPGDQuadModule1" vis="MPGDModuleVis">
         <trd x1="BackwardMPGDQuad_inner_width/2" x2="BackwardMPGDQuad_outer_width/2" z="BackwardMPGDQuad_length/2" />
-	<overlap x="BackwardMPGDQuad_overlap_half_width" z="(BackwardMPGDQuad_active_outer_radius-BackwardMPGDQuad_inner_radius)/2" />
+        <overlap x="BackwardMPGDQuad_overlap_half_width" z="(BackwardMPGDQuad_active_outer_radius-BackwardMPGDQuad_inner_radius)/2" />
         <module_component thickness="BackwardMPGDQuad_cathode_cu" material="Copper" sensitive="false" vis="MPGDVis" />
         <module_component thickness="BackwardMPGDQuad_cathode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
         <module_component thickness="BackwardMPGDQuad_skin" material="Fiberglass" sensitive="false" vis="MPGDVis" />

--- a/compact/tracking/mpgd_forward_endcap.xml
+++ b/compact/tracking/mpgd_forward_endcap.xml
@@ -5,13 +5,12 @@
     <constant name="ForwardMPGDQuad_nlayers" value="2" />
     <constant name="ForwardMPGDQuad_modules_per_quadrant" value="12" />
     <constant name="ForwardMPGDQuad_angle" value="360*degree/(4*ForwardMPGDQuad_modules_per_quadrant)" />
-    <!-- Main defines ForwardMPGD_zmin.  These retain the supplied 1261/1379 mm layout. -->
     <constant name="ForwardMPGDQuad_z1" value="ForwardMPGD_z1" />
     <constant name="ForwardMPGDQuad_z2" value="ForwardMPGD_z2" />
     <constant name="ForwardMPGDQuad_stagger" value="16*mm" />
-    <constant name="ForwardMPGDQuad_inner_radius" value="90*mm" />
-    <constant name="ForwardMPGDQuad_outer_radius" value="500*mm" />
-    <constant name="ForwardMPGDQuad_active_outer_radius" value="468*mm" />
+    <constant name="ForwardMPGDQuad_inner_radius" value="ForwardMPGDMod_rmin" />
+    <constant name="ForwardMPGDQuad_outer_radius" value="ForwardMPGDMod_rmax" />
+    <constant name="ForwardMPGDQuad_active_outer_radius" value="420*mm" />
     <constant name="ForwardMPGDQuad_overlap_half_width" value="12.5*mm" />
     <constant name="ForwardMPGDQuad_overlap_radius" value="(ForwardMPGDQuad_inner_radius + ForwardMPGDQuad_outer_radius)/2" />
 

--- a/compact/tracking/mpgd_forward_endcap.xml
+++ b/compact/tracking/mpgd_forward_endcap.xml
@@ -1,154 +1,121 @@
 <!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
-<!-- Copyright (C) 2022 Nicolas Schmidt -->
-
+<!-- Four-quadrant forward MPGD endcap.  Requires the constants patch shipped beside this file. -->
 <lccdd>
   <define>
-    <comment>
-      --------------------------
-      Forward MPGD Parameters
-      --------------------------
-    </comment>
-    <comment> Forward MPGD position </comment>
-    <constant name="ForwardMPGD_nlayers"             value="2"/>
-    <constant name="ForwardMPGD_AllowedSpace"        value="2.5*cm"/>
+    <constant name="ForwardMPGDQuad_nlayers" value="2" />
+    <constant name="ForwardMPGDQuad_modules_per_quadrant" value="12" />
+    <constant name="ForwardMPGDQuad_angle" value="360*degree/(4*ForwardMPGDQuad_modules_per_quadrant)" />
+    <!-- Main defines ForwardMPGD_zmin.  These retain the supplied 1261/1379 mm layout. -->
+    <constant name="ForwardMPGDQuad_z1" value="ForwardMPGD_z1" />
+    <constant name="ForwardMPGDQuad_z2" value="ForwardMPGD_z2" />
+    <constant name="ForwardMPGDQuad_stagger" value="16*mm" />
+    <constant name="ForwardMPGDQuad_inner_radius" value="90*mm" />
+    <constant name="ForwardMPGDQuad_outer_radius" value="500*mm" />
+    <constant name="ForwardMPGDQuad_active_outer_radius" value="468*mm" />
+    <constant name="ForwardMPGDQuad_overlap_half_width" value="12.5*mm" />
+    <constant name="ForwardMPGDQuad_overlap_radius" value="(ForwardMPGDQuad_inner_radius + ForwardMPGDQuad_outer_radius)/2" />
 
-    <comment> Parameters for the endcap MPGDs </comment>
-    <constant name="ForwardMPGDEndcapMod_count"             value="48" />
-    <constant name="ForwardMPGDEndcapMod_dz"                value="0" />
-    <constant name="ForwardMPGDEndcapMod_overlap"           value="0" />
+    <constant name="ForwardMPGDQuad_cathode_cu" value="5*um" />
+    <constant name="ForwardMPGDQuad_cathode_kapton" value="50*um" />
+    <constant name="ForwardMPGDQuad_skin" value="100*um" />
+    <constant name="ForwardMPGDQuad_gem_kapton" value="50*um" />
+    <constant name="ForwardMPGDQuad_gem_cu" value="5*um" />
+    <constant name="ForwardMPGDQuad_honeycomb" value="3*mm" />
+    <constant name="ForwardMPGDQuad_drift_gas" value="6*mm" />
+    <constant name="ForwardMPGDQuad_transfer_gas" value="3*mm" />
+    <constant name="ForwardMPGDQuad_pcb" value="135*um" />
+    <constant name="ForwardMPGDQuad_anode_kapton" value="50*um" />
+    <constant name="ForwardMPGDQuad_anode_cu" value="5*um" />
 
-    <comment> Layer definitions around the sensor for the endcap MPGDs </comment>
-    <constant name="ForwardMPGDDriftGap_thickness"           value="3.0*mm" />
-    <constant name="ForwardMPGDWindow_thickness"             value="50*um"/>
-    <constant name="ForwardMPGDWindowGap_thickness"          value="2*mm"/>
-    <constant name="ForwardMPGDFoilCu_thickness"             value="5*um"/>
-    <constant name="ForwardMPGDReadOutElectrode_thickness"   value="10*um"/>
-    <constant name="ForwardMPGDFoilKapton_thickness"         value="50*um"/>
-    <constant name="ForwardMPGDReadOutNomex_thickness"       value="50*um"/>
-    <constant name="ForwardMPGDReadOutKapton_thickness"      value="50*um"/>
-    <constant name="ForwardMPGDPCB_thickness"                value="1.5*mm"/>
-  </define>
+    <constant name="ForwardMPGDQuad_thickness"
+      value="2*ForwardMPGDQuad_cathode_cu + 2*ForwardMPGDQuad_cathode_kapton + 2*ForwardMPGDQuad_skin + ForwardMPGDQuad_gem_kapton + 3*ForwardMPGDQuad_gem_cu + 2*ForwardMPGDQuad_honeycomb + ForwardMPGDQuad_drift_gas + ForwardMPGDQuad_transfer_gas + ForwardMPGDQuad_pcb + ForwardMPGDQuad_anode_kapton + ForwardMPGDQuad_anode_cu" />
+    <constant name="ForwardMPGDQuad_layer_length" value="ForwardMPGDQuad_thickness + 2*ForwardMPGDQuad_stagger" />
 
-  <comment>
-    Actual detector implementation.
-  </comment>
-  <define>
-    <constant name="ForwardMPGDEndcapMod_angle"         value="360.0*degree/ForwardMPGDEndcapMod_count*(1.0 + ForwardMPGDEndcapMod_overlap)" />
-    <comment> 1 um padding to not have layer and module touch (ACTS requirement) </comment>
-    <constant name="ForwardMPGDLayerPad"                    value="0*um"/>
-    <comment> Detector thickness </comment>
-    <constant name="ForwardMPGDCathode_thickness" value="ForwardMPGDFoilKapton_thickness + ForwardMPGDFoilCu_thickness"/>
-    <constant name="ForwardMPGDRWell_thickness"   value="ForwardMPGDFoilKapton_thickness + ForwardMPGDFoilCu_thickness"/>
-    <constant name="ForwardMPGDReadOut_thickness"  value="ForwardMPGDReadOutNomex_thickness + ForwardMPGDReadOutElectrode_thickness + ForwardMPGDReadOutKapton_thickness "/>
-    <comment>@TODO: have space for 3 frames (2mm + 2mm + 3mm) need to add frame material </comment>
-    <constant name="ForwardMPGDFrame_thickness"   value="2*ForwardMPGDWindowGap_thickness + ForwardMPGDDriftGap_thickness"/>
-    <constant name="ForwardMPGDEndcapMod_thickness"  value="ForwardMPGDCathode_thickness + ForwardMPGDRWell_thickness + ForwardMPGDReadOut_thickness + ForwardMPGDFrame_thickness"/>
-    <constant name="ForwardMPGDEndcapLayer_thickness"   value="ForwardMPGDEndcapMod_thickness + 2 * ForwardMPGDEndcapMod_dz + ForwardMPGDLayerPad" />
-
-    <constant name="ForwardMPGDMod1_zmin"        value="ForwardMPGD_zmin" />
-    <constant name="ForwardMPGDMod2_zmin"        value="ForwardMPGD_zmin + ForwardMPGDMod_offset" />
-    <constant name="ForwardMPGDLayer1_rmin"       value="ForwardMPGDMod1_rmin - ForwardMPGDLayerPad" />
-    <constant name="ForwardMPGDLayer2_rmin"       value="ForwardMPGDMod2_rmin - ForwardMPGDLayerPad" />
-    <constant name="ForwardMPGDLayer1_rmax"       value="ForwardMPGDMod1_rmax + ForwardMPGDLayerPad" />
-    <constant name="ForwardMPGDLayer2_rmax"       value="ForwardMPGDMod2_rmax + ForwardMPGDLayerPad" />
-    <constant name="ForwardMPGDLayer1_zmin"       value="ForwardMPGDMod1_zmin - ForwardMPGDLayerPad" />
-    <constant name="ForwardMPGDLayer2_zmin"       value="ForwardMPGDMod2_zmin + ForwardMPGDLayerPad" />
-
-    <constant name="ForwardMPGDMod1_x1"           value="2 * ForwardMPGDMod1_rmin * tan(ForwardMPGDEndcapMod_angle/2)" />
-    <constant name="ForwardMPGDMod1_x2"           value="2 * ForwardMPGDMod1_rmax * sin(ForwardMPGDEndcapMod_angle/2)" />
-    <constant name="ForwardMPGDMod1_y"            value="ForwardMPGDMod1_rmax * cos(ForwardMPGDEndcapMod_angle/2) - ForwardMPGDMod1_rmin" />
-    <constant name="ForwardMPGDMod2_x1"           value="2 * ForwardMPGDMod2_rmin * tan(ForwardMPGDEndcapMod_angle/2)" />
-    <constant name="ForwardMPGDMod2_x2"           value="2 * ForwardMPGDMod2_rmax * sin(ForwardMPGDEndcapMod_angle/2)" />
-    <constant name="ForwardMPGDMod2_y"            value="ForwardMPGDMod2_rmax * cos(ForwardMPGDEndcapMod_angle/2) - ForwardMPGDMod2_rmin" />
+    <!-- Trapezoid dimensions use the local Y axis as the detector thickness. -->
+    <constant name="ForwardMPGDQuad_inner_width" value="2*ForwardMPGDQuad_inner_radius*tan(ForwardMPGDQuad_angle/2)" />
+    <constant name="ForwardMPGDQuad_outer_width" value="2*ForwardMPGDQuad_outer_radius*sin(ForwardMPGDQuad_angle/2)" />
+    <constant name="ForwardMPGDQuad_length" value="ForwardMPGDQuad_outer_radius*cos(ForwardMPGDQuad_angle/2)-ForwardMPGDQuad_inner_radius" />
   </define>
 
   <detectors>
-      <detector
-        id="TrackerEndcapP_5_ID"
-        name="ForwardMPGD"
-        type="epic_TrapEndcapTracker"
-        actsType="endcap"
-        readout="ForwardMPGDEndcapHits"
-        vis="MPGDVis"
-        reflect="false">
-        <type_flags type="DetType_TRACKER + DetType_ENDCAP"/>
-        <module name="ForwardModule1" vis="MPGDModuleVis">
-          <trd x1="ForwardMPGDMod1_x1/2.0" x2="ForwardMPGDMod1_x2/2.0" z="ForwardMPGDMod1_y/2"/>
-          <comment> Window and drift region </comment>
-          <module_component name="DriftGap"           thickness="ForwardMPGDDriftGap_thickness" material="Ar90IsoButane" sensitive="true" vis="MPGDVis"/>
-          <module_component name="WindowGasGap"       thickness="ForwardMPGDWindowGap_thickness" material="Ar90IsoButane" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Window"             thickness="ForwardMPGDWindow_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <comment> HV Cathode </comment>
-          <module_component name="Cathode Kapton"     thickness="ForwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Cathode Cu"         thickness="ForwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <comment> Amplification foil (urwell) </comment>
-          <module_component name="RWell Cu"           thickness="ForwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="RWell Kapton"       thickness="ForwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <comment> Readout/Backboard </comment>
-          <module_component name="Readout Nomex"      thickness="ForwardMPGDReadOutNomex_thickness" material="Nomex" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout Electrodes" thickness="ForwardMPGDReadOutElectrode_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout Kapton"     thickness="ForwardMPGDReadOutKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout PCB"        thickness="ForwardMPGDPCB_thickness" material="Fr4" sensitive="false" vis="MPGDVis"/>
-        </module>
-        <module name="ForwardModule2" vis="MPGDModuleVis">
-          <trd x1="ForwardMPGDMod2_x1/2.0" x2="ForwardMPGDMod2_x2/2.0" z="ForwardMPGDMod2_y/2"/>
-          <comment> Window and drift region </comment>
-          <module_component name="DriftGap"           thickness="ForwardMPGDDriftGap_thickness" material="Ar90IsoButane" sensitive="true" vis="MPGDVis"/>
-          <module_component name="WindowGasGap"       thickness="ForwardMPGDWindowGap_thickness" material="Ar90IsoButane" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Window"             thickness="ForwardMPGDWindow_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <comment> HV Cathode </comment>
-          <module_component name="Cathode Kapton"     thickness="ForwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Cathode Cu"         thickness="ForwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <comment> Amplification foil (urwell) </comment>
-          <module_component name="RWell Cu"           thickness="ForwardMPGDFoilCu_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="RWell Kapton"       thickness="ForwardMPGDFoilKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <comment> Readout/Backboard </comment>
-          <module_component name="Readout Nomex"      thickness="ForwardMPGDReadOutNomex_thickness" material="Nomex" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout Electrodes" thickness="ForwardMPGDReadOutElectrode_thickness" material="Copper" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout Kapton"     thickness="ForwardMPGDReadOutKapton_thickness" material="Kapton" sensitive="false" vis="MPGDVis"/>
-          <module_component name="Readout PCB"        thickness="ForwardMPGDPCB_thickness" material="Fr4" sensitive="false" vis="MPGDVis"/>
-        </module>
+    <detector id="TrackerEndcapP_5_ID" name="ForwardMPGD" type="epic_MPGDQuadrantEndcapTracker"
+              actsType="endcap" readout="ForwardMPGDEndcapHits" vis="MPGDVis" reflect="false">
+      <type_flags type="DetType_TRACKER + DetType_ENDCAP" />
 
-        <layer id="0">
-          <envelope  vis="MPGDLayerVis"
-            rmin="ForwardMPGDLayer1_rmin"
-            rmax="ForwardMPGDLayer1_rmax"
-            length="ForwardMPGDEndcapLayer_thickness"
-            zstart="ForwardMPGDLayer1_zmin" />
-          <layer_material surface="inner" binning="binPhi,binR" bins0="ForwardMPGDEndcapMod_count" bins1="30"/>
-          <layer_material surface="outer" binning="binPhi,binR" bins0="ForwardMPGDEndcapMod_count" bins1="30"/>
+      <!-- Layer 1 stack: cathode faces +z, drift gas is component 9/sensor 1. -->
+      <module name="ForwardMPGDQuadModule1" vis="MPGDModuleVis">
+        <trd x1="ForwardMPGDQuad_inner_width/2" x2="ForwardMPGDQuad_outer_width/2" z="ForwardMPGDQuad_length/2" />
+        <overlap x="ForwardMPGDQuad_overlap_half_width" z="(ForwardMPGDQuad_active_outer_radius-ForwardMPGDQuad_inner_radius)/2" />
+        <module_component thickness="ForwardMPGDQuad_cathode_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_cathode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_skin" material="Fiberglass" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_cathode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_gem_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_gem_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_gem_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_gem_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_honeycomb" material="Honeycomb" sensitive="false" vis="MPGDVis" />
+        <module_component name="drift_gas" thickness="ForwardMPGDQuad_drift_gas" material="Ar90IsoButane" sensitive="true" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_transfer_gas" material="Ar90IsoButane" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_honeycomb" material="Honeycomb" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_pcb" material="Fr4" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_skin" material="Fiberglass" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_anode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_anode_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+      </module>
 
-          <ring
-            r="ForwardMPGDMod1_rmin + ForwardMPGDMod1_y/2.0"
-            zstart="0"
-            nmodules="ForwardMPGDEndcapMod_count"
-            dz="ForwardMPGDEndcapMod_dz"
-            module="ForwardModule1" />
-        </layer>
+      <!-- Layer 2 is read out from the opposite face, retaining the existing ePIC convention. -->
+      <module name="ForwardMPGDQuadModule2" vis="MPGDModuleVis">
+        <trd x1="ForwardMPGDQuad_inner_width/2" x2="ForwardMPGDQuad_outer_width/2" z="ForwardMPGDQuad_length/2" />
+        <overlap x="ForwardMPGDQuad_overlap_half_width" z="(ForwardMPGDQuad_active_outer_radius-ForwardMPGDQuad_inner_radius)/2" />
+        <module_component thickness="ForwardMPGDQuad_anode_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_anode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_skin" material="Fiberglass" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_pcb" material="Fr4" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_honeycomb" material="Honeycomb" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_transfer_gas" material="Ar90IsoButane" sensitive="false" vis="MPGDVis" />
+        <module_component name="drift_gas" thickness="ForwardMPGDQuad_drift_gas" material="Ar90IsoButane" sensitive="true" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_honeycomb" material="Honeycomb" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_gem_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_gem_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_gem_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_gem_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_cathode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_skin" material="Fiberglass" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_cathode_kapton" material="Kapton" sensitive="false" vis="MPGDVis" />
+        <module_component thickness="ForwardMPGDQuad_cathode_cu" material="Copper" sensitive="false" vis="MPGDVis" />
+      </module>
 
-        <layer id="1">
-          <envelope  vis="MPGDLayerVis"
-            rmin="ForwardMPGDLayer2_rmin"
-            rmax="ForwardMPGDLayer2_rmax"
-            length="ForwardMPGDEndcapLayer_thickness"
-            zstart="ForwardMPGDLayer2_zmin" />
-          <layer_material surface="inner" binning="binPhi,binR" bins0="ForwardMPGDEndcapMod_count" bins1="30"/>
-          <layer_material surface="outer" binning="binPhi,binR" bins0="ForwardMPGDEndcapMod_count" bins1="30"/>
+      <layer id="1">
+        <envelope vis="MPGDLayerVis" rmin="ForwardMPGDQuad_inner_radius" rmax="ForwardMPGDQuad_outer_radius + ForwardMPGDQuad_overlap_half_width" length="ForwardMPGDQuad_layer_length" zstart="ForwardMPGDQuad_z1" />
+        <layer_material surface="inner" binning="binPhi,binR" bins0="4*ForwardMPGDQuad_modules_per_quadrant" bins1="50" />
+        <layer_material surface="outer" binning="binPhi,binR" bins0="4*ForwardMPGDQuad_modules_per_quadrant" bins1="50" />
+        <ring r="ForwardMPGDQuad_inner_radius + ForwardMPGDQuad_length/2" zstart="0" dz="0" dz_offset="ForwardMPGDQuad_stagger" phi0="ForwardMPGDQuad_angle/2" modules_per_quadrant="ForwardMPGDQuad_modules_per_quadrant" module="ForwardMPGDQuadModule1">
+          <overlap quadrant="0" x="-ForwardMPGDQuad_overlap_radius" y="ForwardMPGDQuad_overlap_half_width" rotation="-90*degree" />
+          <overlap quadrant="1" x="-ForwardMPGDQuad_overlap_half_width" y="-ForwardMPGDQuad_overlap_radius" rotation="180*degree" />
+          <overlap quadrant="2" x="ForwardMPGDQuad_overlap_radius" y="-ForwardMPGDQuad_overlap_half_width" rotation="90*degree" />
+          <overlap quadrant="3" x="ForwardMPGDQuad_overlap_half_width" y="ForwardMPGDQuad_overlap_radius" rotation="0*degree" />
+        </ring>
+      </layer>
 
-          <ring
-            r="ForwardMPGDMod2_rmin + ForwardMPGDMod2_y/2.0"
-            zstart="0"
-            nmodules="ForwardMPGDEndcapMod_count"
-            dz="ForwardMPGDEndcapMod_dz"
-            module="ForwardModule2" />
-        </layer>
-      </detector>
+      <layer id="2">
+        <envelope vis="MPGDLayerVis" rmin="ForwardMPGDQuad_inner_radius" rmax="ForwardMPGDQuad_outer_radius + ForwardMPGDQuad_overlap_half_width" length="ForwardMPGDQuad_layer_length" zstart="ForwardMPGDQuad_z2" />
+        <layer_material surface="inner" binning="binPhi,binR" bins0="4*ForwardMPGDQuad_modules_per_quadrant" bins1="50" />
+        <layer_material surface="outer" binning="binPhi,binR" bins0="4*ForwardMPGDQuad_modules_per_quadrant" bins1="50" />
+        <ring r="ForwardMPGDQuad_inner_radius + ForwardMPGDQuad_length/2" zstart="0" dz="0" dz_offset="ForwardMPGDQuad_stagger" phi0="ForwardMPGDQuad_angle/2" modules_per_quadrant="ForwardMPGDQuad_modules_per_quadrant" module="ForwardMPGDQuadModule2">
+          <overlap quadrant="0" x="-ForwardMPGDQuad_overlap_radius" y="ForwardMPGDQuad_overlap_half_width" rotation="-90*degree" />
+          <overlap quadrant="1" x="-ForwardMPGDQuad_overlap_half_width" y="-ForwardMPGDQuad_overlap_radius" rotation="180*degree" />
+          <overlap quadrant="2" x="ForwardMPGDQuad_overlap_radius" y="-ForwardMPGDQuad_overlap_half_width" rotation="90*degree" />
+          <overlap quadrant="3" x="ForwardMPGDQuad_overlap_half_width" y="ForwardMPGDQuad_overlap_radius" rotation="0*degree" />
+        </ring>
+      </layer>
+    </detector>
   </detectors>
 
   <plugins>
     <plugin name="DD4hep_ParametersPlugin">
-      <argument value="ForwardMPGD"/>
-      <argument value="layer_pattern: str=ForwardMPGD_layer\d_P"/>
+      <argument value="ForwardMPGD" />
+      <argument value="layer_pattern: str=ForwardMPGD_layer\d_P" />
     </plugin>
   </plugins>
 
@@ -158,5 +125,4 @@
       <id>system:8,layer:2,module:6,sensor:16,x:32:-16,z:-16</id>
     </readout>
   </readouts>
-
 </lccdd>

--- a/configurations/mpgd_bect.yml
+++ b/configurations/mpgd_bect.yml
@@ -1,0 +1,4 @@
+features:
+  tracking:
+    definitions_craterlake:
+    mpgd_backward_endcap:

--- a/configurations/mpgd_ect.yml
+++ b/configurations/mpgd_ect.yml
@@ -1,0 +1,7 @@
+features:
+  beampipe:
+  tracking:
+    definitions_craterlake:
+    support_service_craterlake:
+    mpgd_forward_endcap:
+    mpgd_backward_endcap:

--- a/configurations/mpgd_fect.yml
+++ b/configurations/mpgd_fect.yml
@@ -1,0 +1,4 @@
+features:
+  tracking:
+    definitions_craterlake:
+    mpgd_forward_endcap:

--- a/src/MPGDQuadrantEndcapTracker.cpp
+++ b/src/MPGDQuadrantEndcapTracker.cpp
@@ -41,10 +41,10 @@ struct ModulePair {
 ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensitiveDetector,
                                xml_comp_t xModule, const std::string& suffix, bool isOverlap) {
   const std::string moduleName = xModule.nameStr() + suffix;
-  const xml_comp_t trd = xModule.trd();
-  const double x1 = trd.x1();
-  const double x2 = trd.x2();
-  const double halfLength = trd.z();
+  const xml_comp_t trd         = xModule.trd();
+  const double x1              = trd.x1();
+  const double x2              = trd.x2();
+  const double halfLength      = trd.z();
 
   double totalThickness = 0.0;
   for (xml_coll_t component(xModule, _U(module_component)); component; ++component) {
@@ -52,13 +52,13 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
   }
 
   Solid moduleSolid;
-  double overlapHalfWidth = 0.0;
+  double overlapHalfWidth  = 0.0;
   double overlapHalfLength = 0.0;
   if (isOverlap) {
     xml_comp_t xOverlap = xModule.child(_U(overlap));
-    overlapHalfWidth = xOverlap.x();
-    overlapHalfLength = xOverlap.z();
-    moduleSolid = Box(overlapHalfWidth, totalThickness / 2.0, overlapHalfLength);
+    overlapHalfWidth    = xOverlap.x();
+    overlapHalfLength   = xOverlap.z();
+    moduleSolid         = Box(overlapHalfWidth, totalThickness / 2.0, overlapHalfLength);
   } else {
     moduleSolid = Trapezoid(x1, x2, totalThickness / 2.0, totalThickness / 2.0, halfLength);
   }
@@ -67,12 +67,12 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
   prototype.volume = Volume(moduleName, moduleSolid, description.vacuum());
   prototype.volume.setVisAttributes(description.visAttributes(xModule.visStr()));
 
-  double positionY = -totalThickness / 2.0;
+  double positionY       = -totalThickness / 2.0;
   double thicknessBefore = 0.0;
-  int componentId = 0;
-  int sensorId = 1;
+  int componentId        = 0;
+  int sensorId           = 1;
   for (xml_coll_t component(xModule, _U(module_component)); component; ++component, ++componentId) {
-    xml_comp_t xComponent = component;
+    xml_comp_t xComponent  = component;
     const double thickness = xComponent.thickness();
     const std::string componentName =
         getAttrOrDefault(xComponent, _Unicode(name), _toString(componentId, "component%d"));
@@ -81,8 +81,8 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
     if (isOverlap) {
       componentSolid = Box(overlapHalfWidth, thickness / 2.0, overlapHalfLength);
     } else {
-      const double componentX1 = getAttrOrDefault(xComponent, _Unicode(x1), x1);
-      const double componentX2 = getAttrOrDefault(xComponent, _Unicode(x2), x2);
+      const double componentX1         = getAttrOrDefault(xComponent, _Unicode(x1), x1);
+      const double componentX2         = getAttrOrDefault(xComponent, _Unicode(x2), x2);
       const double componentHalfLength = getAttrOrDefault(xComponent, _Unicode(height), halfLength);
       componentSolid = Trapezoid(componentX1, componentX2, thickness / 2.0, thickness / 2.0,
                                  componentHalfLength);
@@ -91,13 +91,13 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
     Volume componentVolume(componentName + suffix, componentSolid,
                            description.material(xComponent.materialStr()));
     componentVolume.setVisAttributes(description.visAttributes(xComponent.visStr()));
-    PlacedVolume componentPlacement =
-        prototype.volume.placeVolume(componentVolume, Position(0.0, positionY + thickness / 2.0, 0.0));
+    PlacedVolume componentPlacement = prototype.volume.placeVolume(
+        componentVolume, Position(0.0, positionY + thickness / 2.0, 0.0));
 
     if (xComponent.isSensitive()) {
       if (sensorId > 2) {
         throw std::runtime_error(
-          "MPGDQuadrantEndcapTracker: at most two sensitive components are supported");
+            "MPGDQuadrantEndcapTracker: at most two sensitive components are supported");
       }
       componentPlacement.addPhysVolID("sensor", sensorId++);
       componentVolume.setSensitiveDetector(sensitiveDetector);
@@ -109,14 +109,11 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
       const Vector3D u(0.0, 0.0, -1.0);
       const Vector3D v(-1.0, 0.0, 0.0);
       const Vector3D n(0.0, 1.0, 0.0);
-      prototype.surfaces.emplace_back(componentVolume, type, innerThickness, outerThickness, u, v, n);
+      prototype.surfaces.emplace_back(componentVolume, type, innerThickness, outerThickness, u, v,
+                                      n);
       //MP-DEBUG
-      std::cout
-       << "Created surface for "
-       << componentVolume.name()
-       << " total surfaces = "
-       << prototype.surfaces.size()
-       << std::endl;
+      std::cout << "Created surface for " << componentVolume.name()
+                << " total surfaces = " << prototype.surfaces.size() << std::endl;
       //
     }
     positionY += thickness;
@@ -134,16 +131,13 @@ void addSensitiveDetElements(DetElement& moduleElement, const ModulePrototype& p
         DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(sensorElement);
     parameters.set<std::string>("axis_definitions", "XZY");
     sensorElement.setPlacement(placement);
-    
+
     //MP - DEBUG
-    std::cout
-    << "\nAttaching ACTS surface"
-    << "\n  Sensor = " << sensorElement.name()
-    << "\n  Module ID = " << moduleId
-    << "\n  Surface index = " << index
-    << "\n  Number of surfaces = " << prototype.surfaces.size()
-    << "\n  Number of placements = " << prototype.sensitivePlacements.size()
-    << std::endl;
+    std::cout << "\nAttaching ACTS surface"
+              << "\n  Sensor = " << sensorElement.name() << "\n  Module ID = " << moduleId
+              << "\n  Surface index = " << index
+              << "\n  Number of surfaces = " << prototype.surfaces.size()
+              << "\n  Number of placements = " << prototype.sensitivePlacements.size() << std::endl;
     //--
 
     volSurfaceList(sensorElement)->push_back(prototype.surfaces.at(index));
@@ -161,17 +155,17 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   std::cout << std::endl;
   //
 
-  xml_det_t xDetector = e;
-  const int detectorId = xDetector.id();
+  xml_det_t xDetector            = e;
+  const int detectorId           = xDetector.id();
   const std::string detectorName = xDetector.nameStr();
-  const bool reflect = xDetector.reflect(false);
+  const bool reflect             = xDetector.reflect(false);
 
   DetElement detector(detectorName, detectorId);
- 
+
   //MP DEBUG
   //std::cout << "Detector name = " << detName << std::endl;
   //
-  
+
   Assembly detectorAssembly(detectorName);
   detectorAssembly.setVisAttributes(description.invisible());
   sensitiveDetector.setType("tracker");
@@ -181,30 +175,29 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(detector);
   for (xml_coll_t boundaryMaterial(xDetector, _Unicode(boundary_material)); boundaryMaterial;
        ++boundaryMaterial) {
-    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(xml_comp_t(boundaryMaterial), detectorParameters,
-                                                    "boundary_material");
+    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(xml_comp_t(boundaryMaterial),
+                                                    detectorParameters, "boundary_material");
   }
 
   std::map<std::string, ModulePair> modules;
   for (xml_coll_t module(xDetector, _U(module)); module; ++module) {
     xml_comp_t xModule = module;
     ModulePair pair;
-    pair.normal = buildPrototype(description, sensitiveDetector, xModule, "", false);
+    pair.normal  = buildPrototype(description, sensitiveDetector, xModule, "", false);
     pair.overlap = buildPrototype(description, sensitiveDetector, xModule, "_overlap", true);
     modules.emplace(xModule.nameStr(), std::move(pair));
   }
 
   for (xml_coll_t layer(xDetector, _U(layer)); layer; ++layer) {
-    xml_comp_t xLayer = layer;
-    const int layerId = xLayer.id();
-    xml_comp_t xEnvelope = xLayer.child(_U(envelope));
+    xml_comp_t xLayer               = layer;
+    const int layerId               = xLayer.id();
+    xml_comp_t xEnvelope            = xLayer.child(_U(envelope));
     const std::string baseLayerName = detectorName + "_layer" + std::to_string(layerId);
-    const double layerLength = xEnvelope.length();
-    const double layerStart = xEnvelope.zstart();
-    const double layerCenter = layerStart + layerLength / 2.0;
+    const double layerLength        = xEnvelope.length();
+    const double layerStart         = xEnvelope.zstart();
+    const double layerCenter        = layerStart + layerLength / 2.0;
 
-    Volume layerVolume(baseLayerName,
-                       Tube(xEnvelope.rmin(), xEnvelope.rmax(), layerLength / 2.0),
+    Volume layerVolume(baseLayerName, Tube(xEnvelope.rmin(), xEnvelope.rmax(), layerLength / 2.0),
                        description.material("Air"));
     layerVolume.setVisAttributes(description.visAttributes(xEnvelope.visStr()));
     const Transform3D layerTransform =
@@ -224,30 +217,30 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
     int nextModuleId = 1;
     for (xml_coll_t ring(xLayer, _U(ring)); ring; ++ring) {
-      xml_comp_t xRing = ring;
+      xml_comp_t xRing             = ring;
       const ModulePair& modulePair = modules.at(xRing.moduleStr());
       const int modulesPerQuadrant = xRing.attr<int>(_Unicode(modules_per_quadrant));
-      const double radius = xRing.r();
-      const double phi0 = xRing.phi0(0.0);
-      const double localZ = xRing.zstart();
-      const double dz = xRing.dz(0.0);
+      const double radius          = xRing.r();
+      const double phi0            = xRing.phi0(0.0);
+      const double localZ          = xRing.zstart();
+      const double dz              = xRing.dz(0.0);
       const double quadrantStagger = getAttrOrDefault(xRing, _Unicode(dz_offset), 0.0);
-      const double phiStep = (M_PI / 2.0) / modulesPerQuadrant;
+      const double phiStep         = (M_PI / 2.0) / modulesPerQuadrant;
 
       for (int quadrantId = 0; quadrantId < 4; ++quadrantId) {
         const std::string quadrantName = "quadrant" + std::to_string(quadrantId);
         Assembly quadrantAssembly(baseLayerName + "_" + quadrantName);
         PlacedVolume quadrantPlacement = layerVolume.placeVolume(quadrantAssembly);
-	//quadrantPlacement.addPhysVolID("system",detector.id());
+        //quadrantPlacement.addPhysVolID("system",detector.id());
         DetElement quadrantElement(layerElement, quadrantName, quadrantId);
         quadrantElement.setPlacement(quadrantPlacement);
 
         const double zOffset = (quadrantId % 2 == 0) ? quadrantStagger : 0.0;
         for (int inQuadrant = 0; inQuadrant < modulesPerQuadrant; ++inQuadrant) {
           const double phi = phi0 + (quadrantId * modulesPerQuadrant + inQuadrant) * phiStep;
-          const double x = -radius * std::cos(phi);
-          const double y = -radius * std::sin(phi);
-          const double z = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
+          const double x   = -radius * std::cos(phi);
+          const double y   = -radius * std::sin(phi);
+          const double z   = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
           PlacedVolume modulePlacement = quadrantAssembly.placeVolume(
               modulePair.normal.volume,
               Transform3D(RotationZYX(0.0, -M_PI / 2.0 - phi, -M_PI / 2.0), Position(x, y, z)));
@@ -257,17 +250,13 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
           moduleElement.setPlacement(modulePlacement);
           addSensitiveDetElements(moduleElement, modulePair.normal, nextModuleId++);
 
-	   //MP DEBUG
-	  std::cout << "\n========== MODULE ==========\n";
+          //MP DEBUG
+          std::cout << "\n========== MODULE ==========\n";
           std::cout << "module = " << nextModuleId << std::endl;
           for (const auto& id : modulePlacement.volIDs()) {
-            std::cout << "  "
-              << id.first
-              << " = "
-              << id.second
-              << std::endl;
+            std::cout << "  " << id.first << " = " << id.second << std::endl;
           }
-	  //
+          //
         }
 
         // Exactly one explicitly declared overlap belongs to each quadrant boundary.
@@ -276,7 +265,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
           if (xOverlap.attr<int>(_Unicode(quadrant)) != quadrantId) {
             continue;
           }
-          const double z = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
+          const double z                = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
           PlacedVolume overlapPlacement = quadrantAssembly.placeVolume(
               modulePair.overlap.volume,
               Transform3D(RotationZYX(0.0, xOverlap.attr<double>(_Unicode(rotation)), -M_PI / 2.0),
@@ -287,15 +276,11 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
           overlapElement.setPlacement(overlapPlacement);
           addSensitiveDetElements(overlapElement, modulePair.overlap, nextModuleId++);
 
-	  //MP -DEBUG
-	  std::cout << "\n========== OVERLAP ==========\n";
+          //MP -DEBUG
+          std::cout << "\n========== OVERLAP ==========\n";
           std::cout << "module = " << nextModuleId << std::endl;
           for (const auto& id : overlapPlacement.volIDs()) {
-            std::cout << "  "
-              << id.first
-              << " = "
-              << id.second
-              << std::endl;
+            std::cout << "  " << id.first << " = " << id.second << std::endl;
           }
         }
       }
@@ -308,12 +293,9 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   detector.setPlacement(detectorPlacement);
 
   //MP DEBUG
-  std::cout << "Returning detector: "
-    << detector.name()
-    << std::endl;
+  std::cout << "Returning detector: " << detector.name() << std::endl;
   //
   return detector;
 }
 
 DECLARE_DETELEMENT(epic_MPGDQuadrantEndcapTracker, create_detector)
-

--- a/src/MPGDQuadrantEndcapTracker.cpp
+++ b/src/MPGDQuadrantEndcapTracker.cpp
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026
+//
+// Forward MPGD endcap with four independently placed quadrant assemblies.
+// The overlap panels are declared in compact XML; no boundary coordinates are
+// encoded in this driver.
+
+#include "DD4hep/DetFactoryHelper.h"
+#include "DD4hep/Shapes.h"
+#include "DDRec/DetectorData.h"
+#include "DDRec/Surface.h"
+#include "DD4hepDetectorHelper.h"
+#include "XML/Utilities.h"
+
+#include <cmath>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+#include <stdexcept>
+
+using namespace dd4hep;
+using namespace dd4hep::detail;
+using namespace dd4hep::rec;
+
+namespace {
+
+using Placements = std::vector<PlacedVolume>;
+
+struct ModulePrototype {
+  Volume volume;
+  Placements sensitivePlacements;
+  std::vector<VolPlane> surfaces;
+};
+
+struct ModulePair {
+  ModulePrototype normal;
+  ModulePrototype overlap;
+};
+
+ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensitiveDetector,
+                               xml_comp_t xModule, const std::string& suffix, bool isOverlap) {
+  const std::string moduleName = xModule.nameStr() + suffix;
+  const xml_comp_t trd = xModule.trd();
+  const double x1 = trd.x1();
+  const double x2 = trd.x2();
+  const double halfLength = trd.z();
+
+  double totalThickness = 0.0;
+  for (xml_coll_t component(xModule, _U(module_component)); component; ++component) {
+    totalThickness += xml_comp_t(component).thickness();
+  }
+
+  Solid moduleSolid;
+  double overlapHalfWidth = 0.0;
+  double overlapHalfLength = 0.0;
+  if (isOverlap) {
+    xml_comp_t xOverlap = xModule.child(_U(overlap));
+    overlapHalfWidth = xOverlap.x();
+    overlapHalfLength = xOverlap.z();
+    moduleSolid = Box(overlapHalfWidth, totalThickness / 2.0, overlapHalfLength);
+  } else {
+    moduleSolid = Trapezoid(x1, x2, totalThickness / 2.0, totalThickness / 2.0, halfLength);
+  }
+
+  ModulePrototype prototype;
+  prototype.volume = Volume(moduleName, moduleSolid, description.vacuum());
+  prototype.volume.setVisAttributes(description.visAttributes(xModule.visStr()));
+
+  double positionY = -totalThickness / 2.0;
+  double thicknessBefore = 0.0;
+  int componentId = 0;
+  int sensorId = 1;
+  for (xml_coll_t component(xModule, _U(module_component)); component; ++component, ++componentId) {
+    xml_comp_t xComponent = component;
+    const double thickness = xComponent.thickness();
+    const std::string componentName =
+        getAttrOrDefault(xComponent, _Unicode(name), _toString(componentId, "component%d"));
+
+    Solid componentSolid;
+    if (isOverlap) {
+      componentSolid = Box(overlapHalfWidth, thickness / 2.0, overlapHalfLength);
+    } else {
+      const double componentX1 = getAttrOrDefault(xComponent, _Unicode(x1), x1);
+      const double componentX2 = getAttrOrDefault(xComponent, _Unicode(x2), x2);
+      const double componentHalfLength = getAttrOrDefault(xComponent, _Unicode(height), halfLength);
+      componentSolid = Trapezoid(componentX1, componentX2, thickness / 2.0, thickness / 2.0,
+                                 componentHalfLength);
+    }
+
+    Volume componentVolume(componentName + suffix, componentSolid,
+                           description.material(xComponent.materialStr()));
+    componentVolume.setVisAttributes(description.visAttributes(xComponent.visStr()));
+    PlacedVolume componentPlacement =
+        prototype.volume.placeVolume(componentVolume, Position(0.0, positionY + thickness / 2.0, 0.0));
+
+    if (xComponent.isSensitive()) {
+      if (sensorId > 2) {
+        throw std::runtime_error(
+          "MPGDQuadrantEndcapTracker: at most two sensitive components are supported");
+      }
+      componentPlacement.addPhysVolID("sensor", sensorId++);
+      componentVolume.setSensitiveDetector(sensitiveDetector);
+      prototype.sensitivePlacements.push_back(componentPlacement);
+
+      const double innerThickness = thicknessBefore + thickness / 2.0;
+      const double outerThickness = totalThickness - innerThickness;
+      const SurfaceType type(SurfaceType::Sensitive);
+      const Vector3D u(0.0, 0.0, -1.0);
+      const Vector3D v(-1.0, 0.0, 0.0);
+      const Vector3D n(0.0, 1.0, 0.0);
+      prototype.surfaces.emplace_back(componentVolume, type, innerThickness, outerThickness, u, v, n);
+      //MP-DEBUG
+      std::cout
+       << "Created surface for "
+       << componentVolume.name()
+       << " total surfaces = "
+       << prototype.surfaces.size()
+       << std::endl;
+      //
+    }
+    positionY += thickness;
+    thicknessBefore += thickness;
+  }
+  return prototype;
+}
+
+void addSensitiveDetElements(DetElement& moduleElement, const ModulePrototype& prototype,
+                             int moduleId) {
+  for (std::size_t index = 0; index < prototype.sensitivePlacements.size(); ++index) {
+    const PlacedVolume& placement = prototype.sensitivePlacements.at(index);
+    DetElement sensorElement(moduleElement, placement.volume().name(), moduleId);
+    auto& parameters =
+        DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(sensorElement);
+    parameters.set<std::string>("axis_definitions", "XZY");
+    sensorElement.setPlacement(placement);
+    
+    //MP - DEBUG
+    std::cout
+    << "\nAttaching ACTS surface"
+    << "\n  Sensor = " << sensorElement.name()
+    << "\n  Module ID = " << moduleId
+    << "\n  Surface index = " << index
+    << "\n  Number of surfaces = " << prototype.surfaces.size()
+    << "\n  Number of placements = " << prototype.sensitivePlacements.size()
+    << std::endl;
+    //--
+
+    volSurfaceList(sensorElement)->push_back(prototype.surfaces.at(index));
+  }
+}
+
+} // namespace
+
+static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector sensitiveDetector) {
+  //MP DEBUG
+  std::cout << "\n\n";
+  std::cout << "###########################################\n";
+  std::cout << "### ENTERING MPGDQuadrantEndcapTracker ###\n";
+  std::cout << "###########################################\n";
+  std::cout << std::endl;
+  //
+
+  xml_det_t xDetector = e;
+  const int detectorId = xDetector.id();
+  const std::string detectorName = xDetector.nameStr();
+  const bool reflect = xDetector.reflect(false);
+
+  DetElement detector(detectorName, detectorId);
+ 
+  //MP DEBUG
+  //std::cout << "Detector name = " << detName << std::endl;
+  //
+  
+  Assembly detectorAssembly(detectorName);
+  detectorAssembly.setVisAttributes(description.invisible());
+  sensitiveDetector.setType("tracker");
+  dd4hep::xml::setDetectorTypeFlag(xDetector, detector);
+
+  auto& detectorParameters =
+      DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(detector);
+  for (xml_coll_t boundaryMaterial(xDetector, _Unicode(boundary_material)); boundaryMaterial;
+       ++boundaryMaterial) {
+    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(xml_comp_t(boundaryMaterial), detectorParameters,
+                                                    "boundary_material");
+  }
+
+  std::map<std::string, ModulePair> modules;
+  for (xml_coll_t module(xDetector, _U(module)); module; ++module) {
+    xml_comp_t xModule = module;
+    ModulePair pair;
+    pair.normal = buildPrototype(description, sensitiveDetector, xModule, "", false);
+    pair.overlap = buildPrototype(description, sensitiveDetector, xModule, "_overlap", true);
+    modules.emplace(xModule.nameStr(), std::move(pair));
+  }
+
+  for (xml_coll_t layer(xDetector, _U(layer)); layer; ++layer) {
+    xml_comp_t xLayer = layer;
+    const int layerId = xLayer.id();
+    xml_comp_t xEnvelope = xLayer.child(_U(envelope));
+    const std::string baseLayerName = detectorName + "_layer" + std::to_string(layerId);
+    const double layerLength = xEnvelope.length();
+    const double layerStart = xEnvelope.zstart();
+    const double layerCenter = layerStart + layerLength / 2.0;
+
+    Volume layerVolume(baseLayerName,
+                       Tube(xEnvelope.rmin(), xEnvelope.rmax(), layerLength / 2.0),
+                       description.material("Air"));
+    layerVolume.setVisAttributes(description.visAttributes(xEnvelope.visStr()));
+    const Transform3D layerTransform =
+        reflect ? Transform3D(RotationZYX(0.0, -M_PI, 0.0), Position(0.0, 0.0, -layerCenter))
+                : Transform3D(Rotation3D(), Position(0.0, 0.0, layerCenter));
+    PlacedVolume layerPlacement = detectorAssembly.placeVolume(layerVolume, layerTransform);
+    layerPlacement.addPhysVolID("layer", layerId);
+    DetElement layerElement(detector, baseLayerName + (reflect ? "_N" : "_P"), layerId);
+    layerElement.setPlacement(layerPlacement);
+
+    auto& layerParameters =
+        DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(layerElement);
+    for (xml_coll_t material(xLayer, _Unicode(layer_material)); material; ++material) {
+      DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(xml_comp_t(material), layerParameters,
+                                                      "layer_material");
+    }
+
+    int nextModuleId = 1;
+    for (xml_coll_t ring(xLayer, _U(ring)); ring; ++ring) {
+      xml_comp_t xRing = ring;
+      const ModulePair& modulePair = modules.at(xRing.moduleStr());
+      const int modulesPerQuadrant = xRing.attr<int>(_Unicode(modules_per_quadrant));
+      const double radius = xRing.r();
+      const double phi0 = xRing.phi0(0.0);
+      const double localZ = xRing.zstart();
+      const double dz = xRing.dz(0.0);
+      const double quadrantStagger = getAttrOrDefault(xRing, _Unicode(dz_offset), 0.0);
+      const double phiStep = (M_PI / 2.0) / modulesPerQuadrant;
+
+      for (int quadrantId = 0; quadrantId < 4; ++quadrantId) {
+        const std::string quadrantName = "quadrant" + std::to_string(quadrantId);
+        Assembly quadrantAssembly(baseLayerName + "_" + quadrantName);
+        PlacedVolume quadrantPlacement = layerVolume.placeVolume(quadrantAssembly);
+	//quadrantPlacement.addPhysVolID("system",detector.id());
+        DetElement quadrantElement(layerElement, quadrantName, quadrantId);
+        quadrantElement.setPlacement(quadrantPlacement);
+
+        const double zOffset = (quadrantId % 2 == 0) ? quadrantStagger : 0.0;
+        for (int inQuadrant = 0; inQuadrant < modulesPerQuadrant; ++inQuadrant) {
+          const double phi = phi0 + (quadrantId * modulesPerQuadrant + inQuadrant) * phiStep;
+          const double x = -radius * std::cos(phi);
+          const double y = -radius * std::sin(phi);
+          const double z = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
+          PlacedVolume modulePlacement = quadrantAssembly.placeVolume(
+              modulePair.normal.volume,
+              Transform3D(RotationZYX(0.0, -M_PI / 2.0 - phi, -M_PI / 2.0), Position(x, y, z)));
+          modulePlacement.addPhysVolID("module", nextModuleId);
+          DetElement moduleElement(quadrantElement, "module" + std::to_string(nextModuleId),
+                                   nextModuleId);
+          moduleElement.setPlacement(modulePlacement);
+          addSensitiveDetElements(moduleElement, modulePair.normal, nextModuleId++);
+
+	   //MP DEBUG
+	  std::cout << "\n========== MODULE ==========\n";
+          std::cout << "module = " << nextModuleId << std::endl;
+          for (const auto& id : modulePlacement.volIDs()) {
+            std::cout << "  "
+              << id.first
+              << " = "
+              << id.second
+              << std::endl;
+          }
+	  //
+        }
+
+        // Exactly one explicitly declared overlap belongs to each quadrant boundary.
+        for (xml_coll_t overlap(xRing, _U(overlap)); overlap; ++overlap) {
+          xml_comp_t xOverlap = overlap;
+          if (xOverlap.attr<int>(_Unicode(quadrant)) != quadrantId) {
+            continue;
+          }
+          const double z = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
+          PlacedVolume overlapPlacement = quadrantAssembly.placeVolume(
+              modulePair.overlap.volume,
+              Transform3D(RotationZYX(0.0, xOverlap.attr<double>(_Unicode(rotation)), -M_PI / 2.0),
+                          Position(xOverlap.x(), xOverlap.y(), z)));
+          overlapPlacement.addPhysVolID("module", nextModuleId);
+          DetElement overlapElement(quadrantElement, "overlap" + std::to_string(nextModuleId),
+                                    nextModuleId);
+          overlapElement.setPlacement(overlapPlacement);
+          addSensitiveDetElements(overlapElement, modulePair.overlap, nextModuleId++);
+
+	  //MP -DEBUG
+	  std::cout << "\n========== OVERLAP ==========\n";
+          std::cout << "module = " << nextModuleId << std::endl;
+          for (const auto& id : overlapPlacement.volIDs()) {
+            std::cout << "  "
+              << id.first
+              << " = "
+              << id.second
+              << std::endl;
+          }
+        }
+      }
+    }
+  }
+
+  PlacedVolume detectorPlacement = description.pickMotherVolume(detector).placeVolume(
+      detectorAssembly, Position(0.0, 0.0, reflect ? -1.0e-9 : 1.0e-9));
+  detectorPlacement.addPhysVolID("system", detectorId);
+  detector.setPlacement(detectorPlacement);
+
+  //MP DEBUG
+  std::cout << "Returning detector: "
+    << detector.name()
+    << std::endl;
+  //
+  return detector;
+}
+
+DECLARE_DETELEMENT(epic_MPGDQuadrantEndcapTracker, create_detector)
+

--- a/src/MPGDQuadrantEndcapTracker.cpp
+++ b/src/MPGDQuadrantEndcapTracker.cpp
@@ -41,10 +41,10 @@ struct ModulePair {
 ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensitiveDetector,
                                xml_comp_t xModule, const std::string& suffix, bool isOverlap) {
   const std::string moduleName = xModule.nameStr() + suffix;
-  const xml_comp_t trd = xModule.trd();
-  const double x1 = trd.x1();
-  const double x2 = trd.x2();
-  const double halfLength = trd.z();
+  const xml_comp_t trd         = xModule.trd();
+  const double x1              = trd.x1();
+  const double x2              = trd.x2();
+  const double halfLength      = trd.z();
 
   double totalThickness = 0.0;
   for (xml_coll_t component(xModule, _U(module_component)); component; ++component) {
@@ -52,13 +52,13 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
   }
 
   Solid moduleSolid;
-  double overlapHalfWidth = 0.0;
+  double overlapHalfWidth  = 0.0;
   double overlapHalfLength = 0.0;
   if (isOverlap) {
     xml_comp_t xOverlap = xModule.child(_U(overlap));
-    overlapHalfWidth = xOverlap.x();
-    overlapHalfLength = xOverlap.z();
-    moduleSolid = Box(overlapHalfWidth, totalThickness / 2.0, overlapHalfLength);
+    overlapHalfWidth    = xOverlap.x();
+    overlapHalfLength   = xOverlap.z();
+    moduleSolid         = Box(overlapHalfWidth, totalThickness / 2.0, overlapHalfLength);
   } else {
     moduleSolid = Trapezoid(x1, x2, totalThickness / 2.0, totalThickness / 2.0, halfLength);
   }
@@ -67,12 +67,12 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
   prototype.volume = Volume(moduleName, moduleSolid, description.vacuum());
   prototype.volume.setVisAttributes(description.visAttributes(xModule.visStr()));
 
-  double positionY = -totalThickness / 2.0;
+  double positionY       = -totalThickness / 2.0;
   double thicknessBefore = 0.0;
-  int componentId = 0;
-  int sensorId = 1;
+  int componentId        = 0;
+  int sensorId           = 1;
   for (xml_coll_t component(xModule, _U(module_component)); component; ++component, ++componentId) {
-    xml_comp_t xComponent = component;
+    xml_comp_t xComponent  = component;
     const double thickness = xComponent.thickness();
     const std::string componentName =
         getAttrOrDefault(xComponent, _Unicode(name), _toString(componentId, "component%d"));
@@ -81,8 +81,8 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
     if (isOverlap) {
       componentSolid = Box(overlapHalfWidth, thickness / 2.0, overlapHalfLength);
     } else {
-      const double componentX1 = getAttrOrDefault(xComponent, _Unicode(x1), x1);
-      const double componentX2 = getAttrOrDefault(xComponent, _Unicode(x2), x2);
+      const double componentX1         = getAttrOrDefault(xComponent, _Unicode(x1), x1);
+      const double componentX2         = getAttrOrDefault(xComponent, _Unicode(x2), x2);
       const double componentHalfLength = getAttrOrDefault(xComponent, _Unicode(height), halfLength);
       componentSolid = Trapezoid(componentX1, componentX2, thickness / 2.0, thickness / 2.0,
                                  componentHalfLength);
@@ -91,13 +91,13 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
     Volume componentVolume(componentName + suffix, componentSolid,
                            description.material(xComponent.materialStr()));
     componentVolume.setVisAttributes(description.visAttributes(xComponent.visStr()));
-    PlacedVolume componentPlacement =
-        prototype.volume.placeVolume(componentVolume, Position(0.0, positionY + thickness / 2.0, 0.0));
+    PlacedVolume componentPlacement = prototype.volume.placeVolume(
+        componentVolume, Position(0.0, positionY + thickness / 2.0, 0.0));
 
     if (xComponent.isSensitive()) {
       if (sensorId > 2) {
         throw std::runtime_error(
-          "MPGDQuadrantEndcapTracker: at most two sensitive components are supported");
+            "MPGDQuadrantEndcapTracker: at most two sensitive components are supported");
       }
       componentPlacement.addPhysVolID("sensor", sensorId++);
       componentVolume.setSensitiveDetector(sensitiveDetector);
@@ -109,7 +109,8 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
       const Vector3D u(0.0, 0.0, -1.0);
       const Vector3D v(-1.0, 0.0, 0.0);
       const Vector3D n(0.0, 1.0, 0.0);
-      prototype.surfaces.emplace_back(componentVolume, type, innerThickness, outerThickness, u, v, n);
+      prototype.surfaces.emplace_back(componentVolume, type, innerThickness, outerThickness, u, v,
+                                      n);
     }
     positionY += thickness;
     thicknessBefore += thickness;
@@ -126,7 +127,7 @@ void addSensitiveDetElements(DetElement& moduleElement, const ModulePrototype& p
         DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(sensorElement);
     parameters.set<std::string>("axis_definitions", "XZY");
     sensorElement.setPlacement(placement);
-    
+
     volSurfaceList(sensorElement)->push_back(prototype.surfaces.at(index));
   }
 }
@@ -135,10 +136,10 @@ void addSensitiveDetElements(DetElement& moduleElement, const ModulePrototype& p
 
 static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector sensitiveDetector) {
 
-  xml_det_t xDetector = e;
-  const int detectorId = xDetector.id();
+  xml_det_t xDetector            = e;
+  const int detectorId           = xDetector.id();
   const std::string detectorName = xDetector.nameStr();
-  const bool reflect = xDetector.reflect(false);
+  const bool reflect             = xDetector.reflect(false);
   DetElement detector(detectorName, detectorId);
   Assembly detectorAssembly(detectorName);
   detectorAssembly.setVisAttributes(description.invisible());
@@ -149,30 +150,29 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(detector);
   for (xml_coll_t boundaryMaterial(xDetector, _Unicode(boundary_material)); boundaryMaterial;
        ++boundaryMaterial) {
-    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(xml_comp_t(boundaryMaterial), detectorParameters,
-                                                    "boundary_material");
+    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(xml_comp_t(boundaryMaterial),
+                                                    detectorParameters, "boundary_material");
   }
 
   std::map<std::string, ModulePair> modules;
   for (xml_coll_t module(xDetector, _U(module)); module; ++module) {
     xml_comp_t xModule = module;
     ModulePair pair;
-    pair.normal = buildPrototype(description, sensitiveDetector, xModule, "", false);
+    pair.normal  = buildPrototype(description, sensitiveDetector, xModule, "", false);
     pair.overlap = buildPrototype(description, sensitiveDetector, xModule, "_overlap", true);
     modules.emplace(xModule.nameStr(), std::move(pair));
   }
 
   for (xml_coll_t layer(xDetector, _U(layer)); layer; ++layer) {
-    xml_comp_t xLayer = layer;
-    const int layerId = xLayer.id();
-    xml_comp_t xEnvelope = xLayer.child(_U(envelope));
+    xml_comp_t xLayer               = layer;
+    const int layerId               = xLayer.id();
+    xml_comp_t xEnvelope            = xLayer.child(_U(envelope));
     const std::string baseLayerName = detectorName + "_layer" + std::to_string(layerId);
-    const double layerLength = xEnvelope.length();
-    const double layerStart = xEnvelope.zstart();
-    const double layerCenter = layerStart + layerLength / 2.0;
+    const double layerLength        = xEnvelope.length();
+    const double layerStart         = xEnvelope.zstart();
+    const double layerCenter        = layerStart + layerLength / 2.0;
 
-    Volume layerVolume(baseLayerName,
-                       Tube(xEnvelope.rmin(), xEnvelope.rmax(), layerLength / 2.0),
+    Volume layerVolume(baseLayerName, Tube(xEnvelope.rmin(), xEnvelope.rmax(), layerLength / 2.0),
                        description.material("Air"));
     layerVolume.setVisAttributes(description.visAttributes(xEnvelope.visStr()));
     const Transform3D layerTransform =
@@ -192,15 +192,15 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
     int nextModuleId = 1;
     for (xml_coll_t ring(xLayer, _U(ring)); ring; ++ring) {
-      xml_comp_t xRing = ring;
+      xml_comp_t xRing             = ring;
       const ModulePair& modulePair = modules.at(xRing.moduleStr());
       const int modulesPerQuadrant = xRing.attr<int>(_Unicode(modules_per_quadrant));
-      const double radius = xRing.r();
-      const double phi0 = xRing.phi0(0.0);
-      const double localZ = xRing.zstart();
-      const double dz = xRing.dz(0.0);
+      const double radius          = xRing.r();
+      const double phi0            = xRing.phi0(0.0);
+      const double localZ          = xRing.zstart();
+      const double dz              = xRing.dz(0.0);
       const double quadrantStagger = getAttrOrDefault(xRing, _Unicode(dz_offset), 0.0);
-      const double phiStep = (M_PI / 2.0) / modulesPerQuadrant;
+      const double phiStep         = (M_PI / 2.0) / modulesPerQuadrant;
 
       for (int quadrantId = 0; quadrantId < 4; ++quadrantId) {
         const std::string quadrantName = "quadrant" + std::to_string(quadrantId);
@@ -212,9 +212,9 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
         const double zOffset = (quadrantId % 2 == 0) ? quadrantStagger : 0.0;
         for (int inQuadrant = 0; inQuadrant < modulesPerQuadrant; ++inQuadrant) {
           const double phi = phi0 + (quadrantId * modulesPerQuadrant + inQuadrant) * phiStep;
-          const double x = -radius * std::cos(phi);
-          const double y = -radius * std::sin(phi);
-          const double z = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
+          const double x   = -radius * std::cos(phi);
+          const double y   = -radius * std::sin(phi);
+          const double z   = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
           PlacedVolume modulePlacement = quadrantAssembly.placeVolume(
               modulePair.normal.volume,
               Transform3D(RotationZYX(0.0, -M_PI / 2.0 - phi, -M_PI / 2.0), Position(x, y, z)));
@@ -223,7 +223,6 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
                                    nextModuleId);
           moduleElement.setPlacement(modulePlacement);
           addSensitiveDetElements(moduleElement, modulePair.normal, nextModuleId++);
-
         }
 
         // Exactly one explicitly declared overlap belongs to each quadrant boundary.
@@ -232,7 +231,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
           if (xOverlap.attr<int>(_Unicode(quadrant)) != quadrantId) {
             continue;
           }
-          const double z = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
+          const double z                = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
           PlacedVolume overlapPlacement = quadrantAssembly.placeVolume(
               modulePair.overlap.volume,
               Transform3D(RotationZYX(0.0, xOverlap.attr<double>(_Unicode(rotation)), -M_PI / 2.0),
@@ -242,7 +241,6 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
                                     nextModuleId);
           overlapElement.setPlacement(overlapPlacement);
           addSensitiveDetElements(overlapElement, modulePair.overlap, nextModuleId++);
-
         }
       }
     }
@@ -257,4 +255,3 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 }
 
 DECLARE_DETELEMENT(epic_MPGDQuadrantEndcapTracker, create_detector)
-

--- a/src/MPGDQuadrantEndcapTracker.cpp
+++ b/src/MPGDQuadrantEndcapTracker.cpp
@@ -41,10 +41,10 @@ struct ModulePair {
 ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensitiveDetector,
                                xml_comp_t xModule, const std::string& suffix, bool isOverlap) {
   const std::string moduleName = xModule.nameStr() + suffix;
-  const xml_comp_t trd         = xModule.trd();
-  const double x1              = trd.x1();
-  const double x2              = trd.x2();
-  const double halfLength      = trd.z();
+  const xml_comp_t trd = xModule.trd();
+  const double x1 = trd.x1();
+  const double x2 = trd.x2();
+  const double halfLength = trd.z();
 
   double totalThickness = 0.0;
   for (xml_coll_t component(xModule, _U(module_component)); component; ++component) {
@@ -52,13 +52,13 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
   }
 
   Solid moduleSolid;
-  double overlapHalfWidth  = 0.0;
+  double overlapHalfWidth = 0.0;
   double overlapHalfLength = 0.0;
   if (isOverlap) {
     xml_comp_t xOverlap = xModule.child(_U(overlap));
-    overlapHalfWidth    = xOverlap.x();
-    overlapHalfLength   = xOverlap.z();
-    moduleSolid         = Box(overlapHalfWidth, totalThickness / 2.0, overlapHalfLength);
+    overlapHalfWidth = xOverlap.x();
+    overlapHalfLength = xOverlap.z();
+    moduleSolid = Box(overlapHalfWidth, totalThickness / 2.0, overlapHalfLength);
   } else {
     moduleSolid = Trapezoid(x1, x2, totalThickness / 2.0, totalThickness / 2.0, halfLength);
   }
@@ -67,12 +67,12 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
   prototype.volume = Volume(moduleName, moduleSolid, description.vacuum());
   prototype.volume.setVisAttributes(description.visAttributes(xModule.visStr()));
 
-  double positionY       = -totalThickness / 2.0;
+  double positionY = -totalThickness / 2.0;
   double thicknessBefore = 0.0;
-  int componentId        = 0;
-  int sensorId           = 1;
+  int componentId = 0;
+  int sensorId = 1;
   for (xml_coll_t component(xModule, _U(module_component)); component; ++component, ++componentId) {
-    xml_comp_t xComponent  = component;
+    xml_comp_t xComponent = component;
     const double thickness = xComponent.thickness();
     const std::string componentName =
         getAttrOrDefault(xComponent, _Unicode(name), _toString(componentId, "component%d"));
@@ -81,8 +81,8 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
     if (isOverlap) {
       componentSolid = Box(overlapHalfWidth, thickness / 2.0, overlapHalfLength);
     } else {
-      const double componentX1         = getAttrOrDefault(xComponent, _Unicode(x1), x1);
-      const double componentX2         = getAttrOrDefault(xComponent, _Unicode(x2), x2);
+      const double componentX1 = getAttrOrDefault(xComponent, _Unicode(x1), x1);
+      const double componentX2 = getAttrOrDefault(xComponent, _Unicode(x2), x2);
       const double componentHalfLength = getAttrOrDefault(xComponent, _Unicode(height), halfLength);
       componentSolid = Trapezoid(componentX1, componentX2, thickness / 2.0, thickness / 2.0,
                                  componentHalfLength);
@@ -91,13 +91,13 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
     Volume componentVolume(componentName + suffix, componentSolid,
                            description.material(xComponent.materialStr()));
     componentVolume.setVisAttributes(description.visAttributes(xComponent.visStr()));
-    PlacedVolume componentPlacement = prototype.volume.placeVolume(
-        componentVolume, Position(0.0, positionY + thickness / 2.0, 0.0));
+    PlacedVolume componentPlacement =
+        prototype.volume.placeVolume(componentVolume, Position(0.0, positionY + thickness / 2.0, 0.0));
 
     if (xComponent.isSensitive()) {
       if (sensorId > 2) {
         throw std::runtime_error(
-            "MPGDQuadrantEndcapTracker: at most two sensitive components are supported");
+          "MPGDQuadrantEndcapTracker: at most two sensitive components are supported");
       }
       componentPlacement.addPhysVolID("sensor", sensorId++);
       componentVolume.setSensitiveDetector(sensitiveDetector);
@@ -109,12 +109,7 @@ ModulePrototype buildPrototype(Detector& description, SensitiveDetector& sensiti
       const Vector3D u(0.0, 0.0, -1.0);
       const Vector3D v(-1.0, 0.0, 0.0);
       const Vector3D n(0.0, 1.0, 0.0);
-      prototype.surfaces.emplace_back(componentVolume, type, innerThickness, outerThickness, u, v,
-                                      n);
-      //MP-DEBUG
-      std::cout << "Created surface for " << componentVolume.name()
-                << " total surfaces = " << prototype.surfaces.size() << std::endl;
-      //
+      prototype.surfaces.emplace_back(componentVolume, type, innerThickness, outerThickness, u, v, n);
     }
     positionY += thickness;
     thicknessBefore += thickness;
@@ -131,15 +126,7 @@ void addSensitiveDetElements(DetElement& moduleElement, const ModulePrototype& p
         DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(sensorElement);
     parameters.set<std::string>("axis_definitions", "XZY");
     sensorElement.setPlacement(placement);
-
-    //MP - DEBUG
-    std::cout << "\nAttaching ACTS surface"
-              << "\n  Sensor = " << sensorElement.name() << "\n  Module ID = " << moduleId
-              << "\n  Surface index = " << index
-              << "\n  Number of surfaces = " << prototype.surfaces.size()
-              << "\n  Number of placements = " << prototype.sensitivePlacements.size() << std::endl;
-    //--
-
+    
     volSurfaceList(sensorElement)->push_back(prototype.surfaces.at(index));
   }
 }
@@ -147,25 +134,12 @@ void addSensitiveDetElements(DetElement& moduleElement, const ModulePrototype& p
 } // namespace
 
 static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector sensitiveDetector) {
-  //MP DEBUG
-  std::cout << "\n\n";
-  std::cout << "###########################################\n";
-  std::cout << "### ENTERING MPGDQuadrantEndcapTracker ###\n";
-  std::cout << "###########################################\n";
-  std::cout << std::endl;
-  //
 
-  xml_det_t xDetector            = e;
-  const int detectorId           = xDetector.id();
+  xml_det_t xDetector = e;
+  const int detectorId = xDetector.id();
   const std::string detectorName = xDetector.nameStr();
-  const bool reflect             = xDetector.reflect(false);
-
+  const bool reflect = xDetector.reflect(false);
   DetElement detector(detectorName, detectorId);
-
-  //MP DEBUG
-  //std::cout << "Detector name = " << detName << std::endl;
-  //
-
   Assembly detectorAssembly(detectorName);
   detectorAssembly.setVisAttributes(description.invisible());
   sensitiveDetector.setType("tracker");
@@ -175,29 +149,30 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       DD4hepDetectorHelper::ensureExtension<dd4hep::rec::VariantParameters>(detector);
   for (xml_coll_t boundaryMaterial(xDetector, _Unicode(boundary_material)); boundaryMaterial;
        ++boundaryMaterial) {
-    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(xml_comp_t(boundaryMaterial),
-                                                    detectorParameters, "boundary_material");
+    DD4hepDetectorHelper::xmlToProtoSurfaceMaterial(xml_comp_t(boundaryMaterial), detectorParameters,
+                                                    "boundary_material");
   }
 
   std::map<std::string, ModulePair> modules;
   for (xml_coll_t module(xDetector, _U(module)); module; ++module) {
     xml_comp_t xModule = module;
     ModulePair pair;
-    pair.normal  = buildPrototype(description, sensitiveDetector, xModule, "", false);
+    pair.normal = buildPrototype(description, sensitiveDetector, xModule, "", false);
     pair.overlap = buildPrototype(description, sensitiveDetector, xModule, "_overlap", true);
     modules.emplace(xModule.nameStr(), std::move(pair));
   }
 
   for (xml_coll_t layer(xDetector, _U(layer)); layer; ++layer) {
-    xml_comp_t xLayer               = layer;
-    const int layerId               = xLayer.id();
-    xml_comp_t xEnvelope            = xLayer.child(_U(envelope));
+    xml_comp_t xLayer = layer;
+    const int layerId = xLayer.id();
+    xml_comp_t xEnvelope = xLayer.child(_U(envelope));
     const std::string baseLayerName = detectorName + "_layer" + std::to_string(layerId);
-    const double layerLength        = xEnvelope.length();
-    const double layerStart         = xEnvelope.zstart();
-    const double layerCenter        = layerStart + layerLength / 2.0;
+    const double layerLength = xEnvelope.length();
+    const double layerStart = xEnvelope.zstart();
+    const double layerCenter = layerStart + layerLength / 2.0;
 
-    Volume layerVolume(baseLayerName, Tube(xEnvelope.rmin(), xEnvelope.rmax(), layerLength / 2.0),
+    Volume layerVolume(baseLayerName,
+                       Tube(xEnvelope.rmin(), xEnvelope.rmax(), layerLength / 2.0),
                        description.material("Air"));
     layerVolume.setVisAttributes(description.visAttributes(xEnvelope.visStr()));
     const Transform3D layerTransform =
@@ -217,30 +192,29 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
     int nextModuleId = 1;
     for (xml_coll_t ring(xLayer, _U(ring)); ring; ++ring) {
-      xml_comp_t xRing             = ring;
+      xml_comp_t xRing = ring;
       const ModulePair& modulePair = modules.at(xRing.moduleStr());
       const int modulesPerQuadrant = xRing.attr<int>(_Unicode(modules_per_quadrant));
-      const double radius          = xRing.r();
-      const double phi0            = xRing.phi0(0.0);
-      const double localZ          = xRing.zstart();
-      const double dz              = xRing.dz(0.0);
+      const double radius = xRing.r();
+      const double phi0 = xRing.phi0(0.0);
+      const double localZ = xRing.zstart();
+      const double dz = xRing.dz(0.0);
       const double quadrantStagger = getAttrOrDefault(xRing, _Unicode(dz_offset), 0.0);
-      const double phiStep         = (M_PI / 2.0) / modulesPerQuadrant;
+      const double phiStep = (M_PI / 2.0) / modulesPerQuadrant;
 
       for (int quadrantId = 0; quadrantId < 4; ++quadrantId) {
         const std::string quadrantName = "quadrant" + std::to_string(quadrantId);
         Assembly quadrantAssembly(baseLayerName + "_" + quadrantName);
         PlacedVolume quadrantPlacement = layerVolume.placeVolume(quadrantAssembly);
-        //quadrantPlacement.addPhysVolID("system",detector.id());
         DetElement quadrantElement(layerElement, quadrantName, quadrantId);
         quadrantElement.setPlacement(quadrantPlacement);
 
         const double zOffset = (quadrantId % 2 == 0) ? quadrantStagger : 0.0;
         for (int inQuadrant = 0; inQuadrant < modulesPerQuadrant; ++inQuadrant) {
           const double phi = phi0 + (quadrantId * modulesPerQuadrant + inQuadrant) * phiStep;
-          const double x   = -radius * std::cos(phi);
-          const double y   = -radius * std::sin(phi);
-          const double z   = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
+          const double x = -radius * std::cos(phi);
+          const double y = -radius * std::sin(phi);
+          const double z = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
           PlacedVolume modulePlacement = quadrantAssembly.placeVolume(
               modulePair.normal.volume,
               Transform3D(RotationZYX(0.0, -M_PI / 2.0 - phi, -M_PI / 2.0), Position(x, y, z)));
@@ -250,13 +224,6 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
           moduleElement.setPlacement(modulePlacement);
           addSensitiveDetElements(moduleElement, modulePair.normal, nextModuleId++);
 
-          //MP DEBUG
-          std::cout << "\n========== MODULE ==========\n";
-          std::cout << "module = " << nextModuleId << std::endl;
-          for (const auto& id : modulePlacement.volIDs()) {
-            std::cout << "  " << id.first << " = " << id.second << std::endl;
-          }
-          //
         }
 
         // Exactly one explicitly declared overlap belongs to each quadrant boundary.
@@ -265,7 +232,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
           if (xOverlap.attr<int>(_Unicode(quadrant)) != quadrantId) {
             continue;
           }
-          const double z                = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
+          const double z = reflect ? -localZ - dz - zOffset : localZ + dz + zOffset;
           PlacedVolume overlapPlacement = quadrantAssembly.placeVolume(
               modulePair.overlap.volume,
               Transform3D(RotationZYX(0.0, xOverlap.attr<double>(_Unicode(rotation)), -M_PI / 2.0),
@@ -276,12 +243,6 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
           overlapElement.setPlacement(overlapPlacement);
           addSensitiveDetElements(overlapElement, modulePair.overlap, nextModuleId++);
 
-          //MP -DEBUG
-          std::cout << "\n========== OVERLAP ==========\n";
-          std::cout << "module = " << nextModuleId << std::endl;
-          for (const auto& id : overlapPlacement.volIDs()) {
-            std::cout << "  " << id.first << " = " << id.second << std::endl;
-          }
         }
       }
     }
@@ -292,10 +253,8 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   detectorPlacement.addPhysVolID("system", detectorId);
   detector.setPlacement(detectorPlacement);
 
-  //MP DEBUG
-  std::cout << "Returning detector: " << detector.name() << std::endl;
-  //
   return detector;
 }
 
 DECLARE_DETELEMENT(epic_MPGDQuadrantEndcapTracker, create_detector)
+


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR segments a single MPGD endcap disk into four quadrants. The code successfully segments the detector, produces detector Sim and Rec Hits. Rec hits are associated with ACTS measurements. 

**TODO before merge:** 
1. Produce detector hits and have ACTS use them --> Done: 
[MPGD-ECT-Geo1.5.pdf](https://github.com/user-attachments/files/30753886/MPGD-ECT-Geo1.5.pdf)

2. Verify final dimensions and position 
3.  verify material budget

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [x ] other: Makes detector geometry and material more realistic

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [x ] This PR changes default behavior. Please describe changes below.
          Will change detector geometry and material budget.
- [x ] AI was used in preparing this PR. Please describe usage below.
         Used to aid in debugging geometry implementation
