### PR TITLE
2DStrip MPGDs: add ecals to configuration file.

### DIFF
--- a/configurations/craterlake_tracking_2DStrip.yml
+++ b/configurations/craterlake_tracking_2DStrip.yml
@@ -15,6 +15,8 @@ features:
     silicon_disks:
     tof_barrel:
     tof_endcap:
+  ecal:
+    bic_layer1_only:
   far_forward:
     default:
   far_backward:


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR is presumed to fix the issue evoked in the PR "https://github.com/eic/EICrecon/pull/2889" of `EICrecon` (_viz._ 2DStrip configuration conflicting with material map).
The modification to the source code is actually quite simple: merely adding ecals to the 2DStrip configuration.

### What is the urgency of this PR?
- [ *] Medium

### What kind of change does this PR introduce?
- [ ] other: Not sure whether it's fixing a bug or merely hiding it.

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
