### PR TITLE
[pr/lfhcal_8m_module_only] Place trigger scintillators in front of the LFHCal TB modules

### DIFF
--- a/compact/hcal/lfhcal_2024_TB.xml
+++ b/compact/hcal/lfhcal_2024_TB.xml
@@ -63,27 +63,26 @@
         scintillatorMaterial="Polystyrene"
         shellMaterial="PolyvinylAcetate"
         shellThickness="3*mm"
-        centerX="2.85*cm"
-        centerY="1*cm"
+        centerX="0*cm"
+        centerY="0*cm"
         scintillatorVis="AnlGreen"
         shellVis="AnlGray">
         <documentation>
-          gapAfter is the surface-to-surface distance to the following volume; Finger2 uses the LFHCal front face.
-          Scintillators are placed slightly off-center from the stack.
+          gapAfter is the surface-to-surface distance to the following volume; the final scintillator uses the LFHCal front face.
           PolyvinylAcetate is used as a substitute for PLA.
         </documentation>
 
-        <scintillator name="Plate1" id="0" gapAfter="3*mm">
+        <scintillator name="SC1" id="0" gapAfter="32.65*cm">
           <dimensions x="200*mm" y="100*mm" z="10*mm"/>
         </scintillator>
-        <scintillator name="Plate2" id="1" gapAfter="10*cm">
-          <dimensions x="200*mm" y="100*mm" z="10*mm"/>
+        <scintillator name="SC4" id="1" gapAfter="3*mm">
+          <dimensions x="15*mm" y="120*mm" z="10*mm"/>
         </scintillator>
-        <scintillator name="Finger1" id="2" gapAfter="3*mm">
+        <scintillator name="SC5" id="2" gapAfter="32.75*cm">
           <dimensions x="120*mm" y="15*mm" z="10*mm"/>
         </scintillator>
-        <scintillator name="Finger2" id="3" gapAfter="30*cm">
-          <dimensions x="15*mm" y="120*mm" z="10*mm"/>
+        <scintillator name="SC6" id="3" gapAfter="165*cm">
+          <dimensions x="200*mm" y="100*mm" z="10*mm"/>
         </scintillator>
       </triggerscintillators>
 

--- a/compact/hcal/lfhcal_2024_TB.xml
+++ b/compact/hcal/lfhcal_2024_TB.xml
@@ -59,6 +59,34 @@
         x0="-FourM_OuterWidth"/>
       <envelope material="Steel235"/>
 
+      <triggerscintillators
+        scintillatorMaterial="Polystyrene"
+        shellMaterial="PolyvinylAcetate"
+        shellThickness="3*mm"
+        centerX="2.85*cm"
+        centerY="1*cm"
+        scintillatorVis="AnlGreen"
+        shellVis="AnlGray">
+        <documentation>
+          gapAfter is the surface-to-surface distance to the following volume; Finger2 uses the LFHCal front face.
+          Scintillators are placed slightly off-center from the stack.
+          PolyvinylAcetate is used as a substitute for PLA.
+        </documentation>
+
+        <scintillator name="Plate1" id="0" gapAfter="3*mm">
+          <dimensions x="200*mm" y="100*mm" z="10*mm"/>
+        </scintillator>
+        <scintillator name="Plate2" id="1" gapAfter="10*cm">
+          <dimensions x="200*mm" y="100*mm" z="10*mm"/>
+        </scintillator>
+        <scintillator name="Finger1" id="2" gapAfter="3*mm">
+          <dimensions x="120*mm" y="15*mm" z="10*mm"/>
+        </scintillator>
+        <scintillator name="Finger2" id="3" gapAfter="30*cm">
+          <dimensions x="15*mm" y="120*mm" z="10*mm"/>
+        </scintillator>
+      </triggerscintillators>
+
       <eightmodule name="8MModule" vis="InvisibleWithDaughters" repeat="0" >
         <dimensions
         width="EightM_OuterWidth"
@@ -159,6 +187,7 @@
           1 bit [0-1] tower Y
           6 bit [0-63] readout layer z
           6 bit [0-63] layer z in readout layer
+        Trigger scintillators use moduleID X/Y = 15 and tower X = 3-0 ordered along +z.
       </documentation>
       <segmentation type="NoSegmentation"/>
       <id>system:8,moduleIDx:4,moduleIDy:4,moduletype:1,passive:1,towerx:2,towery:1,rlayerz:6,layerz:6</id>

