### PR TITLE
ci: add material map validation plots to GitHub Pages

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -894,7 +894,7 @@ jobs:
       - name: Generate material-map validation index
         if: github.event.pull_request.number == matrix.pr || steps.download_material_map.outputs.found_artifact == 'true'
         run: |
-          VALDIR="publishing_docs/pr/${{ matrix.pr }}/material-map/Validation"
+          VALDIR="publishing_docs/pr/${{ matrix.pr }}/material-map/scripts/material_map/Validation"
           if [ -d "$VALDIR" ]; then
             echo '<html><body><h1>Material map validation plots</h1><ul>' > "$VALDIR/index.html"
             find "$VALDIR" -name '*.pdf' | sort | while read f; do
@@ -981,7 +981,7 @@ jobs:
       - name: Generate material-map validation index
         if: github.ref_name == 'main' || steps.download_material_map.outputs.found_artifact == 'true'
         run: |
-          VALDIR="publishing_docs/material-map/Validation"
+          VALDIR="publishing_docs/material-map/scripts/material_map/Validation"
           if [ -d "$VALDIR" ]; then
             echo '<html><body><h1>Material map validation plots</h1><ul>' > "$VALDIR/index.html"
             find "$VALDIR" -name '*.pdf' | sort | while read f; do
@@ -994,7 +994,7 @@ jobs:
         if: github.ref_name == 'main' || steps.download_material_map.outputs.found_artifact == 'true'
         run: |
           echo "### Material map validation for main" >> publishing_docs/material-map/index.md
-          echo "- [Validation plots](https://eic.github.io/epic/material-map/Validation/index.html)" >> publishing_docs/material-map/index.md
+          echo "- [Validation plots](https://eic.github.io/epic/material-map/scripts/material_map/Validation/index.html)" >> publishing_docs/material-map/index.md
       - name: Ensure publishing_docs is non-empty
         run: mkdir -p publishing_docs && touch publishing_docs/.keep
       - uses: actions/upload-artifact@v7
@@ -1055,9 +1055,9 @@ jobs:
         [ -d _site/pr/${{ github.event.pull_request.number }}/capybara/ ] && \
           find _site/pr/${{ github.event.pull_request.number }}/capybara/ -mindepth 1 -maxdepth 1 -type d -printf \
             "- [%f](https://eic.github.io/epic/pr/${{ github.event.pull_request.number }}/capybara/%f/index.html)\n" | sort >> capybara_${{ github.event.pull_request.number }}.md || true
-        if [ -d _site/pr/${{ github.event.pull_request.number }}/material-map/Validation/ ]; then
+        if [ -d _site/pr/${{ github.event.pull_request.number }}/material-map/scripts/material_map/Validation/ ]; then
           echo "### Material map validation" >> capybara_${{ github.event.pull_request.number }}.md
-          echo "- [Validation plots](https://eic.github.io/epic/pr/${{ github.event.pull_request.number }}/material-map/Validation/index.html)" >> capybara_${{ github.event.pull_request.number }}.md
+          echo "- [Validation plots](https://eic.github.io/epic/pr/${{ github.event.pull_request.number }}/material-map/scripts/material_map/Validation/index.html)" >> capybara_${{ github.event.pull_request.number }}.md
         fi
         echo "<sup><sub>Last updated $(TZ=America/New_York date -Iminutes) ${{github.event.pull_request.head.sha}}</sub></sup>" >> capybara_${{ github.event.pull_request.number }}.md
     - name: Create capybara step summary

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -864,6 +864,51 @@ jobs:
           path: publishing_docs/
           if-no-files-found: ignore
 
+  get-material-map-from-open-prs:
+    runs-on: ubuntu-latest
+    needs:
+      - list-open-prs
+      - validate-material-map
+    strategy:
+      matrix: ${{ fromJSON(needs.list-open-prs.outputs.json) }}
+      fail-fast: false
+      max-parallel: 4
+    steps:
+      - name: Download material_map artifact (other PRs)
+        id: download_material_map
+        uses: dawidd6/action-download-artifact@v21
+        if: github.event.pull_request.number != matrix.pr
+        with:
+          commit: ${{ matrix.head_sha }}
+          path: publishing_docs/pr/${{ matrix.pr }}/material-map/
+          name: material_map
+          workflow: ".github/workflows/linux-eic-shell.yml"
+          workflow_conclusion: "completed"
+          if_no_artifact_found: ignore
+      - name: Download material_map artifact (this PR)
+        uses: actions/download-artifact@v8
+        if: github.event.pull_request.number == matrix.pr
+        with:
+          name: material_map
+          path: publishing_docs/pr/${{ matrix.pr }}/material-map/
+      - name: Generate material-map validation index
+        if: github.event.pull_request.number == matrix.pr || steps.download_material_map.outputs.found_artifact == 'true'
+        run: |
+          VALDIR="publishing_docs/pr/${{ matrix.pr }}/material-map/Validation"
+          if [ -d "$VALDIR" ]; then
+            echo '<html><body><h1>Material map validation plots</h1><ul>' > "$VALDIR/index.html"
+            find "$VALDIR" -name '*.pdf' | sort | while read f; do
+              rel="${f#$VALDIR/}"
+              echo "<li><a href=\"$rel\">$rel</a></li>"
+            done >> "$VALDIR/index.html"
+            echo '</ul></body></html>' >> "$VALDIR/index.html"
+          fi
+      - uses: actions/upload-artifact@v7
+        with:
+          name: github-pages-staging-material-map-pr-${{ matrix.pr }}
+          path: publishing_docs/
+          if-no-files-found: ignore
+
   get-docs-from-main:
     runs-on: ubuntu-latest
     needs:
