### PR TITLE
Updated TB geometry 

### DIFF
--- a/compact/hcal/lfhcal_2026_TB_opt1.xml
+++ b/compact/hcal/lfhcal_2026_TB_opt1.xml
@@ -55,6 +55,11 @@
         y="EightM_OuterHeight*4+1*cm"/>
       <envelope material="Steel235"/>
 
+      <copperplate material="Copper" vis="AnlOrange">
+        <dimensions x="30*cm" y="25.112*cm" z="5*mm"/>
+        <position x="0*cm" y="7.644*cm"/>
+      </copperplate>
+
       <eightmodule name="8MModule" vis="InvisibleWithDaughters" repeat="0" >
         <dimensions
         width="EightM_OuterWidth"
@@ -125,11 +130,11 @@
         <position x="-EightM_OuterWidth/2." y="-(EightM_OuterHeight/2.+EightM_OuterHeight)" z="0*mm" orientation="2" IDx="0" IDy="0"/>
         <position x="-EightM_OuterWidth/2." y="-EightM_OuterHeight/2." z="0*mm" orientation="2" IDx="0" IDy="1"/>
         <position x="-EightM_OuterWidth/2." y="EightM_OuterHeight/2." z="0*mm" orientation="2" IDx="0" IDy="2"/>
-        <position x="-EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="2" IDx="0" IDy="3"/>
+        <!-- <position x="-EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="2" IDx="0" IDy="3"/> -->
         <position x="EightM_OuterWidth/2." y="-(EightM_OuterHeight/2.+EightM_OuterHeight)" z="0*mm" orientation="0" IDx="1" IDy="0"/>
         <position x="EightM_OuterWidth/2." y="-EightM_OuterHeight/2." z="0*mm" orientation="0" IDx="1" IDy="1"/>
         <position x="EightM_OuterWidth/2." y="EightM_OuterHeight/2." z="0*mm" orientation="0" IDx="1" IDy="2"/>
-        <position x="EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="0" IDx="1" IDy="3"/>
+        <!-- <position x="EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="0" IDx="1" IDy="3"/> -->
       </eightmodulepositions>
 
 

--- a/compact/hcal/lfhcal_2026_TB_opt2.xml
+++ b/compact/hcal/lfhcal_2026_TB_opt2.xml
@@ -55,6 +55,11 @@
         y="EightM_OuterHeight*4+1*cm"/>
       <envelope material="Steel235"/>
 
+      <copperplate material="Copper" vis="AnlOrange">
+        <dimensions x="30*cm" y="25.112*cm" z="5*mm"/>
+        <position x="0*cm" y="7.644*cm"/>
+      </copperplate>
+
       <eightmodule name="8MModule" vis="InvisibleWithDaughters" repeat="0" >
         <dimensions
         width="EightM_OuterWidth"
@@ -125,11 +130,11 @@
         <position x="-EightM_OuterWidth/2." y="-(EightM_OuterHeight/2.+EightM_OuterHeight)" z="0*mm" orientation="2" IDx="0" IDy="0"/>
         <position x="-EightM_OuterWidth/2." y="-EightM_OuterHeight/2." z="0*mm" orientation="2" IDx="0" IDy="1"/>
         <position x="-EightM_OuterWidth/2." y="EightM_OuterHeight/2." z="0*mm" orientation="2" IDx="0" IDy="2"/>
-        <position x="-EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="2" IDx="0" IDy="3"/>
+        <!-- <position x="-EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="2" IDx="0" IDy="3"/> -->
         <position x="EightM_OuterWidth/2." y="-(EightM_OuterHeight/2.+EightM_OuterHeight)" z="0*mm" orientation="0" IDx="1" IDy="0"/>
         <position x="EightM_OuterWidth/2." y="-EightM_OuterHeight/2." z="0*mm" orientation="0" IDx="1" IDy="1"/>
         <position x="EightM_OuterWidth/2." y="EightM_OuterHeight/2." z="0*mm" orientation="0" IDx="1" IDy="2"/>
-        <position x="EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="0" IDx="1" IDy="3"/>
+        <!-- <position x="EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="0" IDx="1" IDy="3"/> -->
       </eightmodulepositions>
 
 

--- a/src/LFHCAL_geo.cpp
+++ b/src/LFHCAL_geo.cpp
@@ -1261,9 +1261,9 @@ static Ref_t createTestBeam(Detector& desc, xml_h handle, SensitiveDetector sens
                         Position(copper_pos.x(), copper_pos.y(),
                                  -length / 2. + eightM_params.mod_MPThick - copper_dim.z() / 2.));
   }
-  
-  phv              = motherVol.placeVolume(env_vol,
-                                           Transform3D(Position(pos.x(), pos.y(), pos.z() + length / 2.)));
+
+  phv = motherVol.placeVolume(env_vol,
+                              Transform3D(Position(pos.x(), pos.y(), pos.z() + length / 2.)));
   phv.addPhysVolID("system", detID);
   det.setPlacement(phv);
 

--- a/src/LFHCAL_geo.cpp
+++ b/src/LFHCAL_geo.cpp
@@ -1247,6 +1247,21 @@ static Ref_t createTestBeam(Detector& desc, xml_h handle, SensitiveDetector sens
 
   Volume motherVol = desc.pickMotherVolume(det);
   phv              = env_vol.placeVolume(assembly);
+
+  // Add a copper plate in front of the stack for the TB.
+  if (detElem.hasChild(_Unicode(copperplate))) {
+    xml_comp_t copper_xml = detElem.child(_Unicode(copperplate));
+    xml_dim_t copper_dim  = copper_xml.dimensions();
+    xml_dim_t copper_pos  = copper_xml.position();
+    Box copper_box(copper_dim.x() / 2., copper_dim.y() / 2., copper_dim.z() / 2.);
+    Volume copper_vol(detName + "_CopperPlate", copper_box,
+                      desc.material(copper_xml.materialStr()));
+    copper_vol.setVisAttributes(desc.visAttributes(copper_xml.visStr()));
+    env_vol.placeVolume(copper_vol,
+                        Position(copper_pos.x(), copper_pos.y(),
+                                 -length / 2. + eightM_params.mod_MPThick - copper_dim.z() / 2.));
+  }
+  
   phv              = motherVol.placeVolume(env_vol,
                                            Transform3D(Position(pos.x(), pos.y(), pos.z() + length / 2.)));
   phv.addPhysVolID("system", detID);


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

This PR updates both 2026 LFHCal test-beam configurations to use a 2x3 module stack with a 5 mm copper plate on the upper-central front face, which was used for an electron/pion simulation study at the 2026 Yale LFHCal TB Workfest: https://indico.bnl.gov/event/33760/contributions/128665/.

<img width="1657" height="1032" alt="geometry" src="https://github.com/user-attachments/assets/2e8040fa-5846-4977-92ea-a51742c1b733" />


### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [x] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
