### PR TITLE
fix: explicilty initialize GeometryContext with default constructor

### DIFF
--- a/scripts/test_ACTS.cxx
+++ b/scripts/test_ACTS.cxx
@@ -45,7 +45,7 @@ void test_ACTS(const char* compact = "epic.xml") {
   Acts::ViewConfig passiveView{.color = {240, 180, 0}};     // lightning yellow
   Acts::ViewConfig gridView{.color = {220, 0, 0}};          // scarlet red
   Acts::GeometryContext trackingGeoCtx = Acts::GeometryContext::dangerouslyDefaultConstruct();
-  const Acts::TrackingVolume* world = acts_tracking_geometry->highestTrackingVolume();
+  const Acts::TrackingVolume* world    = acts_tracking_geometry->highestTrackingVolume();
   // Export to obj+mtl
   Acts::ObjVisualization3D objVis;
   Acts::GeometryView3D::drawTrackingVolume(objVis, *world, trackingGeoCtx, containerView,

--- a/scripts/test_ACTS.cxx
+++ b/scripts/test_ACTS.cxx
@@ -44,7 +44,7 @@ void test_ACTS(const char* compact = "epic.xml") {
   Acts::ViewConfig sensitiveView{.color = {0, 180, 240}};   // picton blue
   Acts::ViewConfig passiveView{.color = {240, 180, 0}};     // lightning yellow
   Acts::ViewConfig gridView{.color = {220, 0, 0}};          // scarlet red
-  Acts::GeometryContext trackingGeoCtx;
+  Acts::GeometryContext trackingGeoCtx = Acts::GeometryContext::dangerouslyDefaultConstruct();
   const Acts::TrackingVolume* world = acts_tracking_geometry->highestTrackingVolume();
   // Export to obj+mtl
   Acts::ObjVisualization3D objVis;


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes `scripts/test_ACTS.cxx` to use an explicit Acts geometry context constructor, and avoids deprecation warnings.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/epic/actions/runs/32387031311/job/96484531031?pr=900#step:5:173)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
