### PR TITLE
Add npdet_to_dot workflow for detector geometry visualization

### DIFF
--- a/.github/workflows/convert-to-dot.yml
+++ b/.github/workflows/convert-to-dot.yml
@@ -10,9 +10,6 @@ on:
 jobs:
   convert-to-dot:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        detector_config: ${{fromJson(inputs.detector_configs)}}
     steps:
     - uses: actions/checkout@v7
     - uses: actions/download-artifact@v8
@@ -26,20 +23,23 @@ jobs:
         setup: install/bin/thisepic.sh
         run: |
           export DETECTOR_CACHE=/opt/detector/epic-main/share/epic
-          # Generate dot file from detector configuration
-          npdet_to_dot $DETECTOR_PATH/${{matrix.detector_config}}.xml -o ${{matrix.detector_config}}.dot 2>&1 | sed '/TGeoMatrix::dtor/d'
-          # Convert dot to SVG using dot command
-          dot -Tsvg ${{matrix.detector_config}}.dot -o ${{matrix.detector_config}}.svg
-    - name: Check dot file size
-      run: |
-        line_count=$(wc -l < ${{matrix.detector_config}}.dot)
-        if [ $line_count -gt 1000 ]; then
-          echo "::warning::Dot file for ${{matrix.detector_config}} has $line_count lines (> 1000)"
-        fi
+          IFS=, read -a configs <<< "${{inputs.detector_configs}}"
+          for config in ${configs[@]} ; do
+            echo "::group::${config}" ;
+            # Generate dot file from detector configuration
+            npdet_to_dot $DETECTOR_PATH/${config}.xml -o ${config}.dot 2>&1 | sed '/TGeoMatrix::dtor/d'
+            # Convert dot to SVG using dot command
+            dot -Tsvg ${config}.dot -o ${config}.svg
+            line_count=$(wc -l < ${config}.dot)
+            if [ $line_count -gt 1000 ]; then
+              echo "::warning::Dot file for ${config} has $line_count lines (> 1000)"
+            fi
+            echo "::endgroup::" ;
+          done
     - uses: actions/upload-artifact@v7
       with:
         name: github-pages-staging-detector-geometry
         path: |
-          ${{matrix.detector_config}}.dot
-          ${{matrix.detector_config}}.svg
+          *.dot
+          *.svg
         if-no-files-found: error

--- a/.github/workflows/convert-to-dot.yml
+++ b/.github/workflows/convert-to-dot.yml
@@ -36,15 +36,10 @@ jobs:
         if [ $line_count -gt 1000 ]; then
           echo "::warning::Dot file for ${{matrix.detector_config}} has $line_count lines (> 1000)"
         fi
-    - name: Stage files for GitHub Pages artifacts path
-      run: |
-        mkdir -p artifacts
-        cp ${{matrix.detector_config}}.dot artifacts/
-        cp ${{matrix.detector_config}}.svg artifacts/
     - uses: actions/upload-artifact@v7
       with:
-        name: github-pages-staging-artifacts-${{matrix.detector_config}}
+        name: github-pages-staging-detector-geometry
         path: |
-          artifacts/${{matrix.detector_config}}.dot
-          artifacts/${{matrix.detector_config}}.svg
+          ${{matrix.detector_config}}.dot
+          ${{matrix.detector_config}}.svg
         if-no-files-found: error

--- a/.github/workflows/convert-to-dot.yml
+++ b/.github/workflows/convert-to-dot.yml
@@ -27,7 +27,7 @@ jobs:
           for config in ${configs[@]} ; do
             echo "::group::${config}" ;
             # Generate dot file from detector configuration
-            npdet_to_dot $DETECTOR_PATH/${config}.xml -o ${config}.dot 2>&1 | sed '/TGeoMatrix::dtor/d'
+            npdet_to_dot list -d 2 -o ${config} "$DETECTOR_PATH/${config}.xml" 2>&1 | sed '/TGeoMatrix::dtor/d'
             # Convert dot to SVG using dot command
             dot -Tsvg ${config}.dot -o ${config}.svg
             line_count=$(wc -l < ${config}.dot)