--- a/compact/hcal/lfhcal_2025_TB.xml
+++ b/compact/hcal/lfhcal_2025_TB.xml
@@ -55,6 +55,34 @@
         y="EightM_OuterHeight*2+1*cm"/>
       <envelope material="Steel235"/>
 
+      <triggerscintillators
+        scintillatorMaterial="Polystyrene"
+        shellMaterial="PolyvinylAcetate"
+        shellThickness="3*mm"
+        centerX="2.85*cm"
+        centerY="1*cm"
+        scintillatorVis="AnlGreen"
+        shellVis="AnlGray">
+        <documentation>
+          gapAfter is the surface-to-surface distance to the following volume; Finger2 uses the LFHCal front face.
+          Scintillators are placed slightly off-center from the stack.
+          PolyvinylAcetate is used as a substitute for PLA.
+        </documentation>
+
+        <scintillator name="Plate1" id="0" gapAfter="3*mm">
+          <dimensions x="200*mm" y="100*mm" z="10*mm"/>
+        </scintillator>
+        <scintillator name="Plate2" id="1" gapAfter="10*cm">
+          <dimensions x="200*mm" y="100*mm" z="10*mm"/>
+        </scintillator>
+        <scintillator name="Finger1" id="2" gapAfter="3*mm">
+          <dimensions x="120*mm" y="15*mm" z="10*mm"/>
+        </scintillator>
+        <scintillator name="Finger2" id="3" gapAfter="30*cm">
+          <dimensions x="15*mm" y="120*mm" z="10*mm"/>
+        </scintillator>
+      </triggerscintillators>
+
       <eightmodule name="8MModule" vis="InvisibleWithDaughters" repeat="0" >
         <dimensions
         width="EightM_OuterWidth"
@@ -152,6 +180,7 @@
           1 bit [0-1] tower Y
           6 bit [0-63] readout layer z
           6 bit [0-63] layer z in readout layer
+        Trigger scintillators use moduleID X/Y = 15 and tower X = 0-3 ordered along +z.
       </documentation>
       <id>system:8,moduleIDx:4,moduleIDy:4,moduletype:1,passive:1,towerx:2,towery:1,rlayerz:6,layerz:6</id>
     </readout>

--- a/compact/hcal/lfhcal_2025_TB.xml
+++ b/compact/hcal/lfhcal_2025_TB.xml
@@ -59,27 +59,26 @@
         scintillatorMaterial="Polystyrene"
         shellMaterial="PolyvinylAcetate"
         shellThickness="3*mm"
-        centerX="2.85*cm"
-        centerY="1*cm"
+        centerX="0*cm"
+        centerY="0*cm"
         scintillatorVis="AnlGreen"
         shellVis="AnlGray">
         <documentation>
-          gapAfter is the surface-to-surface distance to the following volume; Finger2 uses the LFHCal front face.
-          Scintillators are placed slightly off-center from the stack.
+          gapAfter is the surface-to-surface distance to the following volume; the final scintillator uses the LFHCal front face.
           PolyvinylAcetate is used as a substitute for PLA.
         </documentation>
 
-        <scintillator name="Plate1" id="0" gapAfter="3*mm">
+        <scintillator name="Plate1" id="0" gapAfter="8*cm">
           <dimensions x="200*mm" y="100*mm" z="10*mm"/>
         </scintillator>
-        <scintillator name="Plate2" id="1" gapAfter="10*cm">
-          <dimensions x="200*mm" y="100*mm" z="10*mm"/>
+        <scintillator name="Finger1" id="1" gapAfter="1*cm">
+          <dimensions x="15*mm" y="120*mm" z="10*mm"/>
         </scintillator>
-        <scintillator name="Finger1" id="2" gapAfter="3*mm">
+        <scintillator name="Finger2" id="2" gapAfter="15*cm">
           <dimensions x="120*mm" y="15*mm" z="10*mm"/>
         </scintillator>
-        <scintillator name="Finger2" id="3" gapAfter="30*cm">
-          <dimensions x="15*mm" y="120*mm" z="10*mm"/>
+        <scintillator name="Plate2" id="3" gapAfter="42*cm">
+          <dimensions x="200*mm" y="100*mm" z="10*mm"/>
         </scintillator>
       </triggerscintillators>
 

--- a/compact/hcal/lfhcal_2026_TB_opt1.xml
+++ b/compact/hcal/lfhcal_2026_TB_opt1.xml
@@ -73,7 +73,7 @@
           Scintillators are placed slightly off-center so a ddsim particle gun can avoid shooting between the modules.
           PolyvinylAcetate is used as a substitute for PLA.
         </documentation>