@@ -908,6 +953,57 @@ jobs:
           if-no-files-found: error
           include-hidden-files: true
 
+  get-material-map-from-main:
+    runs-on: ubuntu-latest
+    needs:
+      - validate-material-map
+    steps:
+      # Note:
+      # - If we run this on a non-main branch, we download from main with action-download-artifact.
+      # - If we run this on the main branch, we have to download from this pipeline with download-artifact.
+      - name: Download material_map artifact (in PR)
+        id: download_material_map
+        uses: dawidd6/action-download-artifact@v21
+        if: github.ref_name != 'main'
+        with:
+          branch: main
+          path: publishing_docs/material-map/
+          name: material_map
+          workflow: ".github/workflows/linux-eic-shell.yml"
+          workflow_conclusion: "completed"
+          if_no_artifact_found: ignore
+      - name: Download material_map artifact (on main)
+        uses: actions/download-artifact@v8
+        if: github.ref_name == 'main'
+        with:
+          name: material_map
+          path: publishing_docs/material-map/
+      - name: Generate material-map validation index
+        if: github.ref_name == 'main' || steps.download_material_map.outputs.found_artifact == 'true'
+        run: |
+          VALDIR="publishing_docs/material-map/Validation"
+          if [ -d "$VALDIR" ]; then
+            echo '<html><body><h1>Material map validation plots</h1><ul>' > "$VALDIR/index.html"
+            find "$VALDIR" -name '*.pdf' | sort | while read f; do
+              rel="${f#$VALDIR/}"
+              echo "<li><a href=\"$rel\">$rel</a></li>"
+            done >> "$VALDIR/index.html"
+            echo '</ul></body></html>' >> "$VALDIR/index.html"
+          fi
+      - name: Populate material-map summary (on main)
+        if: github.ref_name == 'main' || steps.download_material_map.outputs.found_artifact == 'true'
+        run: |
+          echo "### Material map validation for main" >> publishing_docs/material-map/index.md
+          echo "- [Validation plots](https://eic.github.io/epic/material-map/Validation/index.html)" >> publishing_docs/material-map/index.md
+      - name: Ensure publishing_docs is non-empty
+        run: mkdir -p publishing_docs && touch publishing_docs/.keep
+      - uses: actions/upload-artifact@v7
+        with:
+          name: github-pages-staging-material-map-main
+          path: publishing_docs/
+          if-no-files-found: error
+          include-hidden-files: true
+
   build-artifacts-page:
     runs-on: ubuntu-latest
     needs:
@@ -918,6 +1014,8 @@ jobs:
     - merge-dawn-view
     - get-docs-from-open-prs
     - get-docs-from-main
+    - get-material-map-from-open-prs
+    - get-material-map-from-main
     if: |
       always() &&
       !cancelled() &&
@@ -957,6 +1055,10 @@ jobs:
         [ -d _site/pr/${{ github.event.pull_request.number }}/capybara/ ] && \
           find _site/pr/${{ github.event.pull_request.number }}/capybara/ -mindepth 1 -maxdepth 1 -type d -printf \
             "- [%f](https://eic.github.io/epic/pr/${{ github.event.pull_request.number }}/capybara/%f/index.html)\n" | sort >> capybara_${{ github.event.pull_request.number }}.md || true
+        if [ -d _site/pr/${{ github.event.pull_request.number }}/material-map/Validation/ ]; then
+          echo "### Material map validation" >> capybara_${{ github.event.pull_request.number }}.md
+          echo "- [Validation plots](https://eic.github.io/epic/pr/${{ github.event.pull_request.number }}/material-map/Validation/index.html)" >> capybara_${{ github.event.pull_request.number }}.md
+        fi
         echo "<sup><sub>Last updated $(TZ=America/New_York date -Iminutes) ${{github.event.pull_request.head.sha}}</sub></sup>" >> capybara_${{ github.event.pull_request.number }}.md
     - name: Create capybara step summary
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -836,6 +836,7 @@ jobs:
     needs:
       - list-open-prs
       - merge-npsim-capybara