--- a/.github/workflows/convert-to-dot.yml
+++ b/.github/workflows/convert-to-dot.yml
@@ -32,7 +32,7 @@ jobs:
           dot -Tsvg ${{matrix.detector_config}}.dot -o ${{matrix.detector_config}}.svg
     - uses: actions/upload-artifact@v7
       with:
-        name: dot-${{matrix.detector_config}}
+        name: github-pages-staging-detector-geometry
         path: |
           ${{matrix.detector_config}}.dot
           ${{matrix.detector_config}}.svg

--- a/.github/workflows/convert-to-dot.yml
+++ b/.github/workflows/convert-to-dot.yml
@@ -1,0 +1,39 @@
+name: Convert to Dot
+
+on:
+  workflow_call:
+    inputs:
+      detector_configs:
+        required: true
+        type: string
+
+jobs:
+  convert-to-dot:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        detector_config: ${{fromJson(inputs.detector_configs)}}
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/download-artifact@v8
+      with:
+        name: build-gcc-nightly-fast-eic-shell
+        path: install/
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
+    - uses: eic/run-cvmfs-osg-eic-shell@main
+      with:
+        platform-release: "eic_xl:nightly"
+        setup: install/bin/thisepic.sh
+        run: |
+          export DETECTOR_CACHE=/opt/detector/epic-main/share/epic
+          # Generate dot file from detector configuration
+          npdet_to_dot $DETECTOR_PATH/${{matrix.detector_config}}.xml -o ${{matrix.detector_config}}.dot 2>&1 | sed '/TGeoMatrix::dtor/d'
+          # Convert dot to SVG using dot command
+          dot -Tsvg ${{matrix.detector_config}}.dot -o ${{matrix.detector_config}}.svg
+    - uses: actions/upload-artifact@v7
+      with:
+        name: dot-${{matrix.detector_config}}
+        path: |
+          ${{matrix.detector_config}}.dot
+          ${{matrix.detector_config}}.svg
+        if-no-files-found: error

--- a/.github/workflows/convert-to-dot.yml
+++ b/.github/workflows/convert-to-dot.yml
@@ -36,10 +36,15 @@ jobs:
         if [ $line_count -gt 1000 ]; then
           echo "::warning::Dot file for ${{matrix.detector_config}} has $line_count lines (> 1000)"
         fi
+    - name: Stage files for GitHub Pages artifacts path
+      run: |
+        mkdir -p artifacts
+        cp ${{matrix.detector_config}}.dot artifacts/
+        cp ${{matrix.detector_config}}.svg artifacts/
     - uses: actions/upload-artifact@v7
       with:
-        name: github-pages-staging-detector-geometry
+        name: github-pages-staging-artifacts-${{matrix.detector_config}}
         path: |
-          ${{matrix.detector_config}}.dot
-          ${{matrix.detector_config}}.svg
+          artifacts/${{matrix.detector_config}}.dot
+          artifacts/${{matrix.detector_config}}.svg
         if-no-files-found: error

--- a/.github/workflows/convert-to-dot.yml
+++ b/.github/workflows/convert-to-dot.yml
@@ -30,6 +30,12 @@ jobs:
           npdet_to_dot $DETECTOR_PATH/${{matrix.detector_config}}.xml -o ${{matrix.detector_config}}.dot 2>&1 | sed '/TGeoMatrix::dtor/d'
           # Convert dot to SVG using dot command
           dot -Tsvg ${{matrix.detector_config}}.dot -o ${{matrix.detector_config}}.svg
+    - name: Check dot file size
+      run: |
+        line_count=$(wc -l < ${{matrix.detector_config}}.dot)
+        if [ $line_count -gt 1000 ]; then
+          echo "::warning::Dot file for ${{matrix.detector_config}} has $line_count lines (> 1000)"
+        fi
     - uses: actions/upload-artifact@v7
       with:
         name: github-pages-staging-detector-geometry

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -1012,15 +1012,6 @@ jobs:
         for dir in artifacts/github-pages-staging-*/; do
           [ -d "$dir" ] && cp -r "$dir"/. _site/ || true
         done