-        
+
         <scintillator name="Plate1" id="0" gapAfter="3*mm">
           <dimensions x="200*mm" y="100*mm" z="10*mm"/>
         </scintillator>

--- a/compact/hcal/lfhcal_2026_TB_opt1.xml
+++ b/compact/hcal/lfhcal_2026_TB_opt1.xml
@@ -60,6 +60,34 @@
         <position x="0*cm" y="7.644*cm"/>
       </copperplate>
 
+      <triggerscintillators
+        scintillatorMaterial="Polystyrene"
+        shellMaterial="PolyvinylAcetate"
+        shellThickness="3*mm"
+        centerX="2.85*cm"
+        centerY="9.1*cm"
+        scintillatorVis="AnlGreen"
+        shellVis="AnlGray">
+        <documentation>
+          gapAfter is the surface-to-surface distance to the following volume; Finger2 uses the LFHCal front face.
+          Scintillators are placed slightly off-center so a ddsim particle gun can avoid shooting between the modules.
+          PolyvinylAcetate is used as a substitute for PLA.
+        </documentation>
+        
+        <scintillator name="Plate1" id="0" gapAfter="3*mm">
+          <dimensions x="200*mm" y="100*mm" z="10*mm"/>
+        </scintillator>
+        <scintillator name="Plate2" id="1" gapAfter="10*cm">
+          <dimensions x="200*mm" y="100*mm" z="10*mm"/>
+        </scintillator>
+        <scintillator name="Finger1" id="2" gapAfter="3*mm">
+          <dimensions x="120*mm" y="15*mm" z="10*mm"/>
+        </scintillator>
+        <scintillator name="Finger2" id="3" gapAfter="30*cm">
+          <dimensions x="15*mm" y="120*mm" z="10*mm"/>
+        </scintillator>
+      </triggerscintillators>
+
       <eightmodule name="8MModule" vis="InvisibleWithDaughters" repeat="0" >
         <dimensions
         width="EightM_OuterWidth"
@@ -162,6 +190,7 @@
           1 bit [0-1] tower Y
           6 bit [0-63] readout layer z
           6 bit [0-63] layer z in readout layer
+        Trigger scintillators use moduleID X/Y = 15 and tower X = 0-3 ordered along +z.
       </documentation>
      <segmentation type="NoSegmentation"/>
       <id>system:8,moduleIDx:4,moduleIDy:4,moduletype:1,passive:1,towerx:2,towery:1,rlayerz:6,layerz:6</id>

--- a/compact/hcal/lfhcal_2026_TB_opt1.xml
+++ b/compact/hcal/lfhcal_2026_TB_opt1.xml
@@ -55,6 +55,11 @@
         y="EightM_OuterHeight*4+1*cm"/>
       <envelope material="Steel235"/>
 
+      <copperplate material="Copper" vis="AnlOrange">
+        <dimensions x="30*cm" y="25.112*cm" z="5*mm"/>
+        <position x="0*cm" y="7.644*cm"/>
+      </copperplate>
+
       <eightmodule name="8MModule" vis="InvisibleWithDaughters" repeat="0" >
         <dimensions
         width="EightM_OuterWidth"
@@ -125,11 +130,11 @@
         <position x="-EightM_OuterWidth/2." y="-(EightM_OuterHeight/2.+EightM_OuterHeight)" z="0*mm" orientation="2" IDx="0" IDy="0"/>
         <position x="-EightM_OuterWidth/2." y="-EightM_OuterHeight/2." z="0*mm" orientation="2" IDx="0" IDy="1"/>
         <position x="-EightM_OuterWidth/2." y="EightM_OuterHeight/2." z="0*mm" orientation="2" IDx="0" IDy="2"/>
-        <position x="-EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="2" IDx="0" IDy="3"/>
+        <!-- <position x="-EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="2" IDx="0" IDy="3"/> -->
         <position x="EightM_OuterWidth/2." y="-(EightM_OuterHeight/2.+EightM_OuterHeight)" z="0*mm" orientation="0" IDx="1" IDy="0"/>
         <position x="EightM_OuterWidth/2." y="-EightM_OuterHeight/2." z="0*mm" orientation="0" IDx="1" IDy="1"/>
         <position x="EightM_OuterWidth/2." y="EightM_OuterHeight/2." z="0*mm" orientation="0" IDx="1" IDy="2"/>