+      - validate-material-map
     strategy:
       matrix: ${{ fromJSON(needs.list-open-prs.outputs.json) }}
       fail-fast: false
@@ -858,22 +859,6 @@ jobs:
         with:
           name: capybara-report
           path: publishing_docs/pr/${{ matrix.pr }}/capybara/
-      - uses: actions/upload-artifact@v7
-        with:
-          name: github-pages-staging-pr-${{ matrix.pr }}
-          path: publishing_docs/
-          if-no-files-found: ignore
-
-  get-material-map-from-open-prs:
-    runs-on: ubuntu-latest
-    needs:
-      - list-open-prs
-      - validate-material-map
-    strategy:
-      matrix: ${{ fromJSON(needs.list-open-prs.outputs.json) }}
-      fail-fast: false
-      max-parallel: 4
-    steps:
       - name: Download material_map artifact (other PRs)
         id: download_material_map
         uses: dawidd6/action-download-artifact@v21
@@ -905,7 +890,7 @@ jobs:
           fi
       - uses: actions/upload-artifact@v7
         with:
-          name: github-pages-staging-material-map-pr-${{ matrix.pr }}
+          name: github-pages-staging-pr-${{ matrix.pr }}
           path: publishing_docs/
           if-no-files-found: ignore
 
@@ -913,6 +898,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - merge-npsim-capybara
+      - validate-material-map
     steps:
       # Note:
       # - If we run this on a non-main branch, we download from main with action-download-artifact.
@@ -934,33 +920,6 @@ jobs:
         with:
           name: capybara-report
           path: publishing_docs/capybara/
-      - name: Populate capybara summary (on main)
-        if: github.ref_name == 'main' || steps.download_capybara.outputs.found_artifact == 'true'
-        run: |
-         echo "### Capybara summary for main" >> publishing_docs/capybara/index.md
-         find publishing_docs/capybara/ -mindepth 1 -maxdepth 1 -type d -printf \
-           "- [%f](https://eic.github.io/epic/capybara/%f/index.html)\n" | sort >> publishing_docs/capybara/index.md
-      - name: Create capybara step summary (this PR)
-        if: github.ref_name == 'main'
-        run: |
-          cat publishing_docs/capybara/index.md >> $GITHUB_STEP_SUMMARY
-      - name: Ensure publishing_docs is non-empty
-        run: mkdir -p publishing_docs && touch publishing_docs/.keep
-      - uses: actions/upload-artifact@v7
-        with:
-          name: github-pages-staging-main
-          path: publishing_docs/
-          if-no-files-found: error
-          include-hidden-files: true
-
-  get-material-map-from-main:
-    runs-on: ubuntu-latest
-    needs:
-      - validate-material-map
-    steps:
-      # Note:
-      # - If we run this on a non-main branch, we download from main with action-download-artifact.
-      # - If we run this on the main branch, we have to download from this pipeline with download-artifact.
       - name: Download material_map artifact (in PR)
         id: download_material_map
         uses: dawidd6/action-download-artifact@v21
@@ -978,6 +937,12 @@ jobs:
         with:
           name: material_map
           path: publishing_docs/material-map/
+      - name: Populate capybara summary (on main)
+        if: github.ref_name == 'main' || steps.download_capybara.outputs.found_artifact == 'true'
+        run: |
+         echo "### Capybara summary for main" >> publishing_docs/capybara/index.md
+         find publishing_docs/capybara/ -mindepth 1 -maxdepth 1 -type d -printf \
+           "- [%f](https://eic.github.io/epic/capybara/%f/index.html)\n" | sort >> publishing_docs/capybara/index.md
       - name: Generate material-map validation index
         if: github.ref_name == 'main' || steps.download_material_map.outputs.found_artifact == 'true'
         run: |
@@ -995,11 +960,15 @@ jobs:
         run: |
           echo "### Material map validation for main" >> publishing_docs/material-map/index.md
           echo "- [Validation plots](https://eic.github.io/epic/material-map/scripts/material_map/Validation/index.html)" >> publishing_docs/material-map/index.md
+      - name: Create capybara step summary (this PR)
+        if: github.ref_name == 'main'
+        run: |
+          cat publishing_docs/capybara/index.md >> $GITHUB_STEP_SUMMARY
       - name: Ensure publishing_docs is non-empty
         run: mkdir -p publishing_docs && touch publishing_docs/.keep
       - uses: actions/upload-artifact@v7
         with:
