### PR TITLE
fix: bump geometry memory limit 1.3 => 1.35 GB

### DIFF
--- a/.github/workflows/check-geometry-configs.yml
+++ b/.github/workflows/check-geometry-configs.yml
@@ -23,7 +23,7 @@ jobs:
         setup: install/bin/thisepic.sh
         run: |
           export DETECTOR_CACHE=/opt/detector/epic-main/share/epic
-          MEMORY_LIMIT_KB=1300000   # 1.3 GB – update this deliberately when geometry grows
+          MEMORY_LIMIT_KB=1350000   # 1.35 GB – update this deliberately when geometry grows
           IFS=, read -a configs <<< "${{inputs.detector_configs}}"
           overall_rc=0
           for config in ${configs[@]} ; do


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
With the latest ROOT upgrade (and likely the TGeoTessellated BVH addition) we went just over the 1.3 GB limit. Only the largest of all geometries is affected: BIC with 6 layers. That one was already close (by design); https://github.com/eic/epic/actions/runs/30377142755/job/90336647260#step:5:1131.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/epic/actions/runs/31197382451/job/93012646081#step:5:1159)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

This fails in main and new PRs.