-        <position x="EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="0" IDx="1" IDy="3"/>
+        <!-- <position x="EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="0" IDx="1" IDy="3"/> -->
       </eightmodulepositions>
 
 

--- a/compact/hcal/lfhcal_2026_TB_opt1.xml
+++ b/compact/hcal/lfhcal_2026_TB_opt1.xml
@@ -64,26 +64,25 @@
         scintillatorMaterial="Polystyrene"
         shellMaterial="PolyvinylAcetate"
         shellThickness="3*mm"
-        centerX="2.85*cm"
-        centerY="9.1*cm"
+        centerX="0*cm"
+        centerY="5.05*cm"
         scintillatorVis="AnlGreen"
         shellVis="AnlGray">
         <documentation>
           gapAfter is the surface-to-surface distance to the following volume; Finger2 uses the LFHCal front face.
-          Scintillators are placed slightly off-center so a ddsim particle gun can avoid shooting between the modules.
           PolyvinylAcetate is used as a substitute for PLA.
         </documentation>
 
         <scintillator name="Plate1" id="0" gapAfter="3*mm">
           <dimensions x="200*mm" y="100*mm" z="10*mm"/>
         </scintillator>
-        <scintillator name="Plate2" id="1" gapAfter="10*cm">
+        <scintillator name="Plate2" id="1" gapAfter="6.5*cm">
           <dimensions x="200*mm" y="100*mm" z="10*mm"/>
         </scintillator>
         <scintillator name="Finger1" id="2" gapAfter="3*mm">
           <dimensions x="120*mm" y="15*mm" z="10*mm"/>
         </scintillator>
-        <scintillator name="Finger2" id="3" gapAfter="30*cm">
+        <scintillator name="Finger2" id="3" gapAfter="183.5*cm">
           <dimensions x="15*mm" y="120*mm" z="10*mm"/>
         </scintillator>
       </triggerscintillators>

--- a/compact/hcal/lfhcal_2026_TB_opt2.xml
+++ b/compact/hcal/lfhcal_2026_TB_opt2.xml
@@ -73,7 +73,7 @@
           Scintillators are placed slightly off-center so a ddsim particle gun can avoid shooting between the modules.
           PolyvinylAcetate is used as a substitute for PLA.
         </documentation>
-        
+
         <scintillator name="Plate1" id="0" gapAfter="3*mm">
           <dimensions x="200*mm" y="100*mm" z="10*mm"/>
         </scintillator>

--- a/compact/hcal/lfhcal_2026_TB_opt2.xml
+++ b/compact/hcal/lfhcal_2026_TB_opt2.xml
@@ -55,6 +55,11 @@
         y="EightM_OuterHeight*4+1*cm"/>
       <envelope material="Steel235"/>
 
+      <copperplate material="Copper" vis="AnlOrange">
+        <dimensions x="30*cm" y="25.112*cm" z="5*mm"/>
+        <position x="0*cm" y="7.644*cm"/>
+      </copperplate>
+
       <eightmodule name="8MModule" vis="InvisibleWithDaughters" repeat="0" >
         <dimensions
         width="EightM_OuterWidth"
@@ -125,11 +130,11 @@
         <position x="-EightM_OuterWidth/2." y="-(EightM_OuterHeight/2.+EightM_OuterHeight)" z="0*mm" orientation="2" IDx="0" IDy="0"/>
         <position x="-EightM_OuterWidth/2." y="-EightM_OuterHeight/2." z="0*mm" orientation="2" IDx="0" IDy="1"/>
         <position x="-EightM_OuterWidth/2." y="EightM_OuterHeight/2." z="0*mm" orientation="2" IDx="0" IDy="2"/>
-        <position x="-EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="2" IDx="0" IDy="3"/>
+        <!-- <position x="-EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="2" IDx="0" IDy="3"/> -->
         <position x="EightM_OuterWidth/2." y="-(EightM_OuterHeight/2.+EightM_OuterHeight)" z="0*mm" orientation="0" IDx="1" IDy="0"/>
         <position x="EightM_OuterWidth/2." y="-EightM_OuterHeight/2." z="0*mm" orientation="0" IDx="1" IDy="1"/>
         <position x="EightM_OuterWidth/2." y="EightM_OuterHeight/2." z="0*mm" orientation="0" IDx="1" IDy="2"/>