-          name: github-pages-staging-material-map-main
+          name: github-pages-staging-main
           path: publishing_docs/
           if-no-files-found: error
           include-hidden-files: true
@@ -1014,8 +983,6 @@ jobs:
     - merge-dawn-view
     - get-docs-from-open-prs
     - get-docs-from-main
-    - get-material-map-from-open-prs
-    - get-material-map-from-main
     if: |
       always() &&
       !cancelled() &&

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -879,7 +879,7 @@ jobs:
       - name: Generate material-map validation index
         if: github.event.pull_request.number == matrix.pr || steps.download_material_map.outputs.found_artifact == 'true'
         run: |
-          VALDIR="publishing_docs/pr/${{ matrix.pr }}/material-map/scripts/material_map/Validation"
+          VALDIR="publishing_docs/pr/${{ matrix.pr }}/material-map/Validation"
           if [ -d "$VALDIR" ]; then
             echo '<html><body><h1>Material map validation plots</h1><ul>' > "$VALDIR/index.html"
             find "$VALDIR" -name '*.pdf' | sort | while read f; do
@@ -946,7 +946,7 @@ jobs:
       - name: Generate material-map validation index
         if: github.ref_name == 'main' || steps.download_material_map.outputs.found_artifact == 'true'
         run: |
-          VALDIR="publishing_docs/material-map/scripts/material_map/Validation"
+          VALDIR="publishing_docs/material-map/Validation"
           if [ -d "$VALDIR" ]; then
             echo '<html><body><h1>Material map validation plots</h1><ul>' > "$VALDIR/index.html"
             find "$VALDIR" -name '*.pdf' | sort | while read f; do
@@ -959,7 +959,7 @@ jobs:
         if: github.ref_name == 'main' || steps.download_material_map.outputs.found_artifact == 'true'
         run: |
           echo "### Material map validation for main" >> publishing_docs/material-map/index.md
-          echo "- [Validation plots](https://eic.github.io/epic/material-map/scripts/material_map/Validation/index.html)" >> publishing_docs/material-map/index.md
+          echo "- [Validation plots](https://eic.github.io/epic/material-map/Validation/index.html)" >> publishing_docs/material-map/index.md
       - name: Create capybara step summary (this PR)
         if: github.ref_name == 'main'
         run: |
@@ -1022,9 +1022,9 @@ jobs:
         [ -d _site/pr/${{ github.event.pull_request.number }}/capybara/ ] && \
           find _site/pr/${{ github.event.pull_request.number }}/capybara/ -mindepth 1 -maxdepth 1 -type d -printf \
             "- [%f](https://eic.github.io/epic/pr/${{ github.event.pull_request.number }}/capybara/%f/index.html)\n" | sort >> capybara_${{ github.event.pull_request.number }}.md || true
-        if [ -d _site/pr/${{ github.event.pull_request.number }}/material-map/scripts/material_map/Validation/ ]; then
+        if [ -d _site/pr/${{ github.event.pull_request.number }}/material-map/Validation/ ]; then
           echo "### Material map validation" >> capybara_${{ github.event.pull_request.number }}.md
-          echo "- [Validation plots](https://eic.github.io/epic/pr/${{ github.event.pull_request.number }}/material-map/scripts/material_map/Validation/index.html)" >> capybara_${{ github.event.pull_request.number }}.md
+          echo "- [Validation plots](https://eic.github.io/epic/pr/${{ github.event.pull_request.number }}/material-map/Validation/index.html)" >> capybara_${{ github.event.pull_request.number }}.md
         fi
         echo "<sup><sub>Last updated $(TZ=America/New_York date -Iminutes) ${{github.event.pull_request.head.sha}}</sub></sup>" >> capybara_${{ github.event.pull_request.number }}.md
     - name: Create capybara step summary


### PR DESCRIPTION
## Summary

This PR stacks on top of #1159 and adds material map validation plots to the GitHub Pages deployment at https://eic.github.io/epic/.

## Changes

- **`get-docs-from-open-prs`**: Extended to download the `material_map` artifact from each open PR's head SHA and stages it to `publishing_docs/pr/<N>/material-map/`. Generates a `Validation/index.html` listing all PDF plots.
- **`get-docs-from-main`**: Extended to download the `material_map` artifact (from latest main run on non-main branches; from current run on main), stages to `publishing_docs/material-map/`, generates `Validation/index.html` and index markdown.
- **PR comment**: Extends the capybara summary step to also append a material-map validation link (only when the `Validation/` directory exists).

## Validation plots URL pattern

- Per-PR: `https://eic.github.io/epic/pr/<N>/material-map/scripts/material_map/Validation/index.html`
- Main: `https://eic.github.io/epic/material-map/scripts/material_map/Validation/index.html`

Missing artifacts are gracefully ignored so the new functionality does not break existing CI.