-    - name: Copy detector geometry dot and svg files
-      run: |
-        mkdir -p _site/detector-geometry
-        for artifact_dir in artifacts/dot-*/; do
-          if [ -d "$artifact_dir" ]; then
-            cp "$artifact_dir"*.dot _site/detector-geometry/ 2>/dev/null || true
-            cp "$artifact_dir"*.svg _site/detector-geometry/ 2>/dev/null || true
-          fi
-        done
     - name: Make PR summary page
       run: |
         mkdir -p _site/pr

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -211,10 +211,10 @@ jobs:
   convert-to-dot:
     needs:
       - build
+      - list-detector-configs
     uses: ./.github/workflows/convert-to-dot.yml
     with:
-      # NOTE: This list of detector configurations must be kept in sync with the configurations linked in README.md.
-      detector_configs: '["epic_craterlake_no_bhcal","epic_imaging_only","epic_drich_only","epic_dirc_only","epic_craterlake_tracking_only","epic_ip6"]'
+      detector_configs: ${{needs.list-detector-configs.outputs.configs_csv}}
 
   dump-constants:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -208,6 +208,14 @@ jobs:
       # NOTE: This list of detector configurations must be kept in sync with the configurations linked in README.md.
       detector_configs: '["epic_craterlake_no_bhcal","epic_imaging_only","epic_drich_only","epic_dirc_only","epic_craterlake_tracking_only","epic_ip6"]'
 
+  convert-to-dot:
+    needs:
+      - build
+    uses: ./.github/workflows/convert-to-dot.yml
+    with:
+      # NOTE: This list of detector configurations must be kept in sync with the configurations linked in README.md.
+      detector_configs: '["epic_craterlake_no_bhcal","epic_imaging_only","epic_drich_only","epic_dirc_only","epic_craterlake_tracking_only","epic_ip6"]'
+
   dump-constants:
     runs-on: ubuntu-latest
     needs: build
@@ -978,6 +986,7 @@ jobs:
     needs:
     - convert-to-gdml
     - convert-to-tgeo
+    - convert-to-dot
     - merge-constants
     - merge-parameter-table
     - merge-dawn-view
@@ -1002,6 +1011,15 @@ jobs:
       run: |
         for dir in artifacts/github-pages-staging-*/; do
           [ -d "$dir" ] && cp -r "$dir"/. _site/ || true
+        done
+    - name: Copy detector geometry dot and svg files
+      run: |
+        mkdir -p _site/detector-geometry
+        for artifact_dir in artifacts/dot-*/; do
+          if [ -d "$artifact_dir" ]; then
+            cp "$artifact_dir"*.dot _site/detector-geometry/ 2>/dev/null || true
+            cp "$artifact_dir"*.svg _site/detector-geometry/ 2>/dev/null || true
+          fi
         done
     - name: Make PR summary page
       run: |


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

This PR adds a new reusable workflow, `convert-to-dot.yml`, that uses `npdet_to_dot` to generate dot graph representations of detector configurations and converts them to SVG format using Graphviz. The generated files are deployed to GitHub Pages under `/detector-geometry/` for easy access and visualization.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated constants (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

The PR was prepared with Copilot assistance. Implementation follows the established patterns of `convert-to-step`, `convert-to-gdml`, and `convert-to-tgeo` workflows.

---

## Changes

**New workflow:**
- `convert-to-dot.yml`: Reusable workflow that generates dot files from detector configurations using `npdet_to_dot`, then converts them to SVG using Graphviz `dot` command. Includes a warning step that flags when dot files exceed 1000 lines.

**Updated workflow:**
- `linux-eic-shell.yml`: 
  - Added `convert-to-dot` job that processes all detector configurations via `list-detector-configs`
  - Updated `build-artifacts-page` to depend on `convert-to-dot`
  - Files are uploaded as `github-pages-staging-detector-geometry` artifacts and automatically deployed to GitHub Pages