### PR TITLE
fix: craterlake_5x41 shouldn't miss barrel_flux_return and forward_endcap_flux

### DIFF
--- a/configurations/craterlake_5x41.yml
+++ b/configurations/craterlake_5x41.yml
@@ -28,6 +28,8 @@ features:
     lfhcal:
     forward_insert:
     barrel_gdml:
+    barrel_flux_return:
+    forward_endcap_flux:
     backward:
     backward_endcap_flux:
   far_forward:


### PR DESCRIPTION
Discovered by accident:
```
diff craterlake_without_zdc_5x41_Au197.yml craterlake_5x41.yml
< pbeam: 41_Au197
---
> pbeam: 41
30,31d29
<     forward_endcap_flux:
<     barrel_flux_return:
36c34
<     default_no_zdc:
---
>     default:
```

### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.
  Claude says no other such mistakes