-        <position x="EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="0" IDx="1" IDy="3"/>
+        <!-- <position x="EightM_OuterWidth/2." y="EightM_OuterHeight/2.+EightM_OuterHeight" z="0*mm" orientation="0" IDx="1" IDy="3"/> -->
       </eightmodulepositions>
 
 

--- a/compact/hcal/lfhcal_2026_TB_opt2.xml
+++ b/compact/hcal/lfhcal_2026_TB_opt2.xml
@@ -64,26 +64,25 @@
         scintillatorMaterial="Polystyrene"
         shellMaterial="PolyvinylAcetate"
         shellThickness="3*mm"
-        centerX="2.85*cm"
-        centerY="9.1*cm"
+        centerX="0*cm"
+        centerY="5.05*cm"
         scintillatorVis="AnlGreen"
         shellVis="AnlGray">
         <documentation>
           gapAfter is the surface-to-surface distance to the following volume; Finger2 uses the LFHCal front face.
-          Scintillators are placed slightly off-center so a ddsim particle gun can avoid shooting between the modules.
           PolyvinylAcetate is used as a substitute for PLA.
         </documentation>
 
         <scintillator name="Plate1" id="0" gapAfter="3*mm">
           <dimensions x="200*mm" y="100*mm" z="10*mm"/>
         </scintillator>
-        <scintillator name="Plate2" id="1" gapAfter="10*cm">
+        <scintillator name="Plate2" id="1" gapAfter="6.5*cm">
           <dimensions x="200*mm" y="100*mm" z="10*mm"/>
         </scintillator>
         <scintillator name="Finger1" id="2" gapAfter="3*mm">
           <dimensions x="120*mm" y="15*mm" z="10*mm"/>
         </scintillator>
-        <scintillator name="Finger2" id="3" gapAfter="30*cm">
+        <scintillator name="Finger2" id="3" gapAfter="183.5*cm">
           <dimensions x="15*mm" y="120*mm" z="10*mm"/>
         </scintillator>
       </triggerscintillators>

--- a/compact/hcal/lfhcal_2026_TB_opt2.xml
+++ b/compact/hcal/lfhcal_2026_TB_opt2.xml
@@ -60,6 +60,34 @@
         <position x="0*cm" y="7.644*cm"/>
       </copperplate>
 
+      <triggerscintillators
+        scintillatorMaterial="Polystyrene"
+        shellMaterial="PolyvinylAcetate"
+        shellThickness="3*mm"
+        centerX="2.85*cm"
+        centerY="9.1*cm"
+        scintillatorVis="AnlGreen"
+        shellVis="AnlGray">
+        <documentation>
+          gapAfter is the surface-to-surface distance to the following volume; Finger2 uses the LFHCal front face.
+          Scintillators are placed slightly off-center so a ddsim particle gun can avoid shooting between the modules.
+          PolyvinylAcetate is used as a substitute for PLA.
+        </documentation>
+        
+        <scintillator name="Plate1" id="0" gapAfter="3*mm">
+          <dimensions x="200*mm" y="100*mm" z="10*mm"/>
+        </scintillator>
+        <scintillator name="Plate2" id="1" gapAfter="10*cm">
+          <dimensions x="200*mm" y="100*mm" z="10*mm"/>
+        </scintillator>
+        <scintillator name="Finger1" id="2" gapAfter="3*mm">
+          <dimensions x="120*mm" y="15*mm" z="10*mm"/>
+        </scintillator>
+        <scintillator name="Finger2" id="3" gapAfter="30*cm">
+          <dimensions x="15*mm" y="120*mm" z="10*mm"/>
+        </scintillator>
+      </triggerscintillators>
+
       <eightmodule name="8MModule" vis="InvisibleWithDaughters" repeat="0" >
         <dimensions
         width="EightM_OuterWidth"
@@ -162,6 +190,7 @@
           1 bit [0-1] tower Y
           6 bit [0-63] readout layer z
           6 bit [0-63] layer z in readout layer
+        Trigger scintillators use moduleID X/Y = 15 and tower X = 0-3 ordered along +z.
       </documentation>
       <segmentation type="NoSegmentation"/>
       <id>system:8,moduleIDx:4,moduleIDy:4,moduletype:1,passive:1,towerx:2,towery:1,rlayerz:4,layerz:6</id>

