### PR TITLE
fix: add fmt/format.h include to FileLoader*

### DIFF
--- a/src/FileLoader.cpp
+++ b/src/FileLoader.cpp
@@ -8,6 +8,7 @@
 #include <XML/Utilities.h>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cstdlib>
 #include <filesystem>

--- a/src/FileLoaderHelper.h
+++ b/src/FileLoaderHelper.h
@@ -9,6 +9,7 @@
 #include <DD4hep/Printout.h>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cstdlib>
 #include <filesystem>


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds an explicit include of fmt/format.h for use of fmt::format. This is required in newer versions of fmt, e.g. https://github.com/fmtlib/fmt/blob/12.2.0/include/fmt/core.h#L12, and fails on macOS in https://github.com/eic/eic-spack/actions/runs/31338619736/job/93353828762#step:14:756.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
