### PR TITLE
compact/calibrations.xml: update IRT configurations to latest

### DIFF
--- a/compact/calibrations.xml
+++ b/compact/calibrations.xml
@@ -66,8 +66,8 @@
     </plugin>
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_CACHE:/opt/detector"/>
-      <arg value="file:calibrations/irt2/drich-reco.json"/>
-      <arg value="url:https://raw.githubusercontent.com/eic/epic-data/f8860f469d240c807b11a244defaaaed96b76137/irt2/drich-reco.json"/>
+      <arg value="file:calibrations/irt2/drich-reco_v2.json"/>
+      <arg value="url:https://raw.githubusercontent.com/eic/epic-data/03b9594f743be82d05176d662b93a499b6362e2e/irt2/drich-reco.json"/>
     </plugin>
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_CACHE:/opt/detector"/>
@@ -76,8 +76,8 @@
     </plugin>
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_CACHE:/opt/detector"/>
-      <arg value="file:calibrations/irt2/pfrich-reco.json"/>
-      <arg value="url:https://raw.githubusercontent.com/eic/epic-data/f8860f469d240c807b11a244defaaaed96b76137/irt2/pfrich-reco.json"/>
+      <arg value="file:calibrations/irt2/pfrich-reco_v2.json"/>
+      <arg value="url:https://raw.githubusercontent.com/eic/epic-data/03b9594f743be82d05176d662b93a499b6362e2e/irt2/pfrich-reco.json"/>
     </plugin>
     <plugin name="epic_FileLoader">
       <arg value="cache:$DETECTOR_CACHE:/opt/detector"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

https://github.com/eic/epic-data/pull/37

1. `OutputRootFile` is removed because otherwise irt2 unconditionally creates an output file.
2. `Calibration` relative path was updated for reconstruction to be able to pick up the calibration files.
3. "display" replaced with "disabled" (any value would work).

I also add _v2 suffix, and plan to change the path in EICrecon, this is the easiest way to ensure that no one uses old files by default. There might be some issues with old files, namely display mode is enabled, and it may crash with older irt2 under certain conditions.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