--- a/src/LFHCAL_geo.cpp
+++ b/src/LFHCAL_geo.cpp
@@ -1305,9 +1305,9 @@ static Ref_t createTestBeam(Detector& desc, xml_h handle, SensitiveDetector sens
     Assembly trigger_assembly(detName + "_TriggerScintillators");
     // Enclose each sensitive block in its shell and place the blocks away from the front face.
     for (const auto& trigger : triggers) {
-      double outer_x  = trigger.x + 2. * shell_thickness;
-      double outer_y  = trigger.y + 2. * shell_thickness;
-      double outer_z  = trigger.thickness + 2. * shell_thickness;
+      double outer_x           = trigger.x + 2. * shell_thickness;
+      double outer_y           = trigger.y + 2. * shell_thickness;
+      double outer_z           = trigger.thickness + 2. * shell_thickness;
       double relative_center_z = relative_face + outer_z / 2.;
       double center_z          = front_face_z + placement_z_sign * relative_center_z;
 

--- a/src/LFHCAL_geo.cpp
+++ b/src/LFHCAL_geo.cpp
@@ -1262,7 +1262,7 @@ static Ref_t createTestBeam(Detector& desc, xml_h handle, SensitiveDetector sens
                                  -length / 2. + eightM_params.mod_MPThick - copper_dim.z() / 2.));
   }
 
-  // Build the upstream trigger-scintillator assembly when configured.
+  // Build the trigger-scintillator assembly when configured.
   if (detElem.hasChild(_Unicode(triggerscintillators))) {
     xml_comp_t triggers_xml = detElem.child(_Unicode(triggerscintillators));
     double shell_thickness  = triggers_xml.attr<double>(_Unicode(shellThickness));
@@ -1284,7 +1284,7 @@ static Ref_t createTestBeam(Detector& desc, xml_h handle, SensitiveDetector sens
     };
     std::vector<TriggerScintillator> triggers;
 
-    // Read scintillator dimensions and downstream gaps ordered along +z.
+    // Read scintillator dimensions and downstream gaps in their listed order.
     for (xml_coll_t trigger_i(triggers_xml, _Unicode(scintillator)); trigger_i; ++trigger_i) {
       xml_comp_t trigger_xml = trigger_i;
       xml_dim_t trigger_dim  = trigger_xml.dimensions();
@@ -1293,19 +1293,23 @@ static Ref_t createTestBeam(Detector& desc, xml_h handle, SensitiveDetector sens
                           trigger_xml.attr<double>(_Unicode(gapAfter))});
     }
 
-    // Locate the assembly upstream of the configured gap to the LFHCal front face.
-    double upstream_face = 0.;
+    // Locate the assembly beside the module's front face.
+    double relative_face = 0.;
     for (const auto& trigger : triggers) {
-      upstream_face -= trigger.thickness + 2. * shell_thickness + trigger.gap_after;
+      relative_face -= trigger.thickness + 2. * shell_thickness + trigger.gap_after;
     }
+    bool flipped            = !pos8M.empty() && pos8M.front().orientation == 1;
+    double front_face_z     = flipped ? length : 0.;
+    double placement_z_sign = flipped ? -1. : 1.;
 
     Assembly trigger_assembly(detName + "_TriggerScintillators");
-    // Enclose each sensitive block in its shell and place the blocks along +z.
+    // Enclose each sensitive block in its shell and place the blocks away from the front face.
     for (const auto& trigger : triggers) {
       double outer_x  = trigger.x + 2. * shell_thickness;
       double outer_y  = trigger.y + 2. * shell_thickness;
       double outer_z  = trigger.thickness + 2. * shell_thickness;
-      double center_z = upstream_face + outer_z / 2.;
+      double relative_center_z = relative_face + outer_z / 2.;
+      double center_z          = front_face_z + placement_z_sign * relative_center_z;
 
       Box shell_box(outer_x / 2., outer_y / 2., outer_z / 2.);
       Volume shell_vol(detName + "_" + trigger.name + "Shell", shell_box,
@@ -1328,7 +1332,7 @@ static Ref_t createTestBeam(Detector& desc, xml_h handle, SensitiveDetector sens
           .addPhysVolID("layerz", 0);
 
       trigger_assembly.placeVolume(shell_vol, Position(center_x, center_y, center_z));
-      upstream_face += outer_z + trigger.gap_after;
+      relative_face += outer_z + trigger.gap_after;
     }
     // Place the completed trigger assembly relative to the LFHCal origin.
     // NOTE: current assembly is placed slightly offset from the center of the stack so ddsim particle gun

--- a/src/LFHCAL_geo.cpp
+++ b/src/LFHCAL_geo.cpp
@@ -1247,6 +1247,21 @@ static Ref_t createTestBeam(Detector& desc, xml_h handle, SensitiveDetector sens
 
   Volume motherVol = desc.pickMotherVolume(det);
   phv              = env_vol.placeVolume(assembly);
+
+  // Add a copper plate in front of the stack for the TB.
+  if (detElem.hasChild(_Unicode(copperplate))) {
+    xml_comp_t copper_xml = detElem.child(_Unicode(copperplate));
+    xml_dim_t copper_dim  = copper_xml.dimensions();
+    xml_dim_t copper_pos  = copper_xml.position();
+    Box copper_box(copper_dim.x() / 2., copper_dim.y() / 2., copper_dim.z() / 2.);
+    Volume copper_vol(detName + "_CopperPlate", copper_box,
+                      desc.material(copper_xml.materialStr()));
+    copper_vol.setVisAttributes(desc.visAttributes(copper_xml.visStr()));
+    env_vol.placeVolume(copper_vol,
+                        Position(copper_pos.x(), copper_pos.y(),
+                                 -length / 2. + eightM_params.mod_MPThick - copper_dim.z() / 2.));
+  }
+  
   phv              = motherVol.placeVolume(env_vol,
                                            Transform3D(Position(pos.x(), pos.y(), pos.z() + length / 2.)));
   phv.addPhysVolID("system", detID);

--- a/src/LFHCAL_geo.cpp
+++ b/src/LFHCAL_geo.cpp
@@ -1261,7 +1261,84 @@ static Ref_t createTestBeam(Detector& desc, xml_h handle, SensitiveDetector sens
                         Position(copper_pos.x(), copper_pos.y(),
                                  -length / 2. + eightM_params.mod_MPThick - copper_dim.z() / 2.));
   }
-  
+
+  // Build the upstream trigger-scintillator assembly when configured.
+  if (detElem.hasChild(_Unicode(triggerscintillators))) {
+    xml_comp_t triggers_xml = detElem.child(_Unicode(triggerscintillators));
+    double shell_thickness  = triggers_xml.attr<double>(_Unicode(shellThickness));
+    double center_x         = triggers_xml.attr<double>(_Unicode(centerX));
+    double center_y         = triggers_xml.attr<double>(_Unicode(centerY));
+    std::string scintillator_material =
+        triggers_xml.attr<std::string>(_Unicode(scintillatorMaterial));
+    std::string shell_material = triggers_xml.attr<std::string>(_Unicode(shellMaterial));
+    std::string scintillator_vis =
+        triggers_xml.attr<std::string>(_Unicode(scintillatorVis));
+    std::string shell_vis = triggers_xml.attr<std::string>(_Unicode(shellVis));
+
+    struct TriggerScintillator {
+      std::string name;
+      int id;
+      double x;
+      double y;
+      double thickness;
+      double gap_after;
+    };
+    std::vector<TriggerScintillator> triggers;
+    
+    // Read scintillator dimensions and downstream gaps ordered along +z.
+    for (xml_coll_t trigger_i(triggers_xml, _Unicode(scintillator)); trigger_i; ++trigger_i) {
+      xml_comp_t trigger_xml = trigger_i;
+      xml_dim_t trigger_dim  = trigger_xml.dimensions();
+      triggers.push_back({trigger_xml.nameStr(), trigger_xml.attr<int>(_Unicode(id)),
+                          trigger_dim.x(), trigger_dim.y(), trigger_dim.z(),
+                          trigger_xml.attr<double>(_Unicode(gapAfter))});
+    }
+
+    // Locate the assembly upstream of the configured gap to the LFHCal front face.
+    double upstream_face = 0.;
+    for (const auto& trigger : triggers) {
+      upstream_face -= trigger.thickness + 2. * shell_thickness + trigger.gap_after;
+    }
+
+    Assembly trigger_assembly(detName + "_TriggerScintillators");
+    // Enclose each sensitive block in its shell and place the blocks along +z.
+    for (const auto& trigger : triggers) {
+      double outer_x  = trigger.x + 2. * shell_thickness;
+      double outer_y  = trigger.y + 2. * shell_thickness;
+      double outer_z  = trigger.thickness + 2. * shell_thickness;
+      double center_z = upstream_face + outer_z / 2.;
+
+      Box shell_box(outer_x / 2., outer_y / 2., outer_z / 2.);
+      Volume shell_vol(detName + "_" + trigger.name + "Shell", shell_box,
+                       desc.material(shell_material));
+      shell_vol.setVisAttributes(desc.visAttributes(shell_vis));
+
+      Box scintillator_box(trigger.x / 2., trigger.y / 2., trigger.thickness / 2.);
+      Volume scintillator_vol(detName + "_" + trigger.name, scintillator_box,
+                              desc.material(scintillator_material));
+      scintillator_vol.setVisAttributes(desc.visAttributes(scintillator_vis));
+      scintillator_vol.setSensitiveDetector(sens);
+      PlacedVolume scintillator_pv = shell_vol.placeVolume(scintillator_vol);
+      scintillator_pv.addPhysVolID("moduleIDx", 15)
+          .addPhysVolID("moduleIDy", 15)
+          .addPhysVolID("moduletype", 1)
+          .addPhysVolID("passive", 0)
+          .addPhysVolID("towerx", trigger.id)
+          .addPhysVolID("towery", 0)
+          .addPhysVolID("rlayerz", 0)
+          .addPhysVolID("layerz", 0);
+
+      trigger_assembly.placeVolume(shell_vol, Position(center_x, center_y, center_z));
+      upstream_face += outer_z + trigger.gap_after;
+    }
+    // Place the completed trigger assembly relative to the LFHCal origin.
+    // NOTE: current assembly is placed slightly offset from the center of the stack so ddsim particle gun
+    // does not shoot into a gap between modules
+    PlacedVolume trigger_pv =
+        motherVol.placeVolume(trigger_assembly, Position(pos.x(), pos.y(), pos.z()));
+    trigger_pv.addPhysVolID("system", detID);
+  }
+
   phv              = motherVol.placeVolume(env_vol,
                                            Transform3D(Position(pos.x(), pos.y(), pos.z() + length / 2.)));
   phv.addPhysVolID("system", detID);

--- a/src/LFHCAL_geo.cpp
+++ b/src/LFHCAL_geo.cpp
@@ -1270,10 +1270,9 @@ static Ref_t createTestBeam(Detector& desc, xml_h handle, SensitiveDetector sens
     double center_y         = triggers_xml.attr<double>(_Unicode(centerY));
     std::string scintillator_material =
         triggers_xml.attr<std::string>(_Unicode(scintillatorMaterial));
-    std::string shell_material = triggers_xml.attr<std::string>(_Unicode(shellMaterial));
-    std::string scintillator_vis =
-        triggers_xml.attr<std::string>(_Unicode(scintillatorVis));
-    std::string shell_vis = triggers_xml.attr<std::string>(_Unicode(shellVis));
+    std::string shell_material   = triggers_xml.attr<std::string>(_Unicode(shellMaterial));
+    std::string scintillator_vis = triggers_xml.attr<std::string>(_Unicode(scintillatorVis));
+    std::string shell_vis        = triggers_xml.attr<std::string>(_Unicode(shellVis));
 
     struct TriggerScintillator {
       std::string name;
@@ -1284,7 +1283,7 @@ static Ref_t createTestBeam(Detector& desc, xml_h handle, SensitiveDetector sens
       double gap_after;
     };
     std::vector<TriggerScintillator> triggers;
-    
+
     // Read scintillator dimensions and downstream gaps ordered along +z.
     for (xml_coll_t trigger_i(triggers_xml, _Unicode(scintillator)); trigger_i; ++trigger_i) {
       xml_comp_t trigger_xml = trigger_i;

--- a/src/LFHCAL_geo.cpp
+++ b/src/LFHCAL_geo.cpp
@@ -1335,8 +1335,6 @@ static Ref_t createTestBeam(Detector& desc, xml_h handle, SensitiveDetector sens
       relative_face += outer_z + trigger.gap_after;
     }
     // Place the completed trigger assembly relative to the LFHCal origin.
-    // NOTE: current assembly is placed slightly offset from the center of the stack so ddsim particle gun
-    // does not shoot into a gap between modules
     PlacedVolume trigger_pv =
         motherVol.placeVolume(trigger_assembly, Position(pos.x(), pos.y(), pos.z()));
     trigger_pv.addPhysVolID("system", detID);


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

Places trigger scintillators in front of the LFHCal TB modules by some arbitrary distance (if someone has the exact measurements that would be great), PolyvinylAcetate was used as a substitute for the PLA casing around scintillators.
<img width="2354" height="1468" alt="geometry" src="https://github.com/user-attachments/assets/580ae4df-a281-4361-8bbc-51442e3b07e0" />

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [x] